### PR TITLE
Cleanup `resources` Functions

### DIFF
--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -53,24 +53,24 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 
 - `from` (Block List, Min: 1, Max: 1) The name of the source, table or materialized view you want to send to the sink. (see [below for nested schema](#nestedblock--from))
 - `kafka_connection` (Block List, Min: 1, Max: 1) The name of the Kafka connection to use in the sink. (see [below for nested schema](#nestedblock--kafka_connection))
-- `name` (String) The identifier for the source.
+- `name` (String) The identifier for the sink.
 - `topic` (String) The Kafka topic you want to subscribe to.
 
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this sink. If not specified, the size option must be specified.
-- `database_name` (String) The identifier for the source database.
+- `database_name` (String) The identifier for the sink database.
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
-- `schema_name` (String) The identifier for the source schema.
+- `schema_name` (String) The identifier for the sink schema.
 - `size` (String) The size of the sink.
 - `snapshot` (Boolean) Whether to emit the consolidated results of the query before the sink was created at the start of the sink.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `qualified_sql_name` (String) The fully qualified name of the source.
+- `qualified_sql_name` (String) The fully qualified name of the sink.
 
 <a id="nestedblock--from"></a>
 ### Nested Schema for `from`

--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -53,24 +53,24 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 
 - `from` (Block List, Min: 1, Max: 1) The name of the source, table or materialized view you want to send to the sink. (see [below for nested schema](#nestedblock--from))
 - `kafka_connection` (Block List, Min: 1, Max: 1) The name of the Kafka connection to use in the sink. (see [below for nested schema](#nestedblock--kafka_connection))
-- `name` (String) The identifier for the sink.
+- `name` (String) The identifier for the source.
 - `topic` (String) The Kafka topic you want to subscribe to.
 
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this sink. If not specified, the size option must be specified.
-- `database_name` (String) The identifier for the sink database.
+- `database_name` (String) The identifier for the source database.
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
-- `schema_name` (String) The identifier for the sink schema.
+- `schema_name` (String) The identifier for the source schema.
 - `size` (String) The size of the sink.
 - `snapshot` (Boolean) Whether to emit the consolidated results of the query before the sink was created at the start of the sink.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `qualified_sql_name` (String) The fully qualified name of the sink.
+- `qualified_sql_name` (String) The fully qualified name of the source.
 
 <a id="nestedblock--from"></a>
 ### Nested Schema for `from`

--- a/pkg/materialize/connection.go
+++ b/pkg/materialize/connection.go
@@ -10,6 +10,18 @@ type ValueSecretStruct struct {
 	Secret IdentifierSchemaStruct
 }
 
+func GetValueSecretStruct(databaseName string, schemaName string, v interface{}) ValueSecretStruct {
+	var value ValueSecretStruct
+	u := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := u["text"]; ok {
+		value.Text = v.(string)
+	}
+	if v, ok := u["secret"]; ok && len(v.([]interface{})) > 0 {
+		value.Secret = GetIdentifierSchemaStruct(databaseName, schemaName, v)
+	}
+	return value
+}
+
 type Connection struct {
 	ConnectionName string
 	SchemaName     string

--- a/pkg/materialize/connection_aws_privatelink.go
+++ b/pkg/materialize/connection_aws_privatelink.go
@@ -11,6 +11,14 @@ type ConnectionAwsPrivatelinkBuilder struct {
 	privateLinkAvailabilityZones []string
 }
 
+func GetAvailabilityZones(v []interface{}) []string {
+	var azs []string
+	for _, az := range v {
+		azs = append(azs, az.(string))
+	}
+	return azs
+}
+
 func NewConnectionAwsPrivatelinkBuilder(connectionName, schemaName, databaseName string) *ConnectionAwsPrivatelinkBuilder {
 	return &ConnectionAwsPrivatelinkBuilder{
 		Connection: Connection{connectionName, schemaName, databaseName},

--- a/pkg/materialize/connection_kafka.go
+++ b/pkg/materialize/connection_kafka.go
@@ -12,6 +12,24 @@ type KafkaBroker struct {
 	PrivateLinkConnection IdentifierSchemaStruct
 }
 
+func GetKafkaBrokersStruct(databaseName, schemaName string, v interface{}) []KafkaBroker {
+	var brokers []KafkaBroker
+	for _, broker := range v.([]interface{}) {
+		b := broker.(map[string]interface{})
+		privateLinkConn := IdentifierSchemaStruct{}
+		if b["private_link_connection"] != nil {
+			privateLinkConn = GetIdentifierSchemaStruct(databaseName, schemaName, b["private_link_connection"].([]interface{}))
+		}
+		brokers = append(brokers, KafkaBroker{
+			Broker:                b["broker"].(string),
+			TargetGroupPort:       b["target_group_port"].(int),
+			AvailabilityZone:      b["availability_zone"].(string),
+			PrivateLinkConnection: privateLinkConn,
+		})
+	}
+	return brokers
+}
+
 type ConnectionKafkaBuilder struct {
 	Connection
 	kafkaBrokers        []KafkaBroker

--- a/pkg/materialize/identifiers.go
+++ b/pkg/materialize/identifiers.go
@@ -6,10 +6,6 @@ type IdentifierSchemaStruct struct {
 	DatabaseName string
 }
 
-func (i *IdentifierSchemaStruct) QualifiedName() string {
-	return QualifiedName(i.DatabaseName, i.SchemaName, i.Name)
-}
-
 func GetIdentifierSchemaStruct(databaseName string, schemaName string, v interface{}) IdentifierSchemaStruct {
 	var conn IdentifierSchemaStruct
 	u := v.([]interface{})[0].(map[string]interface{})
@@ -27,4 +23,8 @@ func GetIdentifierSchemaStruct(databaseName string, schemaName string, v interfa
 		conn.DatabaseName = databaseName
 	}
 	return conn
+}
+
+func (i *IdentifierSchemaStruct) QualifiedName() string {
+	return QualifiedName(i.DatabaseName, i.SchemaName, i.Name)
 }

--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -10,6 +10,18 @@ type IndexColumn struct {
 	Val   string
 }
 
+func GetIndexColumnStruct(v []interface{}) []IndexColumn {
+	var i []IndexColumn
+	for _, column := range v {
+		c := column.(map[string]interface{})
+		i = append(i, IndexColumn{
+			Field: c["field"].(string),
+			Val:   c["val"].(string),
+		})
+	}
+	return i
+}
+
 type IndexBuilder struct {
 	indexName    string
 	indexDefault bool

--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -5,9 +5,20 @@ import (
 	"strings"
 )
 
-type SinkEnvelopeStruct struct {
+type KafkaSinkEnvelopeStruct struct {
 	Upsert   bool
 	Debezium bool
+}
+
+func GetSinkKafkaEnelopeStruct(v interface{}) KafkaSinkEnvelopeStruct {
+	var envelope KafkaSinkEnvelopeStruct
+	if v, ok := v.([]interface{})[0].(map[string]interface{})["upsert"]; ok {
+		envelope.Upsert = v.(bool)
+	}
+	if v, ok := v.([]interface{})[0].(map[string]interface{})["debezium"]; ok {
+		envelope.Debezium = v.(bool)
+	}
+	return envelope
 }
 
 type SinkKafkaBuilder struct {
@@ -19,7 +30,7 @@ type SinkKafkaBuilder struct {
 	topic           string
 	key             []string
 	format          SinkFormatSpecStruct
-	envelope        SinkEnvelopeStruct
+	envelope        KafkaSinkEnvelopeStruct
 	snapshot        bool
 }
 
@@ -64,7 +75,7 @@ func (b *SinkKafkaBuilder) Format(f SinkFormatSpecStruct) *SinkKafkaBuilder {
 	return b
 }
 
-func (b *SinkKafkaBuilder) Envelope(e SinkEnvelopeStruct) *SinkKafkaBuilder {
+func (b *SinkKafkaBuilder) Envelope(e KafkaSinkEnvelopeStruct) *SinkKafkaBuilder {
 	b.envelope = e
 	return b
 }

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -30,7 +30,7 @@ func TestSinkKafkaCreateParamsQuery(t *testing.T) {
 	b.Topic("test_avro_topic")
 	b.Key([]string{"key_1", "key_2"})
 	b.Format(SinkFormatSpecStruct{Avro: &SinkAvroFormatSpec{SchemaRegistryConnection: IdentifierSchemaStruct{Name: "csr_connection", DatabaseName: "database", SchemaName: "public"}}})
-	b.Envelope(SinkEnvelopeStruct{Upsert: true})
+	b.Envelope(KafkaSinkEnvelopeStruct{Upsert: true})
 	b.Snapshot(false)
 	r.Equal(`CREATE SINK "database"."schema"."sink" FROM "database"."schema"."table" INTO KAFKA CONNECTION "database"."schema"."kafka_connection" KEY (key_1, key_2) (TOPIC 'test_avro_topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."public"."csr_connection" ENVELOPE UPSERT WITH ( SIZE = 'xsmall' SNAPSHOT = false);`, b.Create())
 }

--- a/pkg/materialize/source.go
+++ b/pkg/materialize/source.go
@@ -5,6 +5,23 @@ import (
 	"strings"
 )
 
+type Table struct {
+	Name  string
+	Alias string
+}
+
+func GetTableStruct(v []interface{}) []Table {
+	var tables []Table
+	for _, table := range v {
+		t := table.(map[string]interface{})
+		tables = append(tables, Table{
+			Name:  t["name"].(string),
+			Alias: t["alias"].(string),
+		})
+	}
+	return tables
+}
+
 type Source struct {
 	SourceName   string
 	SchemaName   string

--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -11,6 +11,20 @@ type KafkaSourceEnvelopeStruct struct {
 	Upsert   bool
 }
 
+func GetSourceKafkaEnelopeStruct(v interface{}) KafkaSourceEnvelopeStruct {
+	var envelope KafkaSourceEnvelopeStruct
+	if v, ok := v.([]interface{})[0].(map[string]interface{})["upsert"]; ok {
+		envelope.Upsert = v.(bool)
+	}
+	if v, ok := v.([]interface{})[0].(map[string]interface{})["debezium"]; ok {
+		envelope.Debezium = v.(bool)
+	}
+	if v, ok := v.([]interface{})[0].(map[string]interface{})["none"]; ok {
+		envelope.None = v.(bool)
+	}
+	return envelope
+}
+
 type SourceKafkaBuilder struct {
 	Source
 	clusterName      string

--- a/pkg/materialize/source_load_generator.go
+++ b/pkg/materialize/source_load_generator.go
@@ -5,27 +5,73 @@ import (
 	"strings"
 )
 
-type TableLoadgen struct {
-	Name  string
-	Alias string
-}
-
 type CounterOptions struct {
 	TickInterval   string
 	ScaleFactor    float64
 	MaxCardinality int
 }
 
+func GetCounterOptionsStruct(v interface{}) CounterOptions {
+	var o CounterOptions
+	u := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := u["tick_interval"]; ok {
+		o.TickInterval = v.(string)
+	}
+
+	if v, ok := u["scale_factor"]; ok {
+		o.ScaleFactor = v.(float64)
+	}
+
+	if v, ok := u["max_cardinality"]; ok {
+		o.MaxCardinality = v.(int)
+	}
+	return o
+}
+
 type AuctionOptions struct {
 	TickInterval string
 	ScaleFactor  float64
-	Table        []TableLoadgen
+	Table        []Table
+}
+
+func GetAuctionOptionsStruct(v interface{}) AuctionOptions {
+	var o AuctionOptions
+	u := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := u["tick_interval"]; ok {
+		o.TickInterval = v.(string)
+	}
+
+	if v, ok := u["scale_factor"]; ok {
+		o.ScaleFactor = v.(float64)
+	}
+
+	if v, ok := u["table"]; ok {
+		o.Table = GetTableStruct(v.([]interface{}))
+	}
+	return o
 }
 
 type TPCHOptions struct {
 	TickInterval string
 	ScaleFactor  float64
-	Table        []TableLoadgen
+	Table        []Table
+}
+
+func GetTPCHOptionsStruct(v interface{}) TPCHOptions {
+	var o TPCHOptions
+	u := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := u["tick_interval"]; ok {
+		o.TickInterval = v.(string)
+	}
+
+	if v, ok := u["scale_factor"]; ok {
+		o.ScaleFactor = v.(float64)
+	}
+
+	if v, ok := u["table"]; ok {
+		o.Table = GetTableStruct(v.([]interface{}))
+	}
+	return o
 }
 
 type SourceLoadgenBuilder struct {
@@ -114,7 +160,7 @@ func (b *SourceLoadgenBuilder) Create() string {
 		// Tables do not apply to COUNTER
 	} else if len(b.auctionOptions.Table) > 0 || len(b.tpchOptions.Table) > 0 {
 
-		var ot []TableLoadgen
+		var ot []Table
 		if len(b.auctionOptions.Table) > 0 {
 			ot = b.auctionOptions.Table
 		} else {

--- a/pkg/materialize/source_load_generator_test.go
+++ b/pkg/materialize/source_load_generator_test.go
@@ -52,7 +52,7 @@ func TestSourceLoadgenCreateTPCHParamsQuery(t *testing.T) {
 	b.TPCHOptions(TPCHOptions{
 		TickInterval: "1s",
 		ScaleFactor:  0.01,
-		Table: []TableLoadgen{
+		Table: []Table{
 			{
 				Name:  "schema1.table_1",
 				Alias: "s1_table_1",

--- a/pkg/materialize/source_postgres.go
+++ b/pkg/materialize/source_postgres.go
@@ -5,11 +5,6 @@ import (
 	"strings"
 )
 
-type TablePostgres struct {
-	Name  string
-	Alias string
-}
-
 type SourcePostgresBuilder struct {
 	Source
 	clusterName        string
@@ -17,7 +12,7 @@ type SourcePostgresBuilder struct {
 	postgresConnection IdentifierSchemaStruct
 	publication        string
 	textColumns        []string
-	table              []TablePostgres
+	table              []Table
 }
 
 func NewSourcePostgresBuilder(sourceName, schemaName, databaseName string) *SourcePostgresBuilder {
@@ -51,7 +46,7 @@ func (b *SourcePostgresBuilder) TextColumns(t []string) *SourcePostgresBuilder {
 	return b
 }
 
-func (b *SourcePostgresBuilder) Table(t []TablePostgres) *SourcePostgresBuilder {
+func (b *SourcePostgresBuilder) Table(t []Table) *SourcePostgresBuilder {
 	b.table = t
 	return b
 }

--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -29,7 +29,7 @@ func TestSourcePostgresCreateParamsQuery(t *testing.T) {
 	b.PostgresConnection(IdentifierSchemaStruct{Name: "pg_connection", SchemaName: "schema", DatabaseName: "database"})
 	b.Publication("mz_source")
 	b.TextColumns([]string{"table.unsupported_type_1", "table.unsupported_type_2"})
-	b.Table([]TablePostgres{
+	b.Table([]Table{
 		{
 			Name:  "schema1.table_1",
 			Alias: "s1_table_1",

--- a/pkg/materialize/table.go
+++ b/pkg/materialize/table.go
@@ -11,6 +11,19 @@ type TableColumn struct {
 	NotNull bool
 }
 
+func GetTableColumnStruct(v []interface{}) []TableColumn {
+	var columns []TableColumn
+	for _, column := range v {
+		c := column.(map[string]interface{})
+		columns = append(columns, TableColumn{
+			ColName: c["name"].(string),
+			ColType: c["type"].(string),
+			NotNull: c["nullable"].(bool),
+		})
+	}
+	return columns
+}
+
 type TableBuilder struct {
 	tableName    string
 	schemaName   string

--- a/pkg/resources/connection.go
+++ b/pkg/resources/connection.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -77,27 +76,4 @@ func connectionAwsPrivatelinkRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	return nil
-}
-
-func ValueSecretSchema(elem string, description string, isRequired bool, isOptional bool) *schema.Schema {
-	return &schema.Schema{
-		Type: schema.TypeList,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"text": {
-					Description:   fmt.Sprintf("The %s text value.", elem),
-					Type:          schema.TypeString,
-					Optional:      true,
-					ConflictsWith: []string{fmt.Sprintf("%s.0.secret", elem)},
-				},
-				"secret": IdentifierSchema(elem, fmt.Sprintf("The %s secret value.", elem), false),
-			},
-		},
-		Required:    isRequired,
-		Optional:    isOptional,
-		MinItems:    1,
-		MaxItems:    1,
-		ForceNew:    true,
-		Description: description,
-	}
 }

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -11,7 +11,7 @@ import (
 )
 
 var clusterSchema = map[string]*schema.Schema{
-	"name": SchemaResourceName("cluster", true, true),
+	"name": NameSchema("cluster", true, true),
 }
 
 func Cluster() *schema.Resource {

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -12,14 +12,14 @@ import (
 )
 
 var clusterReplicaSchema = map[string]*schema.Schema{
-	"name": SchemaResourceName("replica", true, true),
+	"name": NameSchema("replica", true, true),
 	"cluster_name": {
 		Description: "The cluster whose resources you want to create an additional computation of.",
 		Type:        schema.TypeString,
 		Required:    true,
 		ForceNew:    true,
 	},
-	"size": SchemaSize("replica"),
+	"size": SizeSchema("replica"),
 	"availability_zone": {
 		Description:  "If you want the replica to reside in a specific availability zone.",
 		Type:         schema.TypeString,

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -12,11 +12,10 @@ import (
 )
 
 var connectionAwsPrivatelinkSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("connection", true, false),
-	"schema_name":        SchemaResourceSchemaName("connection", false),
-	"database_name":      SchemaResourceDatabaseName("connection", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("connection"),
-	"connection_type":    SchemaResourceConnectionName(),
+	"name":               NameSchema("connection", true, false),
+	"schema_name":        SchemaNameSchema("connection", false),
+	"database_name":      DatabaseNameSchema("connection", false),
+	"qualified_sql_name": QualifiedNameSchema("connection"),
 	"service_name": {
 		Description: "The name of the AWS PrivateLink service.",
 		Type:        schema.TypeString,
@@ -69,12 +68,8 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("availability_zones"); ok {
-		azs := v.([]interface{})
-		var azStrings []string
-		for _, az := range azs {
-			azStrings = append(azStrings, az.(string))
-		}
-		builder.PrivateLinkAvailabilityZones(azStrings)
+		azs := materialize.GetAvailabilityZones(v.([]interface{}))
+		builder.PrivateLinkAvailabilityZones(azs)
 	}
 
 	qc := builder.Create()
@@ -96,7 +91,7 @@ func connectionAwsPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 	if d.HasChange("name") {
 		_, newConnectionName := d.GetChange("name")
 		q := materialize.NewConnectionAwsPrivatelinkBuilder(connectionName, schemaName, databaseName).Rename(newConnectionName.(string))
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not execute query: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -13,11 +13,10 @@ import (
 )
 
 var connectionKafkaSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("connection", true, false),
-	"schema_name":        SchemaResourceSchemaName("connection", false),
-	"database_name":      SchemaResourceDatabaseName("connection", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("connection"),
-	"connection_type":    SchemaResourceConnectionName(),
+	"name":               NameSchema("connection", true, false),
+	"schema_name":        SchemaNameSchema("connection", false),
+	"database_name":      DatabaseNameSchema("connection", false),
+	"qualified_sql_name": QualifiedNameSchema("connection"),
 	"kafka_broker": {
 		Description: "The Kafka brokers configuration.",
 		Type:        schema.TypeList,
@@ -91,20 +90,7 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	builder := materialize.NewConnectionKafkaBuilder(connectionName, schemaName, databaseName)
 
 	if v, ok := d.GetOk("kafka_broker"); ok {
-		var brokers []materialize.KafkaBroker
-		for _, broker := range v.([]interface{}) {
-			b := broker.(map[string]interface{})
-			privateLinkConn := materialize.IdentifierSchemaStruct{}
-			if b["private_link_connection"] != nil {
-				privateLinkConn = materialize.GetIdentifierSchemaStruct(databaseName, schemaName, b["private_link_connection"].([]interface{}))
-			}
-			brokers = append(brokers, materialize.KafkaBroker{
-				Broker:                b["broker"].(string),
-				TargetGroupPort:       b["target_group_port"].(int),
-				AvailabilityZone:      b["availability_zone"].(string),
-				PrivateLinkConnection: privateLinkConn,
-			})
-		}
+		brokers := materialize.GetKafkaBrokersStruct(databaseName, schemaName, v)
 		builder.KafkaBrokers(brokers)
 	}
 
@@ -113,26 +99,12 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("ssl_certificate_authority"); ok {
-		var ssl_ca materialize.ValueSecretStruct
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["text"]; ok {
-			ssl_ca.Text = v.(string)
-		}
-		if v, ok := u["secret"]; ok && len(v.([]interface{})) > 0 {
-			ssl_ca.Secret = materialize.GetIdentifierSchemaStruct(databaseName, schemaName, v)
-		}
+		ssl_ca := materialize.GetValueSecretStruct(databaseName, schemaName, v)
 		builder.KafkaSSLCa(ssl_ca)
 	}
 
 	if v, ok := d.GetOk("ssl_certificate"); ok {
-		var ssl_cert materialize.ValueSecretStruct
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["text"]; ok {
-			ssl_cert.Text = v.(string)
-		}
-		if v, ok := u["secret"]; ok && len(v.([]interface{})) > 0 {
-			ssl_cert.Secret = materialize.GetIdentifierSchemaStruct(databaseName, schemaName, v)
-		}
+		ssl_cert := materialize.GetValueSecretStruct(databaseName, schemaName, v)
 		builder.KafkaSSLCert(ssl_cert)
 	}
 
@@ -146,14 +118,7 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("sasl_username"); ok {
-		var sasl_username materialize.ValueSecretStruct
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["text"]; ok {
-			sasl_username.Text = v.(string)
-		}
-		if v, ok := u["secret"]; ok && len(v.([]interface{})) > 0 {
-			sasl_username.Secret = materialize.GetIdentifierSchemaStruct(databaseName, schemaName, v)
-		}
+		sasl_username := materialize.GetValueSecretStruct(databaseName, schemaName, v)
 		builder.KafkaSASLUsername(sasl_username)
 	}
 
@@ -185,7 +150,7 @@ func connectionKafkaUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.HasChange("name") {
 		_, newConnectionName := d.GetChange("name")
 		q := materialize.NewConnectionKafkaBuilder(connectionName, schemaName, databaseName).Rename(newConnectionName.(string))
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not execute query: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -12,11 +12,10 @@ import (
 )
 
 var connectionSshTunnelSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("connection", true, false),
-	"schema_name":        SchemaResourceSchemaName("connection", false),
-	"database_name":      SchemaResourceDatabaseName("connection", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("connection"),
-	"connection_type":    SchemaResourceConnectionName(),
+	"name":               NameSchema("connection", true, false),
+	"schema_name":        SchemaNameSchema("connection", false),
+	"database_name":      DatabaseNameSchema("connection", false),
+	"qualified_sql_name": QualifiedNameSchema("connection"),
 	"host": {
 		Description: "The host of the SSH tunnel.",
 		Type:        schema.TypeString,
@@ -82,7 +81,7 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange("name") {
 		_, newConnectionName := d.GetChange("name")
 		q := materialize.NewConnectionSshTunnelBuilder(connectionName, schemaName, databaseName).Rename(newConnectionName.(string))
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not execute query: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -11,7 +11,7 @@ import (
 )
 
 var databaseSchema = map[string]*schema.Schema{
-	"name": SchemaResourceName("database", true, true),
+	"name": NameSchema("database", true, true),
 }
 
 func Database() *schema.Resource {

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -36,7 +36,7 @@ var indexSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
 	},
-	"qualified_sql_name": SchemaResourceQualifiedName("view"),
+	"qualified_sql_name": QualifiedNameSchema("view"),
 	"obj_name":           IdentifierSchema("obj_name", "The name of the source, view, or materialized view on which you want to create an index.", true),
 	"cluster_name": {
 		Description: "The cluster to maintain this index. If not specified, defaults to the active cluster.",
@@ -146,15 +146,8 @@ func indexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("col_expr"); ok {
-		var colExprs []materialize.IndexColumn
-		for _, colExpr := range v.([]interface{}) {
-			b := colExpr.(map[string]interface{})
-			colExprs = append(colExprs, materialize.IndexColumn{
-				Field: b["field"].(string),
-				Val:   b["val"].(string),
-			})
-		}
-		builder.ColExpr(colExprs)
+		c := materialize.GetIndexColumnStruct(v.([]interface{}))
+		builder.ColExpr(c)
 	}
 
 	qc := builder.Create()

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -12,10 +12,10 @@ import (
 )
 
 var materializedViewSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("materialized view", true, false),
-	"schema_name":        SchemaResourceSchemaName("materialized view", false),
-	"database_name":      SchemaResourceDatabaseName("materialized view", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("materialized view"),
+	"name":               NameSchema("materialized view", true, false),
+	"schema_name":        SchemaNameSchema("materialized view", false),
+	"database_name":      DatabaseNameSchema("materialized view", false),
+	"qualified_sql_name": QualifiedNameSchema("materialized view"),
 	"cluster_name": {
 		Description: "The cluster to maintain the materialized view. If not specified, defaults to the default cluster.",
 		Type:        schema.TypeString,
@@ -115,7 +115,7 @@ func materializedViewUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		q := materialize.NewMaterializedViewBuilder(materializedViewName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename materialized view: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -11,9 +11,9 @@ import (
 )
 
 var schemaSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("schema", true, true),
-	"database_name":      SchemaResourceDatabaseName("schema", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("schema"),
+	"name":               NameSchema("schema", true, true),
+	"database_name":      DatabaseNameSchema("schema", false),
+	"qualified_sql_name": QualifiedNameSchema("schema"),
 }
 
 func Schema() *schema.Resource {

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -12,10 +12,10 @@ import (
 )
 
 var secretSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("secret", true, false),
-	"schema_name":        SchemaResourceSchemaName("secret", false),
-	"database_name":      SchemaResourceDatabaseName("secret", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("secret"),
+	"name":               NameSchema("secret", true, false),
+	"schema_name":        SchemaNameSchema("secret", false),
+	"database_name":      DatabaseNameSchema("secret", false),
+	"qualified_sql_name": QualifiedNameSchema("secret"),
 	"value": {
 		Description: "The value for the secret. The value expression may not reference any relations, and must be a bytea string literal.",
 		Type:        schema.TypeString,
@@ -101,7 +101,7 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 		q := materialize.NewSecretBuilder(secretName, schemaName, databaseName).UpdateValue(newValue.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not update value of secret: %s", q)
 			return diag.FromErr(err)
 		}
@@ -112,7 +112,7 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 		q := materialize.NewSecretBuilder(secretName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename secret: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -13,10 +13,10 @@ import (
 )
 
 var sinkKafkaSchema = map[string]*schema.Schema{
-	"name":               NameSchema("source", true, false),
-	"schema_name":        SchemaNameSchema("source", false),
-	"database_name":      DatabaseNameSchema("source", false),
-	"qualified_sql_name": QualifiedNameSchema("source"),
+	"name":               NameSchema("sink", true, false),
+	"schema_name":        SchemaNameSchema("sink", false),
+	"database_name":      DatabaseNameSchema("sink", false),
+	"qualified_sql_name": QualifiedNameSchema("sink"),
 	"cluster_name": {
 		Description:  "The cluster to maintain this sink. If not specified, the size option must be specified.",
 		Type:         schema.TypeString,

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -13,11 +13,10 @@ import (
 )
 
 var sourceKafkaSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("source", true, false),
-	"schema_name":        SchemaResourceSchemaName("source", false),
-	"database_name":      SchemaResourceDatabaseName("source", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("source"),
-	"source_type":        SchemaResourceSourceType(),
+	"name":               NameSchema("source", true, false),
+	"schema_name":        SchemaNameSchema("source", false),
+	"database_name":      DatabaseNameSchema("source", false),
+	"qualified_sql_name": QualifiedNameSchema("source"),
 	"cluster_name": {
 		Description:  "The cluster to maintain this source. If not specified, the size option must be specified.",
 		Type:         schema.TypeString,
@@ -210,16 +209,7 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	if v, ok := d.GetOk("envelope"); ok {
-		var envelope materialize.KafkaSourceEnvelopeStruct
-		if v, ok := v.([]interface{})[0].(map[string]interface{})["upsert"]; ok {
-			envelope.Upsert = v.(bool)
-		}
-		if v, ok := v.([]interface{})[0].(map[string]interface{})["debezium"]; ok {
-			envelope.Debezium = v.(bool)
-		}
-		if v, ok := v.([]interface{})[0].(map[string]interface{})["none"]; ok {
-			envelope.None = v.(bool)
-		}
+		envelope := materialize.GetSourceKafkaEnelopeStruct(v)
 		builder.Envelope(envelope)
 	}
 
@@ -255,7 +245,7 @@ func sourceKafkaUpdate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 		q := materialize.NewSourceKafkaBuilder(sourceName, schemaName, databaseName).UpdateSize(newSize.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not resize sink: %s", q)
 			return diag.FromErr(err)
 		}
@@ -266,7 +256,7 @@ func sourceKafkaUpdate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 		q := materialize.NewSourceKafkaBuilder(sourceName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename sink: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -51,11 +51,10 @@ var table = &schema.Schema{
 }
 
 var sourceLoadgenSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("source", true, false),
-	"schema_name":        SchemaResourceSchemaName("source", false),
-	"database_name":      SchemaResourceDatabaseName("source", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("source"),
-	"source_type":        SchemaResourceSourceType(),
+	"name":               NameSchema("source", true, false),
+	"schema_name":        SchemaNameSchema("source", false),
+	"database_name":      DatabaseNameSchema("source", false),
+	"qualified_sql_name": QualifiedNameSchema("source"),
 	"cluster_name": {
 		Description:  "The cluster to maintain this source. If not specified, the size option must be specified.",
 		Type:         schema.TypeString,
@@ -168,69 +167,17 @@ func sourceLoadgenCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if v, ok := d.GetOk("counter_options"); ok {
-		var o materialize.CounterOptions
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["tick_interval"]; ok {
-			o.TickInterval = v.(string)
-		}
-
-		if v, ok := u["scale_factor"]; ok {
-			o.ScaleFactor = v.(float64)
-		}
-
-		if v, ok := u["max_cardinality"]; ok {
-			o.MaxCardinality = v.(int)
-		}
+		o := materialize.GetCounterOptionsStruct(v)
 		builder.CounterOptions(o)
 	}
 
 	if v, ok := d.GetOk("auction_options"); ok {
-		var o materialize.AuctionOptions
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["tick_interval"]; ok {
-			o.TickInterval = v.(string)
-		}
-
-		if v, ok := u["scale_factor"]; ok {
-			o.ScaleFactor = v.(float64)
-		}
-
-		if v, ok := u["table"]; ok {
-			var tables []materialize.TableLoadgen
-			for _, table := range v.([]interface{}) {
-				t := table.(map[string]interface{})
-				tables = append(tables, materialize.TableLoadgen{
-					Name:  t["name"].(string),
-					Alias: t["alias"].(string),
-				})
-			}
-			o.Table = tables
-		}
+		o := materialize.GetAuctionOptionsStruct(v)
 		builder.AuctionOptions(o)
 	}
 
 	if v, ok := d.GetOk("tpch_options"); ok {
-		var o materialize.TPCHOptions
-		u := v.([]interface{})[0].(map[string]interface{})
-		if v, ok := u["tick_interval"]; ok {
-			o.TickInterval = v.(string)
-		}
-
-		if v, ok := u["scale_factor"]; ok {
-			o.ScaleFactor = v.(float64)
-		}
-
-		if v, ok := u["table"]; ok {
-			var tables []materialize.TableLoadgen
-			for _, table := range v.([]interface{}) {
-				t := table.(map[string]interface{})
-				tables = append(tables, materialize.TableLoadgen{
-					Name:  t["name"].(string),
-					Alias: t["alias"].(string),
-				})
-			}
-			o.Table = tables
-		}
+		o := materialize.GetTPCHOptionsStruct(v)
 		builder.TPCHOptions(o)
 	}
 
@@ -254,7 +201,7 @@ func sourceLoadgenUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		q := materialize.NewSourceLoadgenBuilder(sourceName, schemaName, databaseName).UpdateSize(newSize.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not resize sink: %s", q)
 			return diag.FromErr(err)
 		}
@@ -265,7 +212,7 @@ func sourceLoadgenUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		q := materialize.NewSourceLoadgenBuilder(sourceName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename sink: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -13,11 +13,10 @@ import (
 )
 
 var sourcePostgresSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("source", true, false),
-	"schema_name":        SchemaResourceSchemaName("source", false),
-	"database_name":      SchemaResourceDatabaseName("source", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("source"),
-	"source_type":        SchemaResourceSourceType(),
+	"name":               NameSchema("source", true, false),
+	"schema_name":        SchemaNameSchema("source", false),
+	"database_name":      DatabaseNameSchema("source", false),
+	"qualified_sql_name": QualifiedNameSchema("source"),
 	"cluster_name": {
 		Description:  "The cluster to maintain this source. If not specified, the size option must be specified.",
 		Type:         schema.TypeString,
@@ -114,14 +113,7 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if v, ok := d.GetOk("table"); ok {
-		var tables []materialize.TablePostgres
-		for _, table := range v.([]interface{}) {
-			t := table.(map[string]interface{})
-			tables = append(tables, materialize.TablePostgres{
-				Name:  t["name"].(string),
-				Alias: t["alias"].(string),
-			})
-		}
+		tables := materialize.GetTableStruct(v.([]interface{}))
 		builder.Table(tables)
 	}
 
@@ -149,7 +141,7 @@ func sourcePostgresUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 
 		q := materialize.NewSourcePostgresBuilder(sourceName, schemaName, databaseName).UpdateSize(newSize.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not resize sink: %s", q)
 			return diag.FromErr(err)
 		}
@@ -160,7 +152,7 @@ func sourcePostgresUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 
 		q := materialize.NewSourcePostgresBuilder(sourceName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename sink: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -12,10 +12,10 @@ import (
 )
 
 var viewSchema = map[string]*schema.Schema{
-	"name":               SchemaResourceName("view", true, false),
-	"schema_name":        SchemaResourceSchemaName("view", false),
-	"database_name":      SchemaResourceDatabaseName("view", false),
-	"qualified_sql_name": SchemaResourceQualifiedName("view"),
+	"name":               NameSchema("view", true, false),
+	"schema_name":        SchemaNameSchema("view", false),
+	"database_name":      DatabaseNameSchema("view", false),
+	"qualified_sql_name": QualifiedNameSchema("view"),
 	"statement": {
 		Description: "The SQL statement to create the view.",
 		Type:        schema.TypeString,
@@ -106,7 +106,7 @@ func viewUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 		q := materialize.NewViewBuilder(viewName, schemaName, databaseName).Rename(newName.(string))
 
-		if err := ExecResource(conn, q); err != nil {
+		if err := execResource(conn, q); err != nil {
 			log.Printf("[ERROR] could not rename view: %s", q)
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -12,7 +12,7 @@ const (
 	defaultDatabase = "materialize"
 )
 
-func SchemaResourceName(resource string, required, forceNew bool) *schema.Schema {
+func NameSchema(resource string, required, forceNew bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
 		Description: fmt.Sprintf("The identifier for the %s.", resource),
@@ -22,7 +22,7 @@ func SchemaResourceName(resource string, required, forceNew bool) *schema.Schema
 	}
 }
 
-func SchemaResourceSchemaName(resource string, required bool) *schema.Schema {
+func SchemaNameSchema(resource string, required bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
 		Description: fmt.Sprintf("The identifier for the %s schema.", resource),
@@ -33,7 +33,7 @@ func SchemaResourceSchemaName(resource string, required bool) *schema.Schema {
 	}
 }
 
-func SchemaResourceDatabaseName(resource string, required bool) *schema.Schema {
+func DatabaseNameSchema(resource string, required bool) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
 		Description: fmt.Sprintf("The identifier for the %s database.", resource),
@@ -44,7 +44,7 @@ func SchemaResourceDatabaseName(resource string, required bool) *schema.Schema {
 	}
 }
 
-func SchemaResourceQualifiedName(resource string) *schema.Schema {
+func QualifiedNameSchema(resource string) *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
 		Description: fmt.Sprintf("The fully qualified name of the %s.", resource),
@@ -52,31 +52,7 @@ func SchemaResourceQualifiedName(resource string) *schema.Schema {
 	}
 }
 
-func SchemaResourceConnectionName() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "The type of connection.",
-		Computed:    true,
-	}
-}
-
-func SchemaResourceSinkType() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "The type of sink.",
-		Computed:    true,
-	}
-}
-
-func SchemaResourceSourceType() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeString,
-		Description: "The type of source.",
-		Computed:    true,
-	}
-}
-
-func SchemaSize(resource string) *schema.Schema {
+func SizeSchema(resource string) *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,
 		Description:  fmt.Sprintf("The size of the %s.", resource),
@@ -110,6 +86,29 @@ func IdentifierSchema(elem, description string, required bool) *schema.Schema {
 		},
 		Required:    required,
 		Optional:    !required,
+		MinItems:    1,
+		MaxItems:    1,
+		ForceNew:    true,
+		Description: description,
+	}
+}
+
+func ValueSecretSchema(elem string, description string, isRequired bool, isOptional bool) *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"text": {
+					Description:   fmt.Sprintf("The %s text value.", elem),
+					Type:          schema.TypeString,
+					Optional:      true,
+					ConflictsWith: []string{fmt.Sprintf("%s.0.secret", elem)},
+				},
+				"secret": IdentifierSchema(elem, fmt.Sprintf("The %s secret value.", elem), false),
+			},
+		},
+		Required:    isRequired,
+		Optional:    isOptional,
 		MinItems:    1,
 		MaxItems:    1,
 		ForceNew:    true,

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -16,7 +16,7 @@ func (e *SQLError) Error() string {
 	return fmt.Sprintf("Unable to execute SQL: %v", e.Err)
 }
 
-func ExecResource(conn *sqlx.DB, queryStr string) error {
+func execResource(conn *sqlx.DB, queryStr string) error {
 	_, err := conn.Exec(queryStr)
 	if err != nil {
 		return &SQLError{Err: err}


### PR DESCRIPTION
Doing some cleanup of the `resources`. There were cases where we had logic defined within the resources on how to set certain nested structs and it was defined in multiple places. Centralizing all that logic in the `materialize` package to try and keep the `resources` package specific to Terraform. Also a few other odds and ends cleanup.