### PR TITLE
Rename Connection Fields

### DIFF
--- a/integration/source.tf
+++ b/integration/source.tf
@@ -21,7 +21,7 @@ resource "materialize_source_load_generator" "load_generator_cluster" {
 resource "materialize_source_postgres" "example_source_postgres" {
   name = "source_postgres"
   size = "2"
-  postgres_connection {
+  connection {
     name          = materialize_connection_postgres.postgres_connection.name
     schema_name   = materialize_connection_postgres.postgres_connection.schema_name
     database_name = materialize_connection_postgres.postgres_connection.database_name
@@ -40,7 +40,7 @@ resource "materialize_source_postgres" "example_source_postgres" {
 resource "materialize_source_kafka" "example_source_kafka_format_text" {
   name = "source_kafka_text"
   size = "2"
-  kafka_connection {
+  connection {
     name          = materialize_connection_kafka.kafka_connection.name
     schema_name   = materialize_connection_kafka.kafka_connection.schema_name
     database_name = materialize_connection_kafka.kafka_connection.database_name
@@ -57,8 +57,8 @@ resource "materialize_source_kafka" "example_source_kafka_format_text" {
 resource "materialize_source_kafka" "example_source_kafka_format_avro" {
   name = "source_kafka_avro"
   size = "2"
-  kafka_connection {
-    name          = materialize_connection_kafka.kafka_connection.name
+  connection {
+    name          = materialize_connection_kafka.connection.name
     schema_name   = materialize_connection_kafka.kafka_connection.schema_name
     database_name = materialize_connection_kafka.kafka_connection.database_name
   }

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -32,7 +32,7 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 		ExactlyOneOf: []string{"cluster_name", "size"},
 		ValidateFunc: validation.StringInSlice(append(sourceSizes, localSizes...), true),
 	},
-	"kafka_connection": IdentifierSchema("kafka_connection", "The Kafka connection to use in the source.", true),
+	"connection": IdentifierSchema("connection", "The Kafka connection to use in the source.", true),
 	"topic": {
 		Description: "The Kafka topic you want to subscribe to.",
 		Type:        schema.TypeString,
@@ -161,7 +161,7 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		builder.Size(v.(string))
 	}
 
-	if v, ok := d.GetOk("kafka_connection"); ok {
+	if v, ok := d.GetOk("connection"); ok {
 		conn := materialize.GetIdentifierSchemaStruct(databaseName, schemaName, v)
 		builder.KafkaConnection(conn)
 	}

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -21,7 +21,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 		"cluster_name":      "cluster",
 		"size":              "small",
 		"item_name":         "item",
-		"kafka_connection":  []interface{}{map[string]interface{}{"name": "kafka_conn"}},
+		"connection":        []interface{}{map[string]interface{}{"name": "kafka_conn"}},
 		"topic":             "topic",
 		"include_key":       "key",
 		"include_headers":   true,

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -32,7 +32,7 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		ExactlyOneOf: []string{"cluster_name", "size"},
 		ValidateFunc: validation.StringInSlice(append(sourceSizes, localSizes...), true),
 	},
-	"postgres_connection": IdentifierSchema("posgres_connection", "The PostgreSQL connection to use in the source.", true),
+	"connection": IdentifierSchema("posgres_connection", "The PostgreSQL connection to use in the source.", true),
 	"publication": {
 		Description: "The PostgreSQL publication (the replication data set containing the tables to be streamed to Materialize).",
 		Type:        schema.TypeString,
@@ -103,7 +103,7 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		builder.Size(v.(string))
 	}
 
-	if v, ok := d.GetOk("postgres_connection"); ok {
+	if v, ok := d.GetOk("connection"); ok {
 		conn := materialize.GetIdentifierSchemaStruct(databaseName, schemaName, v)
 		builder.PostgresConnection(conn)
 	}

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -15,15 +15,15 @@ func TestResourceSourcePostgresCreate(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":                "source",
-		"schema_name":         "schema",
-		"database_name":       "database",
-		"cluster_name":        "cluster",
-		"size":                "small",
-		"postgres_connection": []interface{}{map[string]interface{}{"name": "pg_connection"}},
-		"publication":         "mz_source",
-		"text_columns":        []interface{}{"table.unsupported_type_1"},
-		"table":               []interface{}{map[string]interface{}{"name": "name", "alias": "alias"}},
+		"name":          "source",
+		"schema_name":   "schema",
+		"database_name": "database",
+		"cluster_name":  "cluster",
+		"size":          "small",
+		"connection":    []interface{}{map[string]interface{}{"name": "pg_connection"}},
+		"publication":   "mz_source",
+		"text_columns":  []interface{}{"table.unsupported_type_1"},
+		"table":         []interface{}{map[string]interface{}{"name": "name", "alias": "alias"}},
 	}
 	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, in)
 	r.NotNil(d)


### PR DESCRIPTION
Rename `x_connection` fields to just be `connection` (as it is implied by the name resource type).