### PR TITLE
Update Github Action Schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
   - package-ecosystem: gomod
-    directory: /
+    directory: /provider
     schedule:
-      interval: daily
+      interval: weekly
+      day: sunday
+      time: "22:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /provider
+    directory: /
     schedule:
       interval: weekly
       day: sunday

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
       - pkg/**
       - integration/**
   schedule:
-    - cron: 0 11 * * *
+    - cron: 0 11 * * 0
 
 jobs:
   integration:


### PR DESCRIPTION
Changing Dependabot to weekly on Sunday since daily is unnecessary. Likewise changing the scheduled integration tests to once a week since there is no point running the cron for those tests unless there is a new `materialize/materialized` image.