### PR TITLE
release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
-## 0.1.0 (Unreleased)
+# Changelog
 
-BACKWARDS INCOMPATIBILITIES / NOTES:
+## 0.0.2 - 2022-04-18
+
+### Features
+
+### BugFixes
+* Fixes to datasources and added coverage to integration tests
+* Fixes to `UpdateContext` to resources and added coverage to unit tests
+
+### Misc
+* Change the Go import path
+
+## 0.0.1 - 2022-04-06
+
+Initial release.


### PR DESCRIPTION
Release of `0.0.2`. Will then tag and trigger the build for the new release.