### PR TITLE
Materialized views include cluster name

### DIFF
--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -76,12 +76,15 @@ func ReadMaterializedViewParams(id string) string {
 		SELECT
 			mz_materialized_views.name,
 			mz_schemas.name,
-			mz_databases.name
+			mz_databases.name,
+			mz_clusters.name
 		FROM mz_materialized_views
 		JOIN mz_schemas
 			ON mz_materialized_views.schema_id = mz_schemas.id
 		JOIN mz_databases
 			ON mz_schemas.database_id = mz_databases.id
+		LEFT JOIN mz_clusters
+			ON mz_materialized_views.cluster_id = mz_clusters.id
 		WHERE mz_materialized_views.id = %s;`, QuoteString(id))
 }
 

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -51,8 +51,8 @@ func materializedViewRead(ctx context.Context, d *schema.ResourceData, meta inte
 	i := d.Id()
 	q := materialize.ReadMaterializedViewParams(i)
 
-	var name, schema, database *string
-	if err := conn.QueryRowx(q).Scan(&name, &schema, &database); err != nil {
+	var name, schema, database, cluster *string
+	if err := conn.QueryRowx(q).Scan(&name, &schema, &database, &cluster); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -67,6 +67,10 @@ func materializedViewRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("database_name", database); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("cluster_name", cluster); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -87,7 +91,7 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	builder := materialize.NewMaterializedViewBuilder(materializedViewName, schemaName, databaseName)
 
-	if v, ok := d.GetOk("in_cluster"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("cluster_name"); ok && v.(string) != "" {
 		builder.ClusterName(v.(string))
 	}
 

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -20,6 +20,7 @@ var materializedViewSchema = map[string]*schema.Schema{
 		Description: "The cluster to maintain the materialized view. If not specified, defaults to the default cluster.",
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 	},
 	"statement": {
 		Description: "The SQL statement to create the materialized view.",


### PR DESCRIPTION
Include `cluster_name` as a read parameter for the Materialized view query.