### PR TITLE
Include SSH keys in SSH connection

### DIFF
--- a/docs/resources/connection_ssh_tunnel.md
+++ b/docs/resources/connection_ssh_tunnel.md
@@ -47,6 +47,8 @@ resource "materialize_connection_ssh_tunnel" "example_ssh_connection" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `public_key_1` (String) The first public key associated with the SSH tunnel.
+- `public_key_2` (String) The second public key associated with the SSH tunnel.
 - `qualified_sql_name` (String) The fully qualified name of the connection.
 
 ## Import

--- a/pkg/materialize/connection.go
+++ b/pkg/materialize/connection.go
@@ -60,7 +60,7 @@ func ReadConnectionParams(id string) string {
 		WHERE mz_connections.id = %s;`, QuoteString(id))
 }
 
-func ReadAwsPrivatelinkConnectionParams(id string) string {
+func ReadConnectionAwsPrivatelinkParams(id string) string {
 	return fmt.Sprintf(`
 		SELECT
 			mz_connections.name,
@@ -74,6 +74,24 @@ func ReadAwsPrivatelinkConnectionParams(id string) string {
 			ON mz_schemas.database_id = mz_databases.id
 		JOIN mz_aws_privatelink_connections
 			ON mz_connections.id = mz_aws_privatelink_connections.id
+		WHERE mz_connections.id = %s;`, QuoteString(id))
+}
+
+func ReadConnectionSshTunnelParams(id string) string {
+	return fmt.Sprintf(`
+		SELECT
+			mz_connections.name,
+			mz_schemas.name,
+			mz_databases.name,
+			mz_ssh_tunnel_connections.public_key_1,
+			mz_ssh_tunnel_connections.public_key_2
+		FROM mz_connections
+		JOIN mz_schemas
+			ON mz_connections.schema_id = mz_schemas.id
+		JOIN mz_databases
+			ON mz_schemas.database_id = mz_databases.id
+		LEFT JOIN mz_ssh_tunnel_connections
+			ON mz_connections.id = mz_ssh_tunnel_connections.id
 		WHERE mz_connections.id = %s;`, QuoteString(id))
 }
 

--- a/pkg/resources/connection.go
+++ b/pkg/resources/connection.go
@@ -41,39 +41,3 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	return nil
 }
-
-func connectionAwsPrivatelinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*sqlx.DB)
-	i := d.Id()
-	q := materialize.ReadAwsPrivatelinkConnectionParams(i)
-
-	var name, schema, database, principal *string
-	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &principal); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(i)
-
-	if err := d.Set("name", name); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("schema_name", schema); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("database_name", database); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err := d.Set("principal", principal); err != nil {
-		return diag.FromErr(err)
-	}
-
-	b := materialize.Connection{ConnectionName: *name, SchemaName: *schema, DatabaseName: *database}
-	if err := d.Set("qualified_sql_name", b.QualifiedName()); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
-}

--- a/pkg/resources/connection_test.go
+++ b/pkg/resources/connection_test.go
@@ -26,3 +26,19 @@ JOIN mz_databases
 JOIN mz_aws_privatelink_connections
 	ON mz_connections.id = mz_aws_privatelink_connections.id
 WHERE mz_connections.id = 'u1';`
+
+var readConnectionSshTunnellink string = `
+SELECT
+	mz_connections.name,
+	mz_schemas.name,
+	mz_databases.name,
+	mz_ssh_tunnel_connections.public_key_1,
+	mz_ssh_tunnel_connections.public_key_2
+FROM mz_connections
+JOIN mz_schemas
+	ON mz_connections.schema_id = mz_schemas.id
+JOIN mz_databases
+	ON mz_schemas.database_id = mz_databases.id
+LEFT JOIN mz_ssh_tunnel_connections
+	ON mz_connections.id = mz_ssh_tunnel_connections.id
+WHERE mz_connections.id = 'u1';`

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -54,6 +54,42 @@ func ConnectionAwsPrivatelink() *schema.Resource {
 	}
 }
 
+func connectionAwsPrivatelinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*sqlx.DB)
+	i := d.Id()
+	q := materialize.ReadConnectionAwsPrivatelinkParams(i)
+
+	var name, schema, database, principal *string
+	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &principal); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(i)
+
+	if err := d.Set("name", name); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("schema_name", schema); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("database_name", database); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("principal", principal); err != nil {
+		return diag.FromErr(err)
+	}
+
+	b := materialize.Connection{ConnectionName: *name, SchemaName: *schema, DatabaseName: *database}
+	if err := d.Set("qualified_sql_name", b.QualifiedName()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
 func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*sqlx.DB)
 

--- a/pkg/resources/resource_connection_ssh_tunnel_test.go
+++ b/pkg/resources/resource_connection_ssh_tunnel_test.go
@@ -48,19 +48,9 @@ func TestResourceSshTunnelCreate(t *testing.T) {
 			AND mz_databases.name = 'database';`).WillReturnRows(ir)
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).
-			AddRow("conn", "schema", "database")
-		mock.ExpectQuery(`
-			SELECT
-				mz_connections.name,
-				mz_schemas.name,
-				mz_databases.name
-			FROM mz_connections
-			JOIN mz_schemas
-				ON mz_connections.schema_id = mz_schemas.id
-			JOIN mz_databases
-				ON mz_schemas.database_id = mz_databases.id
-			WHERE mz_connections.id = 'u1';`).WillReturnRows(ip)
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "pk1", "pk2"}).
+			AddRow("conn", "schema", "database", "pk1", "pk2")
+		mock.ExpectQuery(readConnectionSshTunnellink).WillReturnRows(ip)
 
 		if err := connectionSshTunnelCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
@@ -71,7 +61,7 @@ func TestResourceSshTunnelCreate(t *testing.T) {
 
 func TestResourceSshTunnelUpdate(t *testing.T) {
 	r := require.New(t)
-	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inSshTunnel)
+	d := schema.TestResourceDataRaw(t, ConnectionSshTunnel().Schema, inSshTunnel)
 
 	// Set current state
 	d.SetId("u1")
@@ -82,8 +72,9 @@ func TestResourceSshTunnelUpdate(t *testing.T) {
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "database"."schema"."conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
-		ip := sqlmock.NewRows([]string{"name", "schema", "database"}).AddRow("conn", "schema", "database")
-		mock.ExpectQuery(readConnection).WillReturnRows(ip)
+		ip := sqlmock.NewRows([]string{"name", "schema", "database", "pk1", "pk2"}).
+			AddRow("conn", "schema", "database", "pk1", "pk2")
+		mock.ExpectQuery(readConnectionSshTunnellink).WillReturnRows(ip)
 
 		if err := connectionSshTunnelUpdate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Include the ssh keys as computed properties on the ssh connection resource. Currently keeping the two keys as separate `TypeString` properties. Not sure if it would make more sense to have that exist as a single property `TypeList`. 