### PR TITLE
Fix Source Loadgen Example

### DIFF
--- a/examples/resources/materialize_source_load_generator/resource.tf
+++ b/examples/resources/materialize_source_load_generator/resource.tf
@@ -1,10 +1,13 @@
 resource "materialize_source_load_generator" "example_source_load_generator" {
-  name                = "source_load_generator"
-  schema_name         = "schema"
-  size                = "3xsmall"
-  load_generator_type = "COUNTER"
-  tick_interval       = "500ms"
-  scale_factor        = 0.01
+  name        = "source_load_generator"
+  schema_name = "schema"
+  size        = "3xsmall"
+
+  counter_options {
+    load_generator_type = "COUNTER"
+    tick_interval       = "500ms"
+    scale_factor        = 0.01
+  }
 }
 
 # CREATE SOURCE schema.source_load_generator


### PR DESCRIPTION
This example was broke after we change load gen options to be nested and specific to the particular load generator type (as Pulumi pointed out).