### PR TITLE
State Import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
+	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.2
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -145,6 +147,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -157,6 +161,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
@@ -168,6 +173,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mitchellh/cli v1.1.4 h1:qj8czE26AU4PbiaPXK5uVmMSM+V5BYsFBiM9HhGRLUA=
 github.com/mitchellh/cli v1.1.4/go.mod h1:vTLESy5mRhKOs9KDp0/RATawxP1UqBmdrpVRMnpcvKQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/materialize/datasources/datasource_cluster.go
+++ b/materialize/datasources/datasource_cluster.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Cluster() *schema.Resource {
@@ -38,7 +39,7 @@ func Cluster() *schema.Resource {
 func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	rows, err := conn.Query(`SELECT id, name FROM mz_clusters;`)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] no clusters found in account")

--- a/materialize/datasources/datasource_cluster_replica.go
+++ b/materialize/datasources/datasource_cluster_replica.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func ClusterReplica() *schema.Resource {
@@ -50,7 +51,7 @@ func ClusterReplica() *schema.Resource {
 func clusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	rows, err := conn.Query(`
 		SELECT
 			mz_cluster_replicas.id,

--- a/materialize/datasources/datasource_connection.go
+++ b/materialize/datasources/datasource_connection.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Connection() *schema.Resource {
@@ -91,7 +92,7 @@ func connectionQuery(databaseName, schemaName string) string {
 func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/datasources/datasource_database.go
+++ b/materialize/datasources/datasource_database.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Database() *schema.Resource {
@@ -38,7 +39,7 @@ func Database() *schema.Resource {
 func databaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	rows, err := conn.Query(`SELECT id, name FROM mz_databases;`)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] no databases found in account")

--- a/materialize/datasources/datasource_schema.go
+++ b/materialize/datasources/datasource_schema.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Schema() *schema.Resource {
@@ -68,7 +69,7 @@ func schemaQuery(databaseName string) string {
 func schemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	databaseName := d.Get("database_name").(string)
 	q := schemaQuery(databaseName)

--- a/materialize/datasources/datasource_secret.go
+++ b/materialize/datasources/datasource_secret.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Secret() *schema.Resource {
@@ -86,7 +87,7 @@ func secretQuery(databaseName, schemaName string) string {
 func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/datasources/datasource_sink.go
+++ b/materialize/datasources/datasource_sink.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Sink() *schema.Resource {
@@ -115,7 +116,7 @@ func sinkQuery(databaseName, schemaName string) string {
 func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/datasources/datasource_source.go
+++ b/materialize/datasources/datasource_source.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Source() *schema.Resource {
@@ -115,7 +116,7 @@ func sourceQuery(databaseName, schemaName string) string {
 func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/provider.go
+++ b/materialize/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"terraform-materialize/materialize/datasources"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq" //PostgreSQL db
 )
 
@@ -86,7 +86,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	connStr := connectionString(host, username, password, port, database)
 
 	var diags diag.Diagnostics
-	db, err := sql.Open("postgres", connStr)
+	db, err := sqlx.Open("postgres", connStr)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/materialize/resources/resource_cluster.go
+++ b/materialize/resources/resource_cluster.go
@@ -2,12 +2,12 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Cluster() *schema.Resource {
@@ -55,7 +55,7 @@ func (b *ClusterBuilder) Drop() string {
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	clusterName := d.Get("name").(string)
 
 	builder := newClusterBuilder(clusterName)
@@ -70,7 +70,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	clusterName := d.Get("name").(string)
 
 	builder := newClusterBuilder(clusterName)
@@ -86,7 +86,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	clusterName := d.Get("name").(string)
 
 	builder := newClusterBuilder(clusterName)

--- a/materialize/resources/resource_cluster_replica.go
+++ b/materialize/resources/resource_cluster_replica.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmoiron/sqlx"
 )
 
 func ClusterReplica() *schema.Resource {
@@ -164,7 +164,7 @@ func (b *ClusterReplicaBuilder) Drop() string {
 func resourceClusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -180,7 +180,7 @@ func resourceClusterReplicaRead(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourceClusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
@@ -219,7 +219,7 @@ func resourceClusterReplicaCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceClusterReplicaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
 

--- a/materialize/resources/resource_cluster_replica.go
+++ b/materialize/resources/resource_cluster_replica.go
@@ -2,8 +2,8 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -12,62 +12,68 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+var clusterReplicaSchema = map[string]*schema.Schema{
+	"name": {
+		Description: "A name for this replica.",
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+	},
+	"cluster_name": {
+		Description: "The cluster whose resources you want to create an additional computation of.",
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+	},
+	"size": {
+		Description:  "The size of the replica.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringInSlice(replicaSizes, true),
+	},
+	"availability_zone": {
+		Description:  "If you want the replica to reside in a specific availability zone.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringInSlice(regions, true),
+	},
+	"introspection_interval": {
+		Description: "The interval at which to collect introspection data.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     "1s",
+	},
+	"introspection_debugging": {
+		Description: "Whether to introspect the gathering of the introspection data.",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     false,
+	},
+	"idle_arrangement_merge_effort": {
+		Description: "The amount of effort the replica should exert on compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+		ForceNew:    true,
+	},
+}
+
 func ClusterReplica() *schema.Resource {
 	return &schema.Resource{
 		Description: "A cluster replica is the physical resource which maintains dataflow-powered objects.",
 
-		CreateContext: resourceClusterReplicaCreate,
-		ReadContext:   resourceClusterReplicaRead,
-		DeleteContext: resourceClusterReplicaDelete,
+		CreateContext: clusterReplicaCreate,
+		ReadContext:   clusterReplicaRead,
+		DeleteContext: clusterReplicaDelete,
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description: "A name for this replica.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"cluster_name": {
-				Description: "The cluster whose resources you want to create an additional computation of.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"size": {
-				Description:  "The size of the replica.",
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(replicaSizes, true),
-			},
-			"availability_zone": {
-				Description:  "If you want the replica to reside in a specific availability zone.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(regions, true),
-			},
-			"introspection_interval": {
-				Description: "The interval at which to collect introspection data.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "1s",
-			},
-			"introspection_debugging": {
-				Description: "Whether to introspect the gathering of the introspection data.",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     false,
-			},
-			"idle_arrangement_merge_effort": {
-				Description: "The amount of effort the replica should exert on compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.",
-				Type:        schema.TypeInt,
-				Optional:    true,
-				ForceNew:    true,
-			},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		Schema: clusterReplicaSchema,
 	}
 }
 
@@ -141,14 +147,9 @@ func (b *ClusterReplicaBuilder) Create() string {
 	return q.String()
 }
 
-func (b *ClusterReplicaBuilder) Read() string {
+func (b *ClusterReplicaBuilder) ReadId() string {
 	return fmt.Sprintf(`
-		SELECT
-			mz_cluster_replicas.id,
-			mz_cluster_replicas.name,
-			mz_clusters.name,
-			mz_cluster_replicas.size,
-			mz_cluster_replicas.availability_zone
+		SELECT mz_cluster_replicas.id
 		FROM mz_cluster_replicas
 		JOIN mz_clusters
 			ON mz_cluster_replicas.cluster_id = mz_clusters.id
@@ -161,25 +162,37 @@ func (b *ClusterReplicaBuilder) Drop() string {
 	return fmt.Sprintf(`DROP CLUSTER REPLICA %s.%s;`, b.clusterName, b.replicaName)
 }
 
-func resourceClusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	conn := meta.(*sqlx.DB)
-	replicaName := d.Get("name").(string)
-	clusterName := d.Get("cluster_name").(string)
-
-	builder := newClusterReplicaBuilder(replicaName, clusterName)
-	q := builder.Read()
-
-	var id, name, cluster, size, availability_zone string
-	conn.QueryRow(q).Scan(&id, &name, &cluster, &size, &availability_zone)
-
-	d.SetId(id)
-
-	return diags
+func readClusterReplicaParams(id string) string {
+	return fmt.Sprintf(`
+		SELECT
+			mz_cluster_replicas.name,
+			mz_clusters.name,
+			mz_cluster_replicas.size,
+			mz_cluster_replicas.availability_zone
+		FROM mz_cluster_replicas
+		JOIN mz_clusters
+			ON mz_cluster_replicas.cluster_id = mz_clusters.id
+		WHERE mz_cluster_replicas.id = '%s';`, id)
 }
 
-func resourceClusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+type _clusterReplica struct {
+	name              sql.NullString `db:"name"`
+	cluster_name      sql.NullString `db:"cluster_name"`
+	size              sql.NullString `db:"size"`
+	availability_zone sql.NullString `db:"availability_zone"`
+}
+
+func clusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*sqlx.DB)
+	i := d.Id()
+	q := readClusterReplicaParams(i)
+
+	readResource(conn, d, i, q, _clusterReplica{}, "cluster replica")
+	return nil
+}
+
+func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 
 	replicaName := d.Get("name").(string)
@@ -207,18 +220,14 @@ func resourceClusterReplicaCreate(ctx context.Context, d *schema.ResourceData, m
 		builder.IdleArrangementMergeEffort(v.(int))
 	}
 
-	q := builder.Create()
+	qc := builder.Create()
+	qr := builder.ReadId()
 
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return resourceClusterReplicaRead(ctx, d, meta)
+	createResource(conn, d, qc, qr, "cluster replica")
+	return clusterReplicaRead(ctx, d, meta)
 }
 
-func resourceClusterReplicaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func clusterReplicaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
@@ -226,9 +235,6 @@ func resourceClusterReplicaDelete(ctx context.Context, d *schema.ResourceData, m
 	builder := newClusterReplicaBuilder(replicaName, clusterName)
 	q := builder.Drop()
 
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return diags
+	dropResource(conn, d, q, "cluster replica")
+	return nil
 }

--- a/materialize/resources/resource_cluster_replica_test.go
+++ b/materialize/resources/resource_cluster_replica_test.go
@@ -31,8 +31,26 @@ func TestResourceClusterReplicaRead(t *testing.T) {
 	r := require.New(t)
 	b := newClusterReplicaBuilder("replica", "cluster")
 	r.Equal(`
+		SELECT mz_cluster_replicas.id
+		FROM mz_cluster_replicas
+		JOIN mz_clusters
+			ON mz_cluster_replicas.cluster_id = mz_clusters.id
+		WHERE mz_cluster_replicas.name = 'replica'
+		AND mz_clusters.name = 'cluster';
+	`, b.ReadId())
+}
+
+func TestResourceClusterReplicaDrop(t *testing.T) {
+	r := require.New(t)
+	b := newClusterReplicaBuilder("replica", "cluster")
+	r.Equal(`DROP CLUSTER REPLICA cluster.replica;`, b.Drop())
+}
+
+func TestResourceClusterReplicaReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readClusterReplicaParams("u1")
+	r.Equal(`
 		SELECT
-			mz_cluster_replicas.id,
 			mz_cluster_replicas.name,
 			mz_clusters.name,
 			mz_cluster_replicas.size,
@@ -40,13 +58,5 @@ func TestResourceClusterReplicaRead(t *testing.T) {
 		FROM mz_cluster_replicas
 		JOIN mz_clusters
 			ON mz_cluster_replicas.cluster_id = mz_clusters.id
-		WHERE mz_cluster_replicas.name = 'replica'
-		AND mz_clusters.name = 'cluster';
-	`, b.Read())
-}
-
-func TestResourceClusterReplicaDrop(t *testing.T) {
-	r := require.New(t)
-	b := newClusterReplicaBuilder("replica", "cluster")
-	r.Equal(`DROP CLUSTER REPLICA cluster.replica;`, b.Drop())
+		WHERE mz_cluster_replicas.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_cluster_test.go
+++ b/materialize/resources/resource_cluster_test.go
@@ -6,20 +6,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourceClusterReadId(t *testing.T) {
+	r := require.New(t)
+	b := newClusterBuilder("cluster")
+	r.Equal(`SELECT id FROM mz_clusters WHERE name = 'cluster';`, b.ReadId())
+}
+
 func TestResourceClusterCreate(t *testing.T) {
 	r := require.New(t)
 	b := newClusterBuilder("cluster")
 	r.Equal(`CREATE CLUSTER cluster REPLICAS ();`, b.Create())
 }
 
-func TestResourceClusterRead(t *testing.T) {
-	r := require.New(t)
-	b := newClusterBuilder("cluster")
-	r.Equal(`SELECT id, name FROM mz_clusters WHERE name = 'cluster';`, b.Read())
-}
-
 func TestResourceClusterDrop(t *testing.T) {
 	r := require.New(t)
 	b := newClusterBuilder("cluster")
 	r.Equal(`DROP CLUSTER cluster;`, b.Drop())
+}
+
+func TestResourceClusterReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readClusterParams("u1")
+	r.Equal(`SELECT name FROM mz_clusters WHERE id = 'u1';`, b)
 }

--- a/materialize/resources/resource_connection.go
+++ b/materialize/resources/resource_connection.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmoiron/sqlx"
 )
 
 func Connection() *schema.Resource {
@@ -653,7 +653,7 @@ func (b *ConnectionBuilder) Drop() string {
 func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
@@ -670,7 +670,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
@@ -828,7 +828,7 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
@@ -848,7 +848,7 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/resources/resource_connection.go
+++ b/materialize/resources/resource_connection.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -12,260 +13,266 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+var connectionSchema = map[string]*schema.Schema{
+	"name": {
+		Description: "The name of the connection.",
+		Type:        schema.TypeString,
+		Required:    true,
+	},
+	"schema_name": {
+		Description: "The identifier for the connection schema.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "public",
+	},
+	"database_name": {
+		Description: "The identifier for the connection database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "materialize",
+	},
+	"connection_type": {
+		Description:  "The type of the connection.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice(connectionTypes, true),
+	},
+	"ssh_host": {
+		Description:  "The host of the SSH tunnel.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"ssh_user", "ssh_port"},
+	},
+	"ssh_user": {
+		Description:  "The user of the SSH tunnel.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"ssh_host", "ssh_port"},
+	},
+	"ssh_port": {
+		Description:  "The port of the SSH tunnel.",
+		Type:         schema.TypeInt,
+		Optional:     true,
+		RequiredWith: []string{"ssh_host", "ssh_user"},
+	},
+	"aws_privatelink_service_name": {
+		Description:   "The name of the AWS PrivateLink service.",
+		Type:          schema.TypeString,
+		Optional:      true,
+		ForceNew:      true,
+		ConflictsWith: []string{"ssh_host", "ssh_user", "ssh_port"},
+		RequiredWith:  []string{"aws_privatelink_availability_zones"},
+	},
+	"aws_privatelink_availability_zones": {
+		Description:   "The availability zones of the AWS PrivateLink service.",
+		Type:          schema.TypeList,
+		Elem:          &schema.Schema{Type: schema.TypeString},
+		Optional:      true,
+		ForceNew:      true,
+		ConflictsWith: []string{"ssh_host", "ssh_user", "ssh_port"},
+		RequiredWith:  []string{"aws_privatelink_service_name"},
+	},
+	"postgres_database": {
+		Description: "The target Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		RequiredWith: []string{
+			"postgres_host",
+			"postgres_port",
+			"postgres_user",
+			"postgres_password",
+		},
+	},
+	"postgres_host": {
+		Description: "The Postgres database hostname.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		RequiredWith: []string{
+			"postgres_database",
+			"postgres_port",
+			"postgres_user",
+			"postgres_password",
+		},
+	},
+	"postgres_port": {
+		Description: "The Postgres database port.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+		RequiredWith: []string{
+			"postgres_database",
+			"postgres_host",
+			"postgres_user",
+			"postgres_password",
+		},
+	},
+	"postgres_user": {
+		Description: "The Postgres database username.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		RequiredWith: []string{
+			"postgres_database",
+			"postgres_host",
+			"postgres_port",
+			"postgres_password",
+		},
+	},
+	"postgres_password": {
+		Description: "The Postgres database password.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		RequiredWith: []string{
+			"postgres_database",
+			"postgres_host",
+			"postgres_port",
+			"postgres_user",
+		},
+	},
+	"postgres_ssh_tunnel": {
+		Description: "The SSH tunnel configuration for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"postgres_ssl_ca": {
+		Description: "The CA certificate for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"postgres_ssl_cert": {
+		Description: "The client certificate for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"postgres_ssl_key": {
+		Description: "The client key for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"postgres_ssl_mode": {
+		Description: "The SSL mode for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"postgres_aws_privatelink": {
+		Description: "The AWS PrivateLink configuration for the Postgres database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"kafka_broker": {
+		Description:   "The Kafka broker configuration.",
+		Type:          schema.TypeString,
+		Optional:      true,
+		ConflictsWith: []string{"kafka_brokers"},
+	},
+	"kafka_brokers": {
+		Description:   "The Kafka brokers configuration.",
+		Type:          schema.TypeList,
+		Elem:          &schema.Schema{Type: schema.TypeString},
+		Optional:      true,
+		ConflictsWith: []string{"kafka_broker"},
+	},
+	"kafka_progress_topic": {
+		Description: "The name of a topic that Kafka sinks can use to track internal consistency metadata.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"kafka_ssl_ca": {
+		Description: "The CA certificate for the Kafka broker.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"kafka_ssl_cert": {
+		Description: "The client certificate for the Kafka broker.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"kafka_ssl_key": {
+		Description: "The client key for the Kafka broker.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"kafka_sasl_mechanisms": {
+		Description:  "The SASL mechanism for the Kafka broker.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringInSlice(saslMechanisms, true),
+		RequiredWith: []string{"kafka_sasl_username", "kafka_sasl_password"},
+	},
+	"kafka_sasl_username": {
+		Description:  "The SASL username for the Kafka broker.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"kafka_sasl_password", "kafka_sasl_mechanisms"},
+	},
+	"kafka_sasl_password": {
+		Description:  "The SASL password for the Kafka broker.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"kafka_sasl_username", "kafka_sasl_mechanisms"},
+	},
+	"kafka_ssh_tunnel": {
+		Description: "The SSH tunnel configuration for the Kafka broker.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	// TODO: Add support for Kafka AWS PrivateLink
+	"confluent_schema_registry_url": {
+		Description: "The URL of the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"confluent_schema_registry_ssl_ca": {
+		Description: "The CA certificate for the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"confluent_schema_registry_ssl_cert": {
+		Description: "The client certificate for the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"confluent_schema_registry_ssl_key": {
+		Description: "The client key for the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"confluent_schema_registry_password": {
+		Description:  "The password for the Confluent Schema Registry.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"confluent_schema_registry_username"},
+	},
+	"confluent_schema_registry_username": {
+		Description:  "The username for the Confluent Schema Registry.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"confluent_schema_registry_password"},
+	},
+	"confluent_schema_registry_ssh_tunnel": {
+		Description: "The SSH tunnel configuration for the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"confluent_schema_registry_aws_privatelink": {
+		Description: "The AWS PrivateLink configuration for the Confluent Schema Registry.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+}
+
 func Connection() *schema.Resource {
 	return &schema.Resource{
 		Description: "The connection resource allows you to manage connections in Materialize.",
 
-		CreateContext: resourceConnectionCreate,
-		ReadContext:   resourceConnectionRead,
-		UpdateContext: resourceConnectionUpdate,
-		DeleteContext: resourceConnectionDelete,
+		CreateContext: connectionCreate,
+		ReadContext:   connectionRead,
+		UpdateContext: connectionUpdate,
+		DeleteContext: connectionDelete,
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description: "The name of the connection.",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"schema_name": {
-				Description: "The identifier for the connection schema.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "public",
-			},
-			"database_name": {
-				Description: "The identifier for the secret database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "materialize",
-			},
-			"connection_type": {
-				Description:  "The type of the connection.",
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(connectionTypes, true),
-			},
-			"ssh_host": {
-				Description:  "The host of the SSH tunnel.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"ssh_user", "ssh_port"},
-			},
-			"ssh_user": {
-				Description:  "The user of the SSH tunnel.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"ssh_host", "ssh_port"},
-			},
-			"ssh_port": {
-				Description:  "The port of the SSH tunnel.",
-				Type:         schema.TypeInt,
-				Optional:     true,
-				RequiredWith: []string{"ssh_host", "ssh_user"},
-			},
-			"aws_privatelink_service_name": {
-				Description:   "The name of the AWS PrivateLink service.",
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"ssh_host", "ssh_user", "ssh_port"},
-				RequiredWith:  []string{"aws_privatelink_availability_zones"},
-			},
-			"aws_privatelink_availability_zones": {
-				Description:   "The availability zones of the AWS PrivateLink service.",
-				Type:          schema.TypeList,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"ssh_host", "ssh_user", "ssh_port"},
-				RequiredWith:  []string{"aws_privatelink_service_name"},
-			},
-			"postgres_database": {
-				Description: "The target Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				RequiredWith: []string{
-					"postgres_host",
-					"postgres_port",
-					"postgres_user",
-					"postgres_password",
-				},
-			},
-			"postgres_host": {
-				Description: "The Postgres database hostname.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				RequiredWith: []string{
-					"postgres_database",
-					"postgres_port",
-					"postgres_user",
-					"postgres_password",
-				},
-			},
-			"postgres_port": {
-				Description: "The Postgres database port.",
-				Type:        schema.TypeInt,
-				Optional:    true,
-				RequiredWith: []string{
-					"postgres_database",
-					"postgres_host",
-					"postgres_user",
-					"postgres_password",
-				},
-			},
-			"postgres_user": {
-				Description: "The Postgres database username.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				RequiredWith: []string{
-					"postgres_database",
-					"postgres_host",
-					"postgres_port",
-					"postgres_password",
-				},
-			},
-			"postgres_password": {
-				Description: "The Postgres database password.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				RequiredWith: []string{
-					"postgres_database",
-					"postgres_host",
-					"postgres_port",
-					"postgres_user",
-				},
-			},
-			"postgres_ssh_tunnel": {
-				Description: "The SSH tunnel configuration for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"postgres_ssl_ca": {
-				Description: "The CA certificate for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"postgres_ssl_cert": {
-				Description: "The client certificate for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"postgres_ssl_key": {
-				Description: "The client key for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"postgres_ssl_mode": {
-				Description: "The SSL mode for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"postgres_aws_privatelink": {
-				Description: "The AWS PrivateLink configuration for the Postgres database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"kafka_broker": {
-				Description:   "The Kafka broker configuration.",
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"kafka_brokers"},
-			},
-			"kafka_brokers": {
-				Description:   "The Kafka brokers configuration.",
-				Type:          schema.TypeList,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Optional:      true,
-				ConflictsWith: []string{"kafka_broker"},
-			},
-			"kafka_progress_topic": {
-				Description: "The name of a topic that Kafka sinks can use to track internal consistency metadata.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"kafka_ssl_ca": {
-				Description: "The CA certificate for the Kafka broker.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"kafka_ssl_cert": {
-				Description: "The client certificate for the Kafka broker.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"kafka_ssl_key": {
-				Description: "The client key for the Kafka broker.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"kafka_sasl_mechanisms": {
-				Description:  "The SASL mechanism for the Kafka broker.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(saslMechanisms, true),
-				RequiredWith: []string{"kafka_sasl_username", "kafka_sasl_password"},
-			},
-			"kafka_sasl_username": {
-				Description:  "The SASL username for the Kafka broker.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"kafka_sasl_password", "kafka_sasl_mechanisms"},
-			},
-			"kafka_sasl_password": {
-				Description:  "The SASL password for the Kafka broker.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"kafka_sasl_username", "kafka_sasl_mechanisms"},
-			},
-			"kafka_ssh_tunnel": {
-				Description: "The SSH tunnel configuration for the Kafka broker.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			// TODO: Add support for Kafka AWS PrivateLink
-			"confluent_schema_registry_url": {
-				Description: "The URL of the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"confluent_schema_registry_ssl_ca": {
-				Description: "The CA certificate for the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"confluent_schema_registry_ssl_cert": {
-				Description: "The client certificate for the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"confluent_schema_registry_ssl_key": {
-				Description: "The client key for the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"confluent_schema_registry_password": {
-				Description:  "The password for the Confluent Schema Registry.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"confluent_schema_registry_username"},
-			},
-			"confluent_schema_registry_username": {
-				Description:  "The username for the Confluent Schema Registry.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"confluent_schema_registry_password"},
-			},
-			"confluent_schema_registry_ssh_tunnel": {
-				Description: "The SSH tunnel configuration for the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"confluent_schema_registry_aws_privatelink": {
-				Description: "The AWS PrivateLink configuration for the Confluent Schema Registry.",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		Schema: connectionSchema,
 	}
 }
 
@@ -621,14 +628,9 @@ func (b *ConnectionBuilder) Create() string {
 	return q.String()
 }
 
-func (b *ConnectionBuilder) Read() string {
+func (b *ConnectionBuilder) ReadId() string {
 	return fmt.Sprintf(`
-		SELECT
-			mz_connections.id,
-			mz_connections.name,
-			mz_connections.type,
-			mz_databases.name AS database_name,
-			mz_schemas.name AS schema_name
+		SELECT mz_connections.id
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id
@@ -645,31 +647,42 @@ func (b *ConnectionBuilder) Rename(newConnectionName string) string {
 }
 
 func (b *ConnectionBuilder) Drop() string {
-	q := strings.Builder{}
-	q.WriteString(fmt.Sprintf(`DROP CONNECTION %s.%s.%s;`, b.databaseName, b.schemaName, b.connectionName))
-	return q.String()
+	return fmt.Sprintf(`DROP CONNECTION %s.%s.%s;`, b.databaseName, b.schemaName, b.connectionName)
 }
 
-func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
+func readConnectionParams(id string) string {
+	return fmt.Sprintf(`
+		SELECT
+			mz_connections.name,
+			mz_schemas.name,
+			mz_databases.name,
+			mz_connections.type
+		FROM mz_connections
+		JOIN mz_schemas
+			ON mz_connections.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_connections.id = '%s';`, id)
+}
 
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+type _connection struct {
+	name            sql.NullString `db:"name"`
+	schema_name     sql.NullString `db:"schema_name"`
+	database_name   sql.NullString `db:"database_name"`
+	connection_type sql.NullString `db:"connection_type"`
+}
+
+func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
-	connectionName := d.Get("name").(string)
-	schemaName := d.Get("schema_name").(string)
-	databaseName := d.Get("database_name").(string)
+	i := d.Id()
+	q := readConnectionParams(i)
 
-	builder := newConnectionBuilder(connectionName, schemaName, databaseName)
-	q := builder.Read()
-
-	var id, name, connection_type, schema_name, database_name string
-	conn.QueryRow(q).Scan(&id, &name, &connection_type, &schema_name, &database_name)
-
-	d.SetId(id)
-
-	return diags
+	readResource(conn, d, i, q, _connection{}, "connection")
+	return nil
 }
 
-func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func connectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 
 	connectionName := d.Get("name").(string)
@@ -818,16 +831,14 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		builder.ConfluentSchemaRegistryAWSPrivateLink(v.(string))
 	}
 
-	q := builder.Create()
+	qc := builder.Create()
+	qr := builder.ReadId()
 
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return resourceConnectionRead(ctx, d, meta)
+	createResource(conn, d, qc, qr, "connection")
+	return connectionRead(ctx, d, meta)
 }
 
-func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func connectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
@@ -842,12 +853,10 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	return resourceConnectionRead(ctx, d, meta)
+	return connectionRead(ctx, d, meta)
 }
 
-func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func connectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 	connectionName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
@@ -856,9 +865,6 @@ func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	builder := newConnectionBuilder(connectionName, schemaName, databaseName)
 	q := builder.Drop()
 
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return diags
+	dropResource(conn, d, q, "connection")
+	return nil
 }

--- a/materialize/resources/resource_connection_test.go
+++ b/materialize/resources/resource_connection_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourceConnectoinReadId(t *testing.T) {
+	r := require.New(t)
+	b := newConnectionBuilder("connection", "schema", "database")
+	r.Equal(`
+		SELECT mz_connections.id
+		FROM mz_connections
+		JOIN mz_schemas
+			ON mz_connections.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_connections.name = 'connection'
+		AND mz_schemas.name = 'schema'
+		AND mz_databases.name = 'database';
+	`, b.ReadId())
+}
+
 func TestResourceConnectionCreateSsh(t *testing.T) {
 	r := require.New(t)
 
@@ -99,4 +115,33 @@ func TestResourceConnectionCreateConfluentSchemaRegistry(t *testing.T) {
 	b.ConfluentSchemaRegistryPassword("password")
 	r.Equal(`CREATE CONNECTION database.schema.csr_conn TO CONFLUENT SCHEMA REGISTRY (URL 'http://localhost:8081', USERNAME = 'user', PASSWORD = SECRET password);`, b.Create())
 
+}
+
+func TestResourceConnectionRename(t *testing.T) {
+	r := require.New(t)
+	b := newConnectionBuilder("connection", "schema", "database")
+	r.Equal(`ALTER CONNECTION database.schema.connection RENAME TO database.schema.new_connection;`, b.Rename("new_connection"))
+}
+
+func TestResourceConnectionDrop(t *testing.T) {
+	r := require.New(t)
+	b := newConnectionBuilder("connection", "schema", "database")
+	r.Equal(`DROP CONNECTION database.schema.connection;`, b.Drop())
+}
+
+func TestResourceConnectionReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readConnectionParams("u1")
+	r.Equal(`
+		SELECT
+			mz_connections.name,
+			mz_schemas.name,
+			mz_databases.name,
+			mz_connections.type
+		FROM mz_connections
+		JOIN mz_schemas
+			ON mz_connections.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_connections.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_database.go
+++ b/materialize/resources/resource_database.go
@@ -2,12 +2,12 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Database() *schema.Resource {
@@ -54,7 +54,7 @@ func (b *DatabaseBuilder) Drop() string {
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	databaseName := d.Get("name").(string)
 
 	builder := newDatabaseBuilder(databaseName)
@@ -69,7 +69,7 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	databaseName := d.Get("name").(string)
 
 	builder := newDatabaseBuilder(databaseName)
@@ -85,7 +85,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	databaseName := d.Get("name").(string)
 
 	builder := newDatabaseBuilder(databaseName)

--- a/materialize/resources/resource_database_test.go
+++ b/materialize/resources/resource_database_test.go
@@ -6,20 +6,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResourceDatabaseReadId(t *testing.T) {
+	r := require.New(t)
+	b := newDatabaseBuilder("database")
+	r.Equal(`SELECT id FROM mz_databases WHERE name = 'database';`, b.ReadId())
+}
+
 func TestResourceDatabaseCreate(t *testing.T) {
 	r := require.New(t)
 	b := newDatabaseBuilder("database")
 	r.Equal(`CREATE DATABASE database;`, b.Create())
 }
 
-func TestResourceDatabaseRead(t *testing.T) {
-	r := require.New(t)
-	b := newDatabaseBuilder("database")
-	r.Equal(`SELECT id, name FROM mz_databases WHERE name = 'database';`, b.Read())
-}
-
 func TestResourceDatabaseDrop(t *testing.T) {
 	r := require.New(t)
 	b := newDatabaseBuilder("database")
 	r.Equal(`DROP DATABASE database;`, b.Drop())
+}
+
+func TestResourceDatabaseReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readDatabaseParams("u1")
+	r.Equal(`SELECT name FROM mz_databases WHERE id = 'u1';`, b)
 }

--- a/materialize/resources/resource_schema.go
+++ b/materialize/resources/resource_schema.go
@@ -2,12 +2,12 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 func Schema() *schema.Resource {
@@ -72,7 +72,7 @@ func (b *SchemaBuilder) Drop() string {
 func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
@@ -88,7 +88,7 @@ func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
@@ -105,7 +105,7 @@ func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 

--- a/materialize/resources/resource_schema.go
+++ b/materialize/resources/resource_schema.go
@@ -2,37 +2,43 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
 )
 
+var schemaSchema = map[string]*schema.Schema{
+	"name": {
+		Description: "The name of the schema.",
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+	},
+	"database_name": {
+		Description: "The name of the database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     "materialize",
+	},
+}
+
 func Schema() *schema.Resource {
 	return &schema.Resource{
-		Description: "The highest level namespace hierarchy in Materialize.",
+		Description: "The second highest level namespace hierarchy in Materialize.",
 
-		CreateContext: resourceSchemaCreate,
-		ReadContext:   resourceSchemaRead,
-		DeleteContext: resourceSchemaDelete,
+		CreateContext: schemaCreate,
+		ReadContext:   schemaRead,
+		DeleteContext: schemaDelete,
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description: "The name of the schema.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"database_name": {
-				Description: "The name of the database.",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Default:     "materialize",
-			},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		Schema: schemaSchema,
 	}
 }
 
@@ -52,12 +58,9 @@ func (b *SchemaBuilder) Create() string {
 	return fmt.Sprintf(`CREATE SCHEMA %s.%s;`, b.databaseName, b.schemaName)
 }
 
-func (b *SchemaBuilder) Read() string {
+func (b *SchemaBuilder) ReadId() string {
 	return fmt.Sprintf(`
-		SELECT
-			mz_schemas.id,
-			mz_schemas.name,
-			mz_databases.name
+		SELECT mz_schemas.id
 		FROM mz_schemas JOIN mz_databases
 			ON mz_schemas.database_id = mz_databases.id
 		WHERE mz_schemas.name = '%s'
@@ -69,42 +72,45 @@ func (b *SchemaBuilder) Drop() string {
 	return fmt.Sprintf(`DROP SCHEMA %s.%s;`, b.databaseName, b.schemaName)
 }
 
-func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
+func readSchemaParams(id string) string {
+	return fmt.Sprintf(`
+		SELECT
+			mz_schemas.name,
+			mz_databases.name
+		FROM mz_schemas JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_schemas.id = '%s';`, id)
+}
 
+//lint:ignore U1000 Ignore unused function temporarily for debugging
+type _schema struct {
+	schema_name   sql.NullString `db:"schema_name"`
+	database_name sql.NullString `db:"database_name"`
+}
+
+func schemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*sqlx.DB)
+	i := d.Id()
+	q := readSchemaParams(i)
+
+	readResource(conn, d, i, q, _schema{}, "schema")
+	return nil
+}
+
+func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
 	builder := newSchemaBuilder(schemaName, databaseName)
-	q := builder.Read()
+	qc := builder.Create()
+	qr := builder.ReadId()
 
-	var id, name, database string
-	conn.QueryRow(q).Scan(&id, &name, &database)
-
-	d.SetId(id)
-
-	return diags
+	createResource(conn, d, qc, qr, "schema")
+	return schemaRead(ctx, d, meta)
 }
 
-func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sqlx.DB)
-	schemaName := d.Get("name").(string)
-	databaseName := d.Get("database_name").(string)
-
-	builder := newSchemaBuilder(schemaName, databaseName)
-	q := builder.Create()
-
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return resourceSchemaRead(ctx, d, meta)
-}
-
-func resourceSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func schemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
@@ -112,9 +118,6 @@ func resourceSchemaDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	builder := newSchemaBuilder(schemaName, databaseName)
 	q := builder.Drop()
 
-	if err := ExecResource(conn, q); err != nil {
-		log.Printf("[ERROR] could not execute query: %s", q)
-		return diag.FromErr(err)
-	}
-	return diags
+	dropResource(conn, d, q, "schema")
+	return nil
 }

--- a/materialize/resources/resource_schema_test.go
+++ b/materialize/resources/resource_schema_test.go
@@ -6,19 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResourceSchemaRead(t *testing.T) {
+func TestResourceSchemaReadId(t *testing.T) {
 	r := require.New(t)
 	b := newSchemaBuilder("schema", "database")
 	r.Equal(`
-		SELECT
-			mz_schemas.id,
-			mz_schemas.name,
-			mz_databases.name
+		SELECT mz_schemas.id
 		FROM mz_schemas JOIN mz_databases
 			ON mz_schemas.database_id = mz_databases.id
 		WHERE mz_schemas.name = 'schema'
 		AND mz_databases.name = 'database';	
-	`, b.Read())
+	`, b.ReadId())
 }
 
 func TestResourceSchemaCreate(t *testing.T) {
@@ -31,4 +28,16 @@ func TestResourceSchemaDrop(t *testing.T) {
 	r := require.New(t)
 	b := newSchemaBuilder("schema", "database")
 	r.Equal(`DROP SCHEMA database.schema;`, b.Drop())
+}
+
+func TestResourceSchemaReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readSchemaParams("u1")
+	r.Equal(`
+		SELECT
+			mz_schemas.name,
+			mz_databases.name
+		FROM mz_schemas JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_schemas.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_secret.go
+++ b/materialize/resources/resource_secret.go
@@ -111,12 +111,11 @@ func readSecretParams(id string) string {
 			ON mz_secrets.schema_id = mz_schemas.id
 		JOIN mz_databases
 			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_secrets.id = '%s';
-	`, id)
+		WHERE mz_secrets.id = '%s';`, id)
 }
 
 //lint:ignore U1000 Ignore unused function temporarily for debugging
-type secret struct {
+type _secret struct {
 	name          sql.NullString `db:"name"`
 	schema_name   sql.NullString `db:"schema_name"`
 	database_name sql.NullString `db:"database_name"`
@@ -127,7 +126,7 @@ func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	i := d.Id()
 	q := readSecretParams(i)
 
-	readResource(conn, d, i, q, secret{}, "secret")
+	readResource(conn, d, i, q, _secret{}, "secret")
 	return nil
 }
 

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -45,3 +45,20 @@ func TestResourceSecretDrop(t *testing.T) {
 	b := newSecretBuilder("secret", "schema", "database")
 	r.Equal(`DROP SECRET database.schema.secret;`, b.Drop())
 }
+
+func TestResourceSecretReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readSecretParams("u1")
+	r.Equal(`
+		SELECT
+			mz_secrets.name,
+			mz_schemas.name,
+			mz_databases.name
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_secrets.id = 'u1';
+	`, b)
+}

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -6,15 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResourceSecretRead(t *testing.T) {
+func TestResourceSecretReadId(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")
 	r.Equal(`
-		SELECT
-			mz_secrets.id,
-			mz_secrets.name,
-			mz_schemas.name,
-			mz_databases.name
+		SELECT mz_secrets.id
 		FROM mz_secrets
 		JOIN mz_schemas
 			ON mz_secrets.schema_id = mz_schemas.id
@@ -23,7 +19,7 @@ func TestResourceSecretRead(t *testing.T) {
 		WHERE mz_secrets.name = 'secret'
 		AND mz_schemas.name = 'schema'
 		AND mz_databases.name = 'database';
-	`, b.Read())
+	`, b.ReadId())
 }
 
 func TestResourceSecretCreate(t *testing.T) {

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -59,6 +59,5 @@ func TestResourceSecretReadParams(t *testing.T) {
 			ON mz_secrets.schema_id = mz_schemas.id
 		JOIN mz_databases
 			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_secrets.id = 'u1';
-	`, b)
+		WHERE mz_secrets.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_sink.go
+++ b/materialize/resources/resource_sink.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmoiron/sqlx"
 )
 
 func Sink() *schema.Resource {
@@ -236,7 +236,7 @@ func (b *SinkBuilder) Drop() string {
 }
 
 func resourceSinkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	sinkName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
@@ -288,7 +288,7 @@ func resourceSinkCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 func resourceSinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	sinkName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
@@ -305,7 +305,7 @@ func resourceSinkRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 }
 
 func resourceSinkUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
@@ -334,13 +334,13 @@ func resourceSinkUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 		}
 	}
 
-	return resourceSecretRead(ctx, d, meta)
+	return resourceSinkRead(ctx, d, meta)
 }
 
 func resourceSinkDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	sinkName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/resources/resource_sink_test.go
+++ b/materialize/resources/resource_sink_test.go
@@ -37,16 +37,7 @@ func TestResourceSinkRead(t *testing.T) {
 	r := require.New(t)
 	b := newSinkBuilder("sink", "schema", "database")
 	r.Equal(`
-		SELECT
-			mz_sinks.id,
-			mz_sinks.name,
-			mz_schemas.name,
-			mz_databases.name,
-			mz_sinks.type,
-			mz_sinks.size,
-			mz_sinks.envelope_type,
-			mz_connections.name as connection_name,
-			mz_clusters.name as cluster_name
+		SELECT mz_sinks.id
 		FROM mz_sinks
 		JOIN mz_schemas
 			ON mz_sinks.schema_id = mz_schemas.id
@@ -59,7 +50,7 @@ func TestResourceSinkRead(t *testing.T) {
 		WHERE mz_sinks.name = 'sink'
 		AND mz_schemas.name = 'schema'
 		AND mz_databases.name = 'database';
-	`, b.Read())
+	`, b.ReadId())
 }
 
 func TestResourceSinkRename(t *testing.T) {
@@ -78,4 +69,29 @@ func TestResourceSinkDrop(t *testing.T) {
 	r := require.New(t)
 	b := newSinkBuilder("sink", "schema", "database")
 	r.Equal(`DROP SINK database.schema.sink;`, b.Drop())
+}
+
+func TestResourceSinkReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readSinkParams("u1")
+	r.Equal(`
+		SELECT
+			mz_sinks.name,
+			mz_schemas.name,
+			mz_databases.name,
+			mz_sinks.type,
+			mz_sinks.size,
+			mz_sinks.envelope_type,
+			mz_connections.name as connection_name,
+			mz_clusters.name as cluster_name
+		FROM mz_sinks
+		JOIN mz_schemas
+			ON mz_sinks.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		LEFT JOIN mz_connections
+			ON mz_sinks.connection_id = mz_connections.id
+		LEFT JOIN mz_clusters
+			ON mz_sinks.cluster_id = mz_clusters.id
+		WHERE mz_sinks.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_source.go
+++ b/materialize/resources/resource_source.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log"
 	"sort"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmoiron/sqlx"
 )
 
 func Source() *schema.Resource {
@@ -420,7 +420,7 @@ func (b *SourceBuilder) Drop() string {
 func resourceSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	sourceName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
@@ -437,7 +437,7 @@ func resourceSourceRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 
 	sourceName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
@@ -523,7 +523,7 @@ func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta any)
 }
 
 func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
@@ -552,13 +552,13 @@ func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	return resourceSecretRead(ctx, d, meta)
+	return resourceSourceRead(ctx, d, meta)
 }
 
 func resourceSourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	conn := meta.(*sql.DB)
+	conn := meta.(*sqlx.DB)
 	sourceName := d.Get("name").(string)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)

--- a/materialize/resources/resource_source_test.go
+++ b/materialize/resources/resource_source_test.go
@@ -70,16 +70,7 @@ func TestResourceSourceRead(t *testing.T) {
 	r := require.New(t)
 	b := newSourceBuilder("source", "schema", "database")
 	r.Equal(`
-		SELECT
-			mz_sources.id,
-			mz_sources.name,
-			mz_schemas.name,
-			mz_databases.name,
-			mz_sources.type,
-			mz_sources.size,
-			mz_sources.envelope_type,
-			mz_connections.name as connection_name,
-			mz_clusters.name as cluster_name
+		SELECT mz_sources.id
 		FROM mz_sources
 		JOIN mz_schemas
 			ON mz_sources.schema_id = mz_schemas.id
@@ -92,7 +83,7 @@ func TestResourceSourceRead(t *testing.T) {
 		WHERE mz_sources.name = 'source'
 		AND mz_schemas.name = 'schema'
 		AND mz_databases.name = 'database';
-	`, b.Read())
+	`, b.ReadId())
 }
 
 func TestResourceSourceRename(t *testing.T) {
@@ -111,4 +102,29 @@ func TestResourceSourceDrop(t *testing.T) {
 	r := require.New(t)
 	b := newSourceBuilder("source", "schema", "database")
 	r.Equal(`DROP SOURCE database.schema.source;`, b.Drop())
+}
+
+func TestResourceSourceReadParams(t *testing.T) {
+	r := require.New(t)
+	b := readSourceParams("u1")
+	r.Equal(`
+		SELECT
+			mz_sources.name,
+			mz_schemas.name,
+			mz_databases.name,
+			mz_sources.type,
+			mz_sources.size,
+			mz_sources.envelope_type,
+			mz_connections.name as connection_name,
+			mz_clusters.name as cluster_name
+		FROM mz_sources
+		JOIN mz_schemas
+			ON mz_sources.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		LEFT JOIN mz_connections
+			ON mz_sources.connection_id = mz_connections.id
+		LEFT JOIN mz_clusters
+			ON mz_sources.cluster_id = mz_clusters.id
+		WHERE mz_sources.id = 'u1';`, b)
 }

--- a/materialize/resources/utils.go
+++ b/materialize/resources/utils.go
@@ -1,8 +1,12 @@
 package resources
 
 import (
-	"database/sql"
 	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 )
 
 type SQLError struct {
@@ -13,11 +17,57 @@ func (e *SQLError) Error() string {
 	return fmt.Sprintf("Unable to execute SQL: %v", e.Err)
 }
 
-func ExecResource(conn *sql.DB, queryStr string) error {
+func ExecResource(conn *sqlx.DB, queryStr string) error {
 	_, err := conn.Exec(queryStr)
 	if err != nil {
 		return &SQLError{Err: err}
 	}
 
+	return nil
+}
+
+func createResource(conn *sqlx.DB, d *schema.ResourceData, queryCreateStr, queryReadStr string) error {
+	_, errr := conn.Exec(queryCreateStr)
+	if errr != nil {
+		log.Printf("[ERROR] could not execute query: %s", queryCreateStr)
+		return &SQLError{Err: errr}
+	}
+
+	var i string
+	err := conn.QueryRow(queryReadStr).Scan(&i)
+	if err != nil {
+		log.Printf("[ERROR] could not execute query: %s", queryReadStr)
+		return &SQLError{Err: err}
+	}
+
+	d.SetId(i)
+	return nil
+}
+
+func readResource(conn *sqlx.DB, d *schema.ResourceData, id, queryStr string, resourceStruct interface{}) error {
+	err := conn.QueryRowx(queryStr).StructScan(resourceStruct)
+	if err != nil {
+		return &SQLError{Err: err}
+	}
+
+	d.SetId(id)
+
+	values := reflect.ValueOf(resourceStruct)
+	types := values.Type()
+	for i := 0; i < values.NumField(); i++ {
+		d.Set(types.Field(i).Name, values.Field(i))
+	}
+
+	return nil
+}
+
+func dropResource(conn *sqlx.DB, d *schema.ResourceData, queryStr string) error {
+	_, errr := conn.Exec(queryStr)
+	if errr != nil {
+		log.Printf("[ERROR] could not execute query: %s", queryStr)
+		return &SQLError{Err: errr}
+	}
+
+	d.SetId("")
 	return nil
 }

--- a/materialize/resources/utils.go
+++ b/materialize/resources/utils.go
@@ -26,17 +26,17 @@ func ExecResource(conn *sqlx.DB, queryStr string) error {
 	return nil
 }
 
-func createResource(conn *sqlx.DB, d *schema.ResourceData, queryCreateStr, queryReadStr string) error {
+func createResource(conn *sqlx.DB, d *schema.ResourceData, queryCreateStr, queryReadStr, resource string) error {
 	_, errr := conn.Exec(queryCreateStr)
 	if errr != nil {
-		log.Printf("[ERROR] could not execute query: %s", queryCreateStr)
+		log.Printf("[ERROR] could not create %s: %s", resource, queryCreateStr)
 		return &SQLError{Err: errr}
 	}
 
 	var i string
 	err := conn.QueryRow(queryReadStr).Scan(&i)
 	if err != nil {
-		log.Printf("[ERROR] could not execute query: %s", queryReadStr)
+		log.Printf("[ERROR] could not read %s id", resource)
 		return &SQLError{Err: err}
 	}
 
@@ -44,9 +44,10 @@ func createResource(conn *sqlx.DB, d *schema.ResourceData, queryCreateStr, query
 	return nil
 }
 
-func readResource(conn *sqlx.DB, d *schema.ResourceData, id, queryStr string, resourceStruct interface{}) error {
+func readResource(conn *sqlx.DB, d *schema.ResourceData, id, queryStr string, resourceStruct interface{}, resource string) error {
 	err := conn.QueryRowx(queryStr).StructScan(resourceStruct)
 	if err != nil {
+		log.Printf("[ERROR] could not read %s: %s", resource, queryStr)
 		return &SQLError{Err: err}
 	}
 
@@ -61,13 +62,14 @@ func readResource(conn *sqlx.DB, d *schema.ResourceData, id, queryStr string, re
 	return nil
 }
 
-func dropResource(conn *sqlx.DB, d *schema.ResourceData, queryStr string) error {
+func dropResource(conn *sqlx.DB, d *schema.ResourceData, queryStr, resource string) error {
 	_, errr := conn.Exec(queryStr)
 	if errr != nil {
-		log.Printf("[ERROR] could not execute query: %s", queryStr)
+		log.Printf("[ERROR] could not drop %s: %s", resource, queryStr)
 		return &SQLError{Err: errr}
 	}
 
+	// Explicit set id to empty
 	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
Support for resource imports. The problem with our existing resources is that the id is based on the id from the mz tables. So the `ReadContext` query should be based around filtering on the id. The `CreateContext` will only have access to that id after the resource is created so it will need to run two queries, one to create the resource and one to query the newly created resource to get the id (this will need to change for all our resources).

_main.tf_
```
resource "materialize_secret" "test" {
  name          = "pg_auto_pass"
  schema_name   = "public"
  database_name = "materialize"
}
```
Import resources:
`terraform import materialize_secret.test u2273`