### PR TITLE
Add integration connections tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,10 +13,6 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d
 
-      - name: Configure Materialize
-        run: |
-          docker exec materialized psql -U mz_system -h localhost -p 6877 -d materialize -c 'ALTER SYSTEM SET max_aws_privatelink_connections = 3;'
-
       - name: Terraform Init
         run: |
           docker exec provider terraform init

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d
 
+      - name: Configure Materialize
+        run: |
+          docker exec materialized psql -U mz_system -h localhost -p 6877 -d materialize -c 'ALTER SYSTEM SET max_aws_privatelink_connections = 3;'
+
       - name: Terraform Init
         run: |
           docker exec provider terraform init
@@ -20,7 +24,7 @@ jobs:
       - name: Terraform Apply
         run: |
           docker exec provider terraform apply -auto-approve -compact-warnings
-      
+
       - name: Terraform Destroy
         run: |
           docker exec provider terraform destroy -auto-approve -compact-warnings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     container_name: materialized
     ports:
       - 6875:6875
-      - 6877:6877
       - 6878:6878
     healthcheck: {test: curl -f localhost:6878/api/readyz, interval: 1s, start_period: 30s}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     container_name: materialized
     ports:
       - 6875:6875
+      - 6877:6877
       - 6878:6878
     healthcheck: {test: curl -f localhost:6878/api/readyz, interval: 1s, start_period: 30s}
 
@@ -41,6 +42,22 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081,http://localhost:8081
+
+  postgres:
+    container_name: postgres
+    build:
+      context: ./integration/postgres
+    init: true
+    ports:
+      - 5432:5432
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pg_password}
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+    command:
+      - postgres
+      - -c
+      - wal_level=logical
 
   provider:
     build:

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -17,3 +17,39 @@ resource "materialize_connection" "schema_registry" {
   connection_type               = "CONFLUENT SCHEMA REGISTRY"
   confluent_schema_registry_url = "http://schema-registry:8081"
 }
+
+resource "materialize_connection" "example_ssh_connection" {
+  name            = "ssh_example_connection"
+  schema_name     = "public"
+  connection_type = "SSH TUNNEL"
+  ssh_host        = "ssh_host"
+  ssh_user        = "ssh_user"
+  ssh_port        = 22
+}
+
+resource "materialize_connection" "kafka_conn_multiple_brokers" {
+  name            = "kafka_conn_multiple_brokers"
+  connection_type = "KAFKA"
+  kafka_brokers = [
+    {
+      broker = "kafka:9092"
+    },
+    {
+      broker = "kafka2:9092"
+    }
+  ]
+  kafka_sasl_username   = "sasl_user"
+  kafka_sasl_password   = format("%s.%s.%s", materialize_database.database.name, materialize_schema.schema.name, materialize_secret.kafka_password.name)
+  kafka_sasl_mechanisms = "SCRAM-SHA-256"
+  kafka_progress_topic  = "progress_topic"
+}
+
+resource "materialize_connection" "example_postgres_connection" {
+  name              = "example_postgres_connection"
+  connection_type   = "POSTGRES"
+  postgres_host     = "postgres"
+  postgres_port     = 5432
+  postgres_user     = "materialize"
+  postgres_password = format("%s.%s.%s", materialize_database.database.name, materialize_schema.schema.name, materialize_secret.postgres_password.name)
+  postgres_database = "postgres"
+}

--- a/integration/postgres/Dockerfile
+++ b/integration/postgres/Dockerfile
@@ -1,0 +1,9 @@
+FROM postgres:14.2-alpine
+
+# Automatically run by Postgres
+COPY ./create.sh /docker-entrypoint-initdb.d/
+COPY ./seed.sh /docker-entrypoint-initdb.d/
+
+# Create Tables, Publications and Roles
+COPY ./create.sql /scripts/
+COPY ./seed.sql /scripts/

--- a/integration/postgres/create.sh
+++ b/integration/postgres/create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Creating tables, publications and roles"
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f /scripts/create.sql

--- a/integration/postgres/create.sql
+++ b/integration/postgres/create.sql
@@ -1,0 +1,19 @@
+CREATE TABLE table1 (
+    id INT GENERATED ALWAYS AS IDENTITY,
+);
+
+CREATE TABLE table2 (
+    id INT,
+    updated_at timestamp NOT NULL
+);
+
+-- Enable REPLICA for both tables
+ALTER TABLE table1 REPLICA IDENTITY FULL;
+ALTER TABLE table2 REPLICA IDENTITY FULL;
+
+-- Create publication on the created tables
+CREATE PUBLICATION mz_source FOR TABLE table1, table2;
+
+-- Create user and role to be used by Materialize
+CREATE ROLE materialize REPLICATION LOGIN PASSWORD 'c2VjcmV0Cg==';
+GRANT SELECT ON table1, table2 TO materialize;

--- a/integration/postgres/seed.sh
+++ b/integration/postgres/seed.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Creating tables, publications and roles"
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f /scripts/seed.sql

--- a/integration/postgres/seed.sql
+++ b/integration/postgres/seed.sql
@@ -1,0 +1,2 @@
+INSERT INTO table1 VALUES (1), (2), (3), (4), (5);
+INSERT INTO table2 VALUES (1, NOW()), (2, NOW()), (3, NOW()), (4, NOW()), (5, NOW());


### PR DESCRIPTION
Adding:
 - A new Postgres container, later on could be used for the Postgres source tests
 - SSH connection test
 - Postgres connection test
 - Kafka connection for multiple brokers + SASL test
 
Unfortunately, we can't test PrivateLink connections due to the following blocker:

> Error in mzcompose: AWS PrivateLink connections are not supported 

https://github.com/MaterializeInc/materialize/blob/main/test/testdrive/connection-create-drop.td#L382-L388

This seems to cause TF to panic.

Closes #24 