### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Include dependabot based on the [terraform-provider-mzcloud](https://github.com/MaterializeInc/terraform-provider-mzcloud/blob/master/.github/dependabot.yml).