### PR TITLE
Remove unnecessary type

### DIFF
--- a/pkg/materialize/connection.go
+++ b/pkg/materialize/connection.go
@@ -39,8 +39,7 @@ func ReadConnectionParams(id string) string {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/connection_aws_privatelink_test.go
+++ b/pkg/materialize/connection_aws_privatelink_test.go
@@ -41,8 +41,7 @@ func TestConnectionAwsPrivatelinkReadParamsQuery(t *testing.T) {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/connection_confluent_schema_registry_test.go
+++ b/pkg/materialize/connection_confluent_schema_registry_test.go
@@ -41,8 +41,7 @@ func TestConnectionConfluentSchemaRegistryReadParamsQuery(t *testing.T) {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/connection_kafka_test.go
+++ b/pkg/materialize/connection_kafka_test.go
@@ -41,8 +41,7 @@ func TestConnectionKafkaReadParamsQuery(t *testing.T) {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/connection_postgres_test.go
+++ b/pkg/materialize/connection_postgres_test.go
@@ -41,8 +41,7 @@ func TestConnectionPostgresReadParamsQuery(t *testing.T) {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/connection_ssh_tunnel_test.go
+++ b/pkg/materialize/connection_ssh_tunnel_test.go
@@ -41,8 +41,7 @@ func TestConnectionSshTunnelReadParamsQuery(t *testing.T) {
 		SELECT
 			mz_connections.name,
 			mz_schemas.name,
-			mz_databases.name,
-			mz_connections.type
+			mz_databases.name
 		FROM mz_connections
 		JOIN mz_schemas
 			ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/materialize/sink.go
+++ b/pkg/materialize/sink.go
@@ -39,7 +39,6 @@ func ReadSinkParams(id string) string {
 			mz_sinks.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sinks.type,
 			mz_sinks.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -81,7 +81,6 @@ func TestSinkKafkaReadParamsQuery(t *testing.T) {
 			mz_sinks.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sinks.type,
 			mz_sinks.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/materialize/source.go
+++ b/pkg/materialize/source.go
@@ -39,7 +39,6 @@ func ReadSourceParams(id string) string {
 			mz_sources.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sources.type,
 			mz_sources.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/materialize/source_kafka_test.go
+++ b/pkg/materialize/source_kafka_test.go
@@ -85,7 +85,6 @@ func TestResourceSourceKafkaReadParamsQuery(t *testing.T) {
 			mz_sources.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sources.type,
 			mz_sources.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/materialize/source_load_generator_test.go
+++ b/pkg/materialize/source_load_generator_test.go
@@ -86,7 +86,6 @@ func TestSourceLoadgenReadParamsQuery(t *testing.T) {
 			mz_sources.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sources.type,
 			mz_sources.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -88,7 +88,6 @@ func TestSourcePostgresReadParamsQuery(t *testing.T) {
 			mz_sources.name,
 			mz_schemas.name,
 			mz_databases.name,
-			mz_sources.type,
 			mz_sources.size,
 			mz_connections.name as connection_name,
 			mz_clusters.name as cluster_name

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -1,11 +1,5 @@
 package resources
 
-var envelopes = []string{
-	"DEBEZIUM",
-	"UPSERT",
-	"TPCH",
-}
-
 var loadGeneratorTypes = []string{
 	"AUCTION",
 	"COUNTER",

--- a/pkg/resources/connection.go
+++ b/pkg/resources/connection.go
@@ -15,8 +15,8 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	i := d.Id()
 	q := materialize.ReadConnectionParams(i)
 
-	var name, schema, database, connection_type *string
-	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &connection_type); err != nil {
+	var name, schema, database *string
+	if err := conn.QueryRowx(q).Scan(&name, &schema, &database); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -31,10 +31,6 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	if err := d.Set("database_name", database); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("connection_type", connection_type); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_connection_aws_privatelink_test.go
+++ b/pkg/resources/resource_connection_aws_privatelink_test.go
@@ -44,14 +44,13 @@ func TestResourceAwsPrivatelinkCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "connection_type"}).
-			AddRow("conn", "schema", "database", "connection_type")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
+			AddRow("conn", "schema", "database")
 		mock.ExpectQuery(`
 			SELECT
 				mz_connections.name,
 				mz_schemas.name,
-				mz_databases.name,
-				mz_connections.type
+				mz_databases.name
 			FROM mz_connections
 			JOIN mz_schemas
 				ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/resources/resource_connection_confluent_schema_registry_test.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry_test.go
@@ -51,14 +51,13 @@ func TestResourceConfluentSchemaRegistryCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "connection_type"}).
-			AddRow("conn", "schema", "database", "connection_type")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
+			AddRow("conn", "schema", "database")
 		mock.ExpectQuery(`
 			SELECT
 				mz_connections.name,
 				mz_schemas.name,
-				mz_databases.name,
-				mz_connections.type
+				mz_databases.name
 			FROM mz_connections
 			JOIN mz_schemas
 				ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -52,14 +52,13 @@ func TestResourceKafkaCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "connection_type"}).
-			AddRow("conn", "schema", "database", "connection_type")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
+			AddRow("conn", "schema", "database")
 		mock.ExpectQuery(`
 			SELECT
 				mz_connections.name,
 				mz_schemas.name,
-				mz_databases.name,
-				mz_connections.type
+				mz_databases.name
 			FROM mz_connections
 			JOIN mz_schemas
 				ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/resources/resource_connection_postgres_test.go
+++ b/pkg/resources/resource_connection_postgres_test.go
@@ -53,14 +53,13 @@ func TestResourcePostgresCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "connection_type"}).
-			AddRow("conn", "schema", "database", "connection_type")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
+			AddRow("conn", "schema", "database")
 		mock.ExpectQuery(`
 			SELECT
 				mz_connections.name,
 				mz_schemas.name,
-				mz_databases.name,
-				mz_connections.type
+				mz_databases.name
 			FROM mz_connections
 			JOIN mz_schemas
 				ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/resources/resource_connection_ssh_tunnel_test.go
+++ b/pkg/resources/resource_connection_ssh_tunnel_test.go
@@ -46,14 +46,13 @@ func TestResourceSshTunnelCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "connection_type"}).
-			AddRow("conn", "schema", "database", "connection_type")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
+			AddRow("conn", "schema", "database")
 		mock.ExpectQuery(`
 			SELECT
 				mz_connections.name,
 				mz_schemas.name,
-				mz_databases.name,
-				mz_connections.type
+				mz_databases.name
 			FROM mz_connections
 			JOIN mz_schemas
 				ON mz_connections.schema_id = mz_schemas.id

--- a/pkg/resources/resource_sink_kafka_test.go
+++ b/pkg/resources/resource_sink_kafka_test.go
@@ -56,14 +56,13 @@ func TestResourceSinkKafkaCreate(t *testing.T) {
 		`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "sink_type", "size", "connection_name", "cluster_name"}).
-			AddRow("conn", "schema", "database", "sink_type", "small", "conn", "cluster")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "size", "connection_name", "cluster_name"}).
+			AddRow("conn", "schema", "database", "small", "conn", "cluster")
 		mock.ExpectQuery(`
 			SELECT
 				mz_sinks.name,
 				mz_schemas.name,
 				mz_databases.name,
-				mz_sinks.type,
 				mz_sinks.size,
 				mz_connections.name as connection_name,
 				mz_clusters.name as cluster_name

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -62,14 +62,13 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 		`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "source_type", "size", "connection_name", "cluster_name"}).
-			AddRow("conn", "schema", "database", "source_type", "small", "conn", "cluster")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "size", "connection_name", "cluster_name"}).
+			AddRow("conn", "schema", "database", "small", "conn", "cluster")
 		mock.ExpectQuery(`
 			SELECT
 				mz_sources.name,
 				mz_schemas.name,
 				mz_databases.name,
-				mz_sources.type,
 				mz_sources.size,
 				mz_connections.name as connection_name,
 				mz_clusters.name as cluster_name

--- a/pkg/resources/resource_source_load_generator_test.go
+++ b/pkg/resources/resource_source_load_generator_test.go
@@ -54,14 +54,13 @@ func TestResourceSourceLoadgenCreate(t *testing.T) {
 		`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "source_type", "size", "connection_name", "cluster_name"}).
-			AddRow("conn", "schema", "database", "source_type", "small", "conn", "cluster")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "size", "connection_name", "cluster_name"}).
+			AddRow("conn", "schema", "database", "small", "conn", "cluster")
 		mock.ExpectQuery(`
 			SELECT
 				mz_sources.name,
 				mz_schemas.name,
 				mz_databases.name,
-				mz_sources.type,
 				mz_sources.size,
 				mz_connections.name as connection_name,
 				mz_clusters.name as cluster_name

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -53,14 +53,13 @@ func TestResourceSourcePostgresCreate(t *testing.T) {
 		`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database", "source_type", "size", "connection_name", "cluster_name"}).
-			AddRow("conn", "schema", "database", "source_type", "small", "conn", "cluster")
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "size", "connection_name", "cluster_name"}).
+			AddRow("conn", "schema", "database", "small", "conn", "cluster")
 		mock.ExpectQuery(`
 			SELECT
 				mz_sources.name,
 				mz_schemas.name,
 				mz_databases.name,
-				mz_sources.type,
 				mz_sources.size,
 				mz_connections.name as connection_name,
 				mz_clusters.name as cluster_name

--- a/pkg/resources/sink.go
+++ b/pkg/resources/sink.go
@@ -14,8 +14,8 @@ func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	i := d.Id()
 	q := materialize.ReadSinkParams(i)
 
-	var name, schema, database, sink_type, size, connection_name, cluster_name *string
-	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &sink_type, &size, &connection_name, &cluster_name); err != nil {
+	var name, schema, database, size, connection_name, cluster_name *string
+	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &size, &connection_name, &cluster_name); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -30,10 +30,6 @@ func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	}
 
 	if err := d.Set("database_name", database); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("sink_type", sink_type); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/source.go
+++ b/pkg/resources/source.go
@@ -14,8 +14,8 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	i := d.Id()
 	q := materialize.ReadSourceParams(i)
 
-	var name, schema, database, source_type, size, connection_name, cluster_name *string
-	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &source_type, &size, &connection_name, &cluster_name); err != nil {
+	var name, schema, database, size, connection_name, cluster_name *string
+	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &size, &connection_name, &cluster_name); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -30,10 +30,6 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	}
 
 	if err := d.Set("database_name", database); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("source_type", source_type); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Remove unnecessary `x_type` from sources, sinks and connections which is unnecessary for the resources now that those resources are already divided out.