### PR TITLE
Separate Query Package

### DIFF
--- a/materialize/datasources/datasource_secret.go
+++ b/materialize/datasources/datasource_secret.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log"
-	"strings"
+
+	"terraform-materialize/materialize/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,7 +15,7 @@ import (
 
 func Secret() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: secretRead,
+		ReadContext: SecretRead,
 		Schema: map[string]*schema.Schema{
 			"database_name": {
 				Type:        schema.TypeString,
@@ -57,41 +57,14 @@ func Secret() *schema.Resource {
 	}
 }
 
-func secretQuery(databaseName, schemaName string) string {
-	q := strings.Builder{}
-	q.WriteString(`
-		SELECT
-			mz_secrets.id,
-			mz_secrets.name,
-			mz_schemas.name,
-			mz_databases.name
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id`)
-
-	if databaseName != "" {
-		q.WriteString(fmt.Sprintf(`
-		WHERE mz_databases.name = '%s'`, databaseName))
-
-		if schemaName != "" {
-			q.WriteString(fmt.Sprintf(` AND mz_schemas.name = '%s'`, schemaName))
-		}
-	}
-
-	q.WriteString(`;`)
-	return q.String()
-}
-
-func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func SecretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*sqlx.DB)
 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
-	q := secretQuery(databaseName, schemaName)
+	q := materialize.ReadSecretDatasource(databaseName, schemaName)
 
 	rows, err := conn.Query(q)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -123,15 +96,6 @@ func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
-	if databaseName != "" && schemaName != "" {
-		id := fmt.Sprintf("%s|%s|secrets", databaseName, schemaName)
-		d.SetId(id)
-	} else if databaseName != "" {
-		id := fmt.Sprintf("%s|secrets", databaseName)
-		d.SetId(id)
-	} else {
-		d.SetId("secrets")
-	}
-
+	SetId("secrets", databaseName, schemaName, d)
 	return diags
 }

--- a/materialize/datasources/datasource_secret_test.go
+++ b/materialize/datasources/datasource_secret_test.go
@@ -1,57 +1,45 @@
 package datasources
 
 import (
+	"context"
 	"testing"
 
+	"terraform-materialize/materialize/testmocks"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSecretQuery(t *testing.T) {
+func TestResourceSecretCreate(t *testing.T) {
 	r := require.New(t)
-	b := secretQuery("", "")
-	r.Equal(`
-		SELECT
-			mz_secrets.id,
-			mz_secrets.name,
-			mz_schemas.name,
-			mz_databases.name
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id;`, b)
-}
 
-func TestSecretDatabaseQuery(t *testing.T) {
-	r := require.New(t)
-	b := secretQuery("database", "")
-	r.Equal(`
-		SELECT
-			mz_secrets.id,
-			mz_secrets.name,
-			mz_schemas.name,
-			mz_databases.name
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_databases.name = 'database';`, b)
-}
+	in := map[string]interface{}{
+		"schema_name":   "schema",
+		"database_name": "database",
+	}
+	d := schema.TestResourceDataRaw(t, Secret().Schema, in)
+	r.NotNil(d)
 
-func TestSecretSchemaDatabaseQuery(t *testing.T) {
-	r := require.New(t)
-	b := secretQuery("database", "schema")
-	r.Equal(`
-		SELECT
-			mz_secrets.id,
-			mz_secrets.name,
-			mz_schemas.name,
-			mz_databases.name
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema';`, b)
+	testmocks.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		ir := mock.NewRows([]string{"id", "name", "schema", "database"}).
+			AddRow("u1", "secret", "schema", "database")
+		mock.ExpectQuery(`
+			SELECT
+				mz_secrets.id,
+				mz_secrets.name,
+				mz_schemas.name,
+				mz_databases.name
+			FROM mz_secrets
+			JOIN mz_schemas
+				ON mz_secrets.schema_id = mz_schemas.id
+			JOIN mz_databases
+				ON mz_schemas.database_id = mz_databases.id`).WillReturnRows(ir)
+
+		if err := SecretRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 }

--- a/materialize/datasources/utils.go
+++ b/materialize/datasources/utils.go
@@ -1,0 +1,20 @@
+package datasources
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SetId(resource, databaseName, schemaName string, d *schema.ResourceData) {
+	var id string
+	if databaseName != "" && schemaName != "" {
+		id = fmt.Sprintf("%s|%s|%s", databaseName, schemaName, resource)
+	} else if databaseName != "" {
+		id = fmt.Sprintf("%s|%s", databaseName, resource)
+	} else {
+		id = resource
+	}
+
+	d.SetId(id)
+}

--- a/materialize/materialize/secret.go
+++ b/materialize/materialize/secret.go
@@ -1,0 +1,97 @@
+package materialize
+
+import (
+	"fmt"
+	"strings"
+)
+
+type SecretBuilder struct {
+	secretName   string
+	schemaName   string
+	databaseName string
+}
+
+func (b *SecretBuilder) qualifiedName() string {
+	return QualifiedName(b.databaseName, b.schemaName, b.secretName)
+}
+
+func NewSecretBuilder(secretName, schemaName, databaseName string) *SecretBuilder {
+	return &SecretBuilder{
+		secretName:   secretName,
+		schemaName:   schemaName,
+		databaseName: databaseName,
+	}
+}
+
+func (b *SecretBuilder) Create(value string) string {
+	escapedValue := QuoteString(value)
+	return fmt.Sprintf(`CREATE SECRET %s AS %s;`, b.qualifiedName(), escapedValue)
+}
+
+func (b *SecretBuilder) Rename(newName string) string {
+	n := QualifiedName(b.databaseName, b.schemaName, newName)
+	return fmt.Sprintf(`ALTER SECRET %s RENAME TO %s;`, b.qualifiedName(), n)
+}
+
+func (b *SecretBuilder) UpdateValue(newValue string) string {
+	escapedValue := QuoteString(newValue)
+	return fmt.Sprintf(`ALTER SECRET %s AS %s;`, b.qualifiedName(), escapedValue)
+}
+
+func (b *SecretBuilder) Drop() string {
+	return fmt.Sprintf(`DROP SECRET %s;`, b.qualifiedName())
+}
+
+func (b *SecretBuilder) ReadId() string {
+	return fmt.Sprintf(`
+		SELECT mz_secrets.id
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_secrets.name = '%s'
+		AND mz_schemas.name = '%s'
+		AND mz_databases.name = '%s';`, b.secretName, b.schemaName, b.databaseName)
+}
+
+func ReadSecretParams(id string) string {
+	return fmt.Sprintf(`
+		SELECT
+			mz_secrets.name AS name,
+			mz_schemas.name AS schema_name,
+			mz_databases.name AS database_name
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_secrets.id = '%s';`, id)
+}
+
+func ReadSecretDatasource(databaseName, schemaName string) string {
+	q := strings.Builder{}
+	q.WriteString(`
+		SELECT
+			mz_secrets.id,
+			mz_secrets.name,
+			mz_schemas.name,
+			mz_databases.name
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id`)
+
+	if databaseName != "" {
+		q.WriteString(fmt.Sprintf(`
+		WHERE mz_databases.name = '%s'`, databaseName))
+
+		if schemaName != "" {
+			q.WriteString(fmt.Sprintf(` AND mz_schemas.name = '%s'`, schemaName))
+		}
+	}
+
+	q.WriteString(`;`)
+	return q.String()
+}

--- a/materialize/materialize/secret_test.go
+++ b/materialize/materialize/secret_test.go
@@ -1,0 +1,97 @@
+package materialize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretCreateQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`CREATE SECRET "database"."schema"."secret" AS 'c2VjcmV0Cg';`, b.Create(`c2VjcmV0Cg`))
+}
+
+func TestSecretCreateEmptyValueQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`CREATE SECRET "database"."schema"."secret" AS '';`, b.Create(``))
+}
+
+func TestSecretCreateEscapedValueQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`CREATE SECRET "database"."schema"."secret" AS 'c2Vjcm''V0Cg';`, b.Create(`c2Vjcm'V0Cg`))
+}
+
+func TestSecretRenameQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`ALTER SECRET "database"."schema"."secret" RENAME TO "database"."schema"."new_secret";`, b.Rename("new_secret"))
+}
+
+func TestSecretUpdateValueQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`ALTER SECRET "database"."schema"."secret" AS 'c2VjcmV0Cgdd';`, b.UpdateValue(`c2VjcmV0Cgdd`))
+}
+
+func TestSecretUpdateEscapedValueQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`ALTER SECRET "database"."schema"."secret" AS 'c2Vjcm''V0Cgdd';`, b.UpdateValue(`c2Vjcm'V0Cgdd`))
+}
+
+func TestSecretDropQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`DROP SECRET "database"."schema"."secret";`, b.Drop())
+}
+
+func TestSecretReadIdQuery(t *testing.T) {
+	r := require.New(t)
+	b := NewSecretBuilder("secret", "schema", "database")
+	r.Equal(`
+		SELECT mz_secrets.id
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_secrets.name = 'secret'
+		AND mz_schemas.name = 'schema'
+		AND mz_databases.name = 'database';`, b.ReadId())
+}
+
+func TestSecretReadParamsQuery(t *testing.T) {
+	r := require.New(t)
+	b := ReadSecretParams("u1")
+	r.Equal(`
+		SELECT
+			mz_secrets.name AS name,
+			mz_schemas.name AS schema_name,
+			mz_databases.name AS database_name
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_secrets.id = 'u1';`, b)
+}
+
+func TestSecretSchemaDatabaseQuery(t *testing.T) {
+	r := require.New(t)
+	b := ReadSecretDatasource("database", "schema")
+	r.Equal(`
+		SELECT
+			mz_secrets.id,
+			mz_secrets.name,
+			mz_schemas.name,
+			mz_databases.name
+		FROM mz_secrets
+		JOIN mz_schemas
+			ON mz_secrets.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema';`, b)
+}

--- a/materialize/materialize/utils.go
+++ b/materialize/materialize/utils.go
@@ -1,0 +1,27 @@
+package materialize
+
+import (
+	"fmt"
+	"strings"
+)
+
+func QuoteString(input string) (output string) {
+	output = "'" + strings.Replace(input, "'", "''", -1) + "'"
+	return
+}
+
+func QuoteIdentifier(input string) (output string) {
+	output = `"` + strings.Replace(input, `"`, `""`, -1) + `"`
+	return
+}
+
+func QualifiedName(fields ...string) string {
+	var o []string
+	for _, f := range fields {
+		c := fmt.Sprintf(`"%v"`, f)
+		o = append(o, c)
+	}
+
+	q := strings.Join(o[:], ".")
+	return q
+}

--- a/materialize/resources/resource_materialized_view.go
+++ b/materialize/resources/resource_materialized_view.go
@@ -208,7 +208,7 @@ func materializedViewUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if d.HasChange("name") {
 		_, newName := d.GetChange("name")
 
-		q := newSecretBuilder(materializedViewName, schemaName, databaseName).Rename(newName.(string))
+		q := newMaterializedViewBuilder(materializedViewName, schemaName, databaseName).Rename(newName.(string))
 
 		if err := ExecResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename materialized view: %s", q)

--- a/materialize/resources/resource_secret_test.go
+++ b/materialize/resources/resource_secret_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"terraform-materialize/materialize/testmocks"
+
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
@@ -22,7 +24,7 @@ func TestResourceSecretCreate(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, Secret().Schema, in)
 	r.NotNil(d)
 
-	WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+	testmocks.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
 			`CREATE SECRET "database"."schema"."secret" AS 'value';`,
@@ -57,7 +59,7 @@ func TestResourceSecretCreate(t *testing.T) {
 				ON mz_schemas.database_id = mz_databases.id
 			WHERE mz_secrets.id = 'u1';`).WillReturnRows(ip)
 
-		if err := secretCreate(context.TODO(), d, db); err != nil {
+		if err := SecretCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -76,85 +78,12 @@ func TestResourceSecretDelete(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, Secret().Schema, in)
 	r.NotNil(d)
 
-	WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+	testmocks.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP SECRET "database"."schema"."secret";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		if err := secretDelete(context.TODO(), d, db); err != nil {
+		if err := SecretDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}
 	})
 
-}
-
-func TestSecretCreateQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`CREATE SECRET "database"."schema"."secret" AS 'c2VjcmV0Cg';`, b.Create(`c2VjcmV0Cg`))
-}
-
-func TestSecretCreateEmptyValueQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`CREATE SECRET "database"."schema"."secret" AS '';`, b.Create(``))
-}
-
-func TestSecretCreateEscapedValueQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`CREATE SECRET "database"."schema"."secret" AS 'c2Vjcm''V0Cg';`, b.Create(`c2Vjcm'V0Cg`))
-}
-
-func TestSecretRenameQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`ALTER SECRET "database"."schema"."secret" RENAME TO "database"."schema"."new_secret";`, b.Rename("new_secret"))
-}
-
-func TestSecretUpdateValueQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`ALTER SECRET "database"."schema"."secret" AS 'c2VjcmV0Cgdd';`, b.UpdateValue(`c2VjcmV0Cgdd`))
-}
-
-func TestSecretUpdateEscapedValueQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`ALTER SECRET "database"."schema"."secret" AS 'c2Vjcm''V0Cgdd';`, b.UpdateValue(`c2Vjcm'V0Cgdd`))
-}
-
-func TestSecretDropQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`DROP SECRET "database"."schema"."secret";`, b.Drop())
-}
-
-func TestSecretReadIdQuery(t *testing.T) {
-	r := require.New(t)
-	b := newSecretBuilder("secret", "schema", "database")
-	r.Equal(`
-		SELECT mz_secrets.id
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_secrets.name = 'secret'
-		AND mz_schemas.name = 'schema'
-		AND mz_databases.name = 'database';`, b.ReadId())
-}
-
-func TestSecretReadParamsQuery(t *testing.T) {
-	r := require.New(t)
-	b := readSecretParams("u1")
-	r.Equal(`
-		SELECT
-			mz_secrets.name AS name,
-			mz_schemas.name AS schema_name,
-			mz_databases.name AS database_name
-		FROM mz_secrets
-		JOIN mz_schemas
-			ON mz_secrets.schema_id = mz_schemas.id
-		JOIN mz_databases
-			ON mz_schemas.database_id = mz_databases.id
-		WHERE mz_secrets.id = 'u1';`, b)
 }

--- a/materialize/resources/resource_table.go
+++ b/materialize/resources/resource_table.go
@@ -53,8 +53,8 @@ var tableSchema = map[string]*schema.Schema{
 				},
 				"not_null": {
 					Description: "	Do not allow the column to contain NULL values. Columns without this constraint can contain NULL values.",
-					Type:     schema.TypeBool,
-					Optional: true,
+					Type:        schema.TypeBool,
+					Optional:    true,
 				},
 			},
 		},
@@ -238,7 +238,7 @@ func tableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	if d.HasChange("name") {
 		_, newName := d.GetChange("name")
 
-		q := newSecretBuilder(tableName, schemaName, databaseName).Rename(newName.(string))
+		q := newTableBuilder(tableName, schemaName, databaseName).Rename(newName.(string))
 
 		if err := ExecResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename table: %s", q)

--- a/materialize/resources/resource_view.go
+++ b/materialize/resources/resource_view.go
@@ -195,7 +195,7 @@ func viewUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	if d.HasChange("name") {
 		_, newName := d.GetChange("name")
 
-		q := newSecretBuilder(viewName, schemaName, databaseName).Rename(newName.(string))
+		q := newViewBuilder(viewName, schemaName, databaseName).Rename(newName.(string))
 
 		if err := ExecResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename view: %s", q)

--- a/materialize/testmocks/helpers.go
+++ b/materialize/testmocks/helpers.go
@@ -1,0 +1,22 @@
+package testmocks
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func WithMockDb(t *testing.T, f func(*sqlx.DB, sqlmock.Sqlmock)) {
+	t.Helper()
+	r := require.New(t)
+	db, mock, err := sqlmock.New()
+	dbx := sqlx.NewDb(db, "sqlmock")
+	r.NoError(err)
+	defer dbx.Close()
+
+	mock.MatchExpectationsInOrder(true)
+
+	f(dbx, mock)
+}


### PR DESCRIPTION
Attempting to rearrange and make the repo a little more readable by breaking out SQL functionality into it's own package (called `materialize`). This package should contain all the functionality to generate the SQL for both the resource and datasource. The tests in this package should just focus on creating correct SQL for various uses cases.

The `datasources` and `resources` packages should use the SQL from the `materialize` package. The tests for these packages should just ensure that when fields are set in Terraform, expected SQL is executed against the mock database. These tests should not test as many permutations of SQL generation as the `materialize` tests.

New package layout (just using secrets for clarity)
```
├── datasources
│   ├── datasource_secret.go
│   ├── datasource_secret_test.go
│   └── utils.go
├── materialize
│   ├── secret.go
│   ├── secret_test.go
│   └── utils.go
├── provider.go
├── provider_test.go
├── resources
│   ├── resource_secret.go
│   ├── resource_secret_test.go
│   ├── utils.go
│   └── utils_test.go
└── testmocks
    └── helpers.go -- Pulling out into its own package as both resources and datasources will use it
```