### PR TITLE
Update secret creation value

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -55,7 +55,7 @@ resource "materialize_source" "example_source_load_generator" {
 resource "materialize_secret" "example_secret" {
   name        = "example"
   schema_name = materialize_schema.example_schema.name
-  value       = "decode('c2VjcmV0Cg==', 'base64')"
+  value       = "some-secret-value"
 }
 
 

--- a/examples/resources/materialize_secret/resource.tf
+++ b/examples/resources/materialize_secret/resource.tf
@@ -1,4 +1,4 @@
 resource "materialize_secret" "example_secret" {
   name  = "secret"
-  value = "decode('c2VjcmV0Cg==', 'base64')"
+  value = "some-secret-value"
 }

--- a/integration/secret.tf
+++ b/integration/secret.tf
@@ -1,18 +1,18 @@
 resource "materialize_secret" "password" {
   name  = "password"
-  value = "decode('c2VjcmV0Cg==', 'base64')"
+  value = "c2VjcmV0Cg=="
 }
 
 resource "materialize_secret" "postgres_password" {
   name          = "pg_pass"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
-  value         = "decode('c2VjcmV0Cg==', 'base64')"
+  value         = "c2VjcmV0Cg=="
 }
 
 resource "materialize_secret" "kafka_password" {
   name          = "kafka_pass"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
-  value         = "decode('c2VjcmV0Cg==', 'base64')"
+  value         = "c2VjcmV0Cg=="
 }

--- a/materialize/resources/resource_secret.go
+++ b/materialize/resources/resource_secret.go
@@ -95,7 +95,8 @@ func (b *SecretBuilder) Rename(newName string) string {
 }
 
 func (b *SecretBuilder) UpdateValue(newValue string) string {
-	return fmt.Sprintf(`ALTER SECRET %s.%s.%s AS '%s';`, b.databaseName, b.schemaName, b.secretName, newValue)
+	escapedValue := pq.QuoteLiteral(newValue)
+	return fmt.Sprintf(`ALTER SECRET %s.%s.%s AS %s;`, b.databaseName, b.schemaName, b.secretName, escapedValue)
 }
 
 func (b *SecretBuilder) Drop() string {

--- a/materialize/resources/resource_secret.go
+++ b/materialize/resources/resource_secret.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 var secretSchema = map[string]*schema.Schema{
@@ -71,7 +72,8 @@ func newSecretBuilder(secretName, schemaName, databaseName string) *SecretBuilde
 }
 
 func (b *SecretBuilder) Create(value string) string {
-	return fmt.Sprintf(`CREATE SECRET %s.%s.%s AS '%s';`, b.databaseName, b.schemaName, b.secretName, value)
+	escapedValue := pq.QuoteLiteral(value)
+	return fmt.Sprintf(`CREATE SECRET %s.%s.%s AS %s;`, b.databaseName, b.schemaName, b.secretName, escapedValue)
 }
 
 func (b *SecretBuilder) ReadId() string {

--- a/materialize/resources/resource_secret.go
+++ b/materialize/resources/resource_secret.go
@@ -71,7 +71,7 @@ func newSecretBuilder(secretName, schemaName, databaseName string) *SecretBuilde
 }
 
 func (b *SecretBuilder) Create(value string) string {
-	return fmt.Sprintf(`CREATE SECRET %s.%s.%s AS %s;`, b.databaseName, b.schemaName, b.secretName, value)
+	return fmt.Sprintf(`CREATE SECRET %s.%s.%s AS '%s';`, b.databaseName, b.schemaName, b.secretName, value)
 }
 
 func (b *SecretBuilder) ReadId() string {
@@ -93,7 +93,7 @@ func (b *SecretBuilder) Rename(newName string) string {
 }
 
 func (b *SecretBuilder) UpdateValue(newValue string) string {
-	return fmt.Sprintf(`ALTER SECRET %s.%s.%s AS %s;`, b.databaseName, b.schemaName, b.secretName, newValue)
+	return fmt.Sprintf(`ALTER SECRET %s.%s.%s AS '%s';`, b.databaseName, b.schemaName, b.secretName, newValue)
 }
 
 func (b *SecretBuilder) Drop() string {

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -25,7 +25,7 @@ func TestResourceSecretReadId(t *testing.T) {
 func TestResourceSecretCreate(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`CREATE SECRET database.schema.secret AS decode('c2VjcmV0Cg==', 'base64');`, b.Create(`decode('c2VjcmV0Cg==', 'base64')`))
+	r.Equal(`CREATE SECRET database.schema.secret AS 'c2VjcmV0Cg';`, b.Create(`c2VjcmV0Cg`))
 }
 
 func TestResourceSecretRename(t *testing.T) {
@@ -37,7 +37,7 @@ func TestResourceSecretRename(t *testing.T) {
 func TestResourceSecretUpdateValue(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`ALTER SECRET database.schema.secret AS decode('c2VjcmV0Cgdd', 'base64');`, b.UpdateValue(`decode('c2VjcmV0Cgdd', 'base64')`))
+	r.Equal(`ALTER SECRET database.schema.secret AS 'c2VjcmV0Cgdd';`, b.UpdateValue(`c2VjcmV0Cgdd`))
 }
 
 func TestResourceSecretDrop(t *testing.T) {

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -28,6 +28,18 @@ func TestResourceSecretCreate(t *testing.T) {
 	r.Equal(`CREATE SECRET database.schema.secret AS 'c2VjcmV0Cg';`, b.Create(`c2VjcmV0Cg`))
 }
 
+func TestResourceSecretCreateEmptyValue(t *testing.T) {
+	r := require.New(t)
+	b := newSecretBuilder("secret", "schema", "database")
+	r.Equal(`CREATE SECRET database.schema.secret AS '';`, b.Create(``))
+}
+
+func TestResourceSecretCreateEscapeValue(t *testing.T) {
+	r := require.New(t)
+	b := newSecretBuilder("secret", "schema", "database")
+	r.Equal(`CREATE SECRET database.schema.secret AS 'c2Vjcm''V0Cg';`, b.Create(`c2Vjcm'V0Cg`))
+}
+
 func TestResourceSecretRename(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -34,7 +34,7 @@ func TestResourceSecretCreateEmptyValue(t *testing.T) {
 	r.Equal(`CREATE SECRET database.schema.secret AS '';`, b.Create(``))
 }
 
-func TestResourceSecretCreateEscapeValue(t *testing.T) {
+func TestResourceSecretCreateEscapedValue(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")
 	r.Equal(`CREATE SECRET database.schema.secret AS 'c2Vjcm''V0Cg';`, b.Create(`c2Vjcm'V0Cg`))
@@ -50,6 +50,12 @@ func TestResourceSecretUpdateValue(t *testing.T) {
 	r := require.New(t)
 	b := newSecretBuilder("secret", "schema", "database")
 	r.Equal(`ALTER SECRET database.schema.secret AS 'c2VjcmV0Cgdd';`, b.UpdateValue(`c2VjcmV0Cgdd`))
+}
+
+func TestResourceSecretUpdateEscapedValue(t *testing.T) {
+	r := require.New(t)
+	b := newSecretBuilder("secret", "schema", "database")
+	r.Equal(`ALTER SECRET database.schema.secret AS 'c2Vjcm''V0Cgdd';`, b.UpdateValue(`c2Vjcm'V0Cgdd`))
 }
 
 func TestResourceSecretDrop(t *testing.T) {


### PR DESCRIPTION
As discussed [here](https://github.com/MaterializeInc/terraform-provider-materialize/pull/12/files#r1101929562),  we want the value to be a string that gets escaped and provided directly like `CREATE SECRET s AS '<escaped value goes here>'`. 