### PR TITLE
Change mod path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-materialize
+module github.com/MaterializeInc/terraform-materialize-provider
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	provider "terraform-materialize/pkg"
+	provider "github.com/MaterializeInc/terraform-materialize-provider/pkg"
 )
 
 // Provider documentation generation.

--- a/pkg/datasources/datasource_cluster.go
+++ b/pkg/datasources/datasource_cluster.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_cluster_replica.go
+++ b/pkg/datasources/datasource_cluster_replica.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_cluster_replica_test.go
+++ b/pkg/datasources/datasource_cluster_replica_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_cluster_test.go
+++ b/pkg/datasources/datasource_cluster_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_connection.go
+++ b/pkg/datasources/datasource_connection.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_connection_test.go
+++ b/pkg/datasources/datasource_connection_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_database.go
+++ b/pkg/datasources/datasource_database.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_database_test.go
+++ b/pkg/datasources/datasource_database_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_index.go
+++ b/pkg/datasources/datasource_index.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_index_test.go
+++ b/pkg/datasources/datasource_index_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_materialized_view.go
+++ b/pkg/datasources/datasource_materialized_view.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_materialized_view_test.go
+++ b/pkg/datasources/datasource_materialized_view_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_schema.go
+++ b/pkg/datasources/datasource_schema.go
@@ -6,7 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_schema_test.go
+++ b/pkg/datasources/datasource_schema_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_secret.go
+++ b/pkg/datasources/datasource_secret.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"log"
 
-	"terraform-materialize/pkg/materialize"
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_secret_test.go
+++ b/pkg/datasources/datasource_secret_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_sink.go
+++ b/pkg/datasources/datasource_sink.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_sink_test.go
+++ b/pkg/datasources/datasource_sink_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_source.go
+++ b/pkg/datasources/datasource_source.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_source_test.go
+++ b/pkg/datasources/datasource_source_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_table.go
+++ b/pkg/datasources/datasource_table.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_table_test.go
+++ b/pkg/datasources/datasource_table_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_view.go
+++ b/pkg/datasources/datasource_view.go
@@ -5,7 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/datasources/datasource_view_test.go
+++ b/pkg/datasources/datasource_view_test.go
@@ -2,8 +2,9 @@ package datasources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/provider.go
+++ b/pkg/provider.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"terraform-materialize/pkg/datasources"
-	"terraform-materialize/pkg/resources"
+	datasources "github.com/MaterializeInc/terraform-materialize-provider/pkg/datasources"
+	resources "github.com/MaterializeInc/terraform-materialize-provider/pkg/resources"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/connection.go
+++ b/pkg/resources/connection.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"fmt"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_aws_privatelink_test.go
+++ b/pkg/resources/resource_connection_aws_privatelink_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_confluent_schema_registry.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_confluent_schema_registry_test.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_postgres.go
+++ b/pkg/resources/resource_connection_postgres.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_postgres_test.go
+++ b/pkg/resources/resource_connection_postgres_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_connection_ssh_tunnel_test.go
+++ b/pkg/resources/resource_connection_ssh_tunnel_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_database_test.go
+++ b/pkg/resources/resource_database_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_index_test.go
+++ b/pkg/resources/resource_index_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_materialized_view_test.go
+++ b/pkg/resources/resource_materialized_view_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_schema_test.go
+++ b/pkg/resources/resource_schema_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_secret_test.go
+++ b/pkg/resources/resource_secret_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_sink_kafka_test.go
+++ b/pkg/resources/resource_sink_kafka_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_load_generator_test.go
+++ b/pkg/resources/resource_source_load_generator_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_table_test.go
+++ b/pkg/resources/resource_table_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -3,7 +3,8 @@ package resources
 import (
 	"context"
 	"log"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/resource_view_test.go
+++ b/pkg/resources/resource_view_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/testhelpers"
 	"testing"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/testhelpers"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/sink.go
+++ b/pkg/resources/sink.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/pkg/resources/source.go
+++ b/pkg/resources/source.go
@@ -2,7 +2,8 @@ package resources
 
 import (
 	"context"
-	"terraform-materialize/pkg/materialize"
+
+	"github.com/MaterializeInc/terraform-materialize-provider/pkg/materialize"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
Change module name to `github.com/MaterializeInc/terraform-materialize-provider` to make it more standard and easier to be used in the pulumi provider.