### PR TITLE
Resource Owner

### DIFF
--- a/pkg/materialize/constants.go
+++ b/pkg/materialize/constants.go
@@ -14,6 +14,7 @@ type ObjectType struct {
 	CatalogTable string
 }
 
+// https://materialize.com/docs/sql/grant-privilege/#details
 var ObjectPermissions = map[string]ObjectType{
 	"DATABASE": {
 		Permissions:  []string{"U", "C"},

--- a/pkg/materialize/constants.go
+++ b/pkg/materialize/constants.go
@@ -1,0 +1,68 @@
+package materialize
+
+var Permissions = map[string]string{
+	"r": "SELECT",
+	"a": "INSERT",
+	"w": "UPDATE",
+	"d": "DELETE",
+	"C": "CREATE",
+	"U": "USAGE",
+}
+
+type ObjectType struct {
+	Permissions  []string
+	CatalogTable string
+}
+
+var ObjectPermissions = map[string]ObjectType{
+	"DATABASE": {
+		Permissions:  []string{"U", "C"},
+		CatalogTable: "mz_databases",
+	},
+	"SCHEMA": {
+		Permissions:  []string{"U", "C"},
+		CatalogTable: "mz_schemas",
+	},
+	"TABLE": {
+		Permissions:  []string{"a", "r", "w", "d"},
+		CatalogTable: "mz_tables",
+	},
+	"VIEW": {
+		Permissions:  []string{"r"},
+		CatalogTable: "mz_views",
+	},
+	"MATERIALIZED VIEW": {
+		Permissions:  []string{"r"},
+		CatalogTable: "mz_materialized_views",
+	},
+	"INDEX": {
+		Permissions:  []string{},
+		CatalogTable: "mz_indexes",
+	},
+	"TYPE": {
+		Permissions:  []string{"U"},
+		CatalogTable: "mz_types",
+	},
+	"SOURCE": {
+		Permissions:  []string{"r"},
+		CatalogTable: "mz_sources",
+	},
+	"SINK": {
+		Permissions:  []string{},
+		CatalogTable: "mz_sinks",
+	},
+	"CONNECTION": {
+		Permissions:  []string{"U"},
+		CatalogTable: "mz_connections",
+	},
+	"SECRET": {
+		Permissions:  []string{"U"},
+		CatalogTable: "mz_secrets",
+	},
+	"CLUSTER": {
+		Permissions:  []string{"U", "C"},
+		CatalogTable: "mz_clusters",
+	},
+}
+
+var TableMapping = []string{"SOURCE", "VIEW", "MATERIALIZED VIEW"}

--- a/pkg/materialize/identifiers.go
+++ b/pkg/materialize/identifiers.go
@@ -1,5 +1,7 @@
 package materialize
 
+// Any Materialize Object. Will contain name and database and schema
+// If no database or schema is provided will inherit those values
 type IdentifierSchemaStruct struct {
 	Name         string
 	SchemaName   string

--- a/pkg/materialize/object.go
+++ b/pkg/materialize/object.go
@@ -1,0 +1,39 @@
+package materialize
+
+// Any Materialize Object. Will contain name and optionally database and schema
+type ObjectSchemaStruct struct {
+	Name         string
+	SchemaName   string
+	DatabaseName string
+}
+
+func GetObjectSchemaStruct(v interface{}) ObjectSchemaStruct {
+	var conn ObjectSchemaStruct
+	u := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := u["name"]; ok {
+		conn.Name = v.(string)
+	}
+	if v, ok := u["schema_name"]; ok && v.(string) != "" {
+		conn.SchemaName = v.(string)
+	}
+
+	if v, ok := u["database_name"]; ok && v.(string) != "" {
+		conn.DatabaseName = v.(string)
+	}
+	return conn
+}
+
+func (g *ObjectSchemaStruct) QualifiedName() string {
+	fields := []string{}
+
+	if g.DatabaseName != "" {
+		fields = append(fields, g.DatabaseName)
+	}
+
+	if g.SchemaName != "" {
+		fields = append(fields, g.SchemaName)
+	}
+
+	fields = append(fields, g.Name)
+	return QualifiedName(fields...)
+}

--- a/pkg/materialize/ownership.go
+++ b/pkg/materialize/ownership.go
@@ -10,7 +10,7 @@ import (
 type OwnershipBuilder struct {
 	conn       *sqlx.DB
 	objectType string
-	object     IdentifierSchemaStruct
+	object     ObjectSchemaStruct
 	roleName   string
 }
 
@@ -21,7 +21,7 @@ func NewOwnershipBuilder(conn *sqlx.DB, objectType string) *OwnershipBuilder {
 	}
 }
 
-func (b *OwnershipBuilder) Object(o IdentifierSchemaStruct) *OwnershipBuilder {
+func (b *OwnershipBuilder) Object(o ObjectSchemaStruct) *OwnershipBuilder {
 	b.object = o
 	return b
 }

--- a/pkg/materialize/ownership.go
+++ b/pkg/materialize/ownership.go
@@ -1,0 +1,118 @@
+package materialize
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type OwnershipBuilder struct {
+	conn       *sqlx.DB
+	objectType string
+	object     IdentifierSchemaStruct
+	roleName   string
+}
+
+func NewOwnershipBuilder(conn *sqlx.DB, objectType string) *OwnershipBuilder {
+	return &OwnershipBuilder{
+		conn:       conn,
+		objectType: objectType,
+	}
+}
+
+func (b *OwnershipBuilder) Object(o IdentifierSchemaStruct) *OwnershipBuilder {
+	b.object = o
+	return b
+}
+
+func (b *OwnershipBuilder) RoleName(r string) *OwnershipBuilder {
+	b.roleName = r
+	return b
+}
+
+// generate a unique id `ownership|object_type|id` as there is no catalog id
+func OwnershipResourceId(objectType, catalogId string) string {
+	lo := strings.ToLower(objectType)
+	fo := strings.ReplaceAll(lo, " ", "_")
+	return fmt.Sprintf("ownership|%s|%s", fo, catalogId)
+}
+
+func OwnershipCatalogId(resourceId string) string {
+	ci := strings.Split(resourceId, "|")
+	return ci[len(ci)-1]
+}
+
+func (b *OwnershipBuilder) Alter() error {
+	q := fmt.Sprintf(`ALTER %s %s OWNER TO %s;`, b.objectType, b.object.QualifiedName(), b.roleName)
+	_, err := b.conn.Exec(q)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *OwnershipBuilder) ReadId() (string, error) {
+	o := ObjectPermissions[b.objectType]
+
+	q := strings.Builder{}
+	q.WriteString(fmt.Sprintf(`SELECT o.id FROM %s o`, o.CatalogTable))
+
+	if b.object.SchemaName != "" {
+		q.WriteString(` JOIN mz_schemas ON o.schema_id = mz_schemas.id`)
+	}
+
+	if b.object.DatabaseName != "" {
+		q.WriteString(` JOIN mz_databases ON mz_schemas.database_id = mz_databases.id`)
+	}
+
+	// filter predicate
+	q.WriteString(fmt.Sprintf(` WHERE o.name = %s`, QuoteString(b.object.Name)))
+
+	if b.object.DatabaseName != "" {
+		q.WriteString(fmt.Sprintf(`
+		AND mz_databases.name = %s`, QuoteString(b.object.DatabaseName)))
+
+		if b.object.SchemaName != "" {
+			q.WriteString(fmt.Sprintf(` AND mz_schemas.name = %s`, QuoteString(b.object.SchemaName)))
+		}
+	}
+
+	var i string
+	if err := b.conn.QueryRowx(q.String()).Scan(&i); err != nil {
+		return "", err
+	}
+
+	return OwnershipResourceId(b.objectType, i), nil
+}
+
+// return parameters specific to ownership
+type OwnershipParams struct {
+	OwnershipId string
+	RoleName    string
+}
+
+func (b *OwnershipBuilder) Params(catalogId string) (OwnershipParams, error) {
+	o := ObjectPermissions[b.objectType]
+	q := fmt.Sprintf(`
+		SELECT
+			o.owner_id,
+			r.name
+		FROM %s o
+		JOIN mz_roles r
+			ON o.owner_id = r.id
+		WHERE o.id = %s
+	`, o.CatalogTable, QuoteString(catalogId))
+
+	var i, r string
+	if err := b.conn.QueryRowx(q).Scan(&i, &r); err != nil {
+		return OwnershipParams{}, err
+	}
+
+	return OwnershipParams{
+		OwnershipId: i,
+		RoleName:    r,
+	}, nil
+}

--- a/pkg/materialize/ownership_test.go
+++ b/pkg/materialize/ownership_test.go
@@ -36,7 +36,7 @@ func TestOwnershipAlter(t *testing.T) {
 
 		b := NewOwnershipBuilder(db, "TABLE")
 		b.RoleName("my_role")
-		b.Object(IdentifierSchemaStruct{
+		b.Object(ObjectSchemaStruct{
 			DatabaseName: "database",
 			SchemaName:   "schema",
 			Name:         "table",
@@ -67,7 +67,7 @@ func TestOwnershipReadId(t *testing.T) {
 		mock.ExpectQuery(query).WillReturnRows(ir)
 
 		b := NewOwnershipBuilder(db, "TABLE")
-		b.Object(IdentifierSchemaStruct{
+		b.Object(ObjectSchemaStruct{
 			DatabaseName: "database",
 			SchemaName:   "schema",
 			Name:         "table",

--- a/pkg/materialize/ownership_test.go
+++ b/pkg/materialize/ownership_test.go
@@ -1,0 +1,117 @@
+package materialize
+
+import (
+	"testing"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/stretchr/testify/require"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestOwnershipResourceId(t *testing.T) {
+	r := require.New(t)
+
+	table := OwnershipResourceId("TABLE", "u1")
+	r.Equal(`ownership|table|u1`, table)
+
+	mview := OwnershipResourceId("MATERIALIZED VIEW", "u1")
+	r.Equal("ownership|materialized_view|u1", mview)
+}
+
+func TestOwnershipCatalogId(t *testing.T) {
+	r := require.New(t)
+
+	table := OwnershipCatalogId("ownership|table|u1")
+	r.Equal("u1", table)
+
+	mview := OwnershipCatalogId("ownership|materialized_view|u1")
+	r.Equal("u1", mview)
+}
+
+func TestOwnershipAlter(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER TABLE "database"."schema"."table" OWNER TO my_role;`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		b := NewOwnershipBuilder(db, "TABLE")
+		b.RoleName("my_role")
+		b.Object(IdentifierSchemaStruct{
+			DatabaseName: "database",
+			SchemaName:   "schema",
+			Name:         "table",
+		})
+
+		if err := b.Alter(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestOwnershipReadId(t *testing.T) {
+	r := require.New(t)
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		query := `
+			SELECT o.id
+			FROM mz_tables o
+			JOIN mz_schemas
+				ON o.schema_id = mz_schemas.id
+			JOIN mz_databases
+				ON mz_schemas.database_id = mz_databases.id
+			WHERE o.name = 'table'
+			AND mz_databases.name = 'database'
+			AND mz_schemas.name = 'schema'
+		`
+		ir := mock.NewRows([]string{"id"}).AddRow("u1")
+		mock.ExpectQuery(query).WillReturnRows(ir)
+
+		b := NewOwnershipBuilder(db, "TABLE")
+		b.Object(IdentifierSchemaStruct{
+			DatabaseName: "database",
+			SchemaName:   "schema",
+			Name:         "table",
+		})
+
+		id, err := b.ReadId()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r.Equal("ownership|table|u1", id)
+	})
+}
+
+func TestOwnershipParams(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		query := `
+			SELECT
+				o.owner_id,
+				r.name
+			FROM mz_tables o
+			JOIN mz_roles r
+				ON o.owner_id = r.id
+			WHERE o.id = 'u1'
+		`
+		ir := mock.NewRows([]string{"ower_id", "name"}).AddRow("u1", "my_role")
+		mock.ExpectQuery(query).WillReturnRows(ir)
+
+		b := NewOwnershipBuilder(db, "TABLE")
+
+		params, err := b.Params("u1")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedParams := OwnershipParams{
+			OwnershipId: "u1",
+			RoleName:    "my_role",
+		}
+
+		if params != expectedParams {
+			t.Errorf("%s does not match %s", params, expectedParams)
+		}
+	})
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -65,7 +65,9 @@ func Provider() *schema.Provider {
 			"materialize_connection_ssh_tunnel":                resources.ConnectionSshTunnel(),
 			"materialize_database":                             resources.Database(),
 			"materialize_index":                                resources.Index(),
-			"materialize_materialized_view":                    resources.MaterializedView(),
+			// TODO Expose RBAC resources when ready
+			// "materialize_ownership":                            resources.Ownership(),
+			"materialize_materialized_view": resources.MaterializedView(),
 			// "materialize_role":                                 resources.Role(),
 			"materialize_schema":                resources.Schema(),
 			"materialize_secret":                resources.Secret(),

--- a/pkg/resources/resource_ownership.go
+++ b/pkg/resources/resource_ownership.go
@@ -1,0 +1,132 @@
+package resources
+
+import (
+	"context"
+	"log"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmoiron/sqlx"
+)
+
+var allowedOwners = []string{
+	"CLUSTER",
+	"CLUSTER_REPLICA",
+	"CONNECTION",
+	"DATABASE",
+	"SCHEMA",
+	"SOURCE",
+	"SINK",
+	"VIEW",
+	"MATERIALIZED VIEW",
+	"TABLE",
+	"TYPE",
+	"SECRET",
+}
+
+var ownershipSchema = map[string]*schema.Schema{
+	"object":                    IdentifierSchema("object", "The identifier of the item you want to set ownership.", true),
+	"object_qualified_sql_name": QualifiedNameSchema("object"),
+	"object_type": {
+		Description:  "The type of object.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice(allowedOwners, true),
+	},
+	"role_name": {
+		Description: "The role to assoicate as the owner of the object.",
+		Type:        schema.TypeString,
+		Required:    true,
+	},
+}
+
+func Ownership() *schema.Resource {
+	return &schema.Resource{
+		Description: "The owner of an item in Materialize.",
+
+		CreateContext: ownershipCreate,
+		ReadContext:   ownershipRead,
+		UpdateContext: ownershipUpdate,
+		DeleteContext: ownershipDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: ownershipSchema,
+	}
+}
+
+func ownershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	objectType := d.Get("object_type").(string)
+	id := d.Id()
+
+	builder := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), objectType)
+
+	catalogId := materialize.OwnershipCatalogId(id)
+	params, err := builder.Params(catalogId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("role_name", params.RoleName); err != nil {
+		return diag.FromErr(err)
+	}
+
+	qn := d.Get("object").(materialize.IdentifierSchemaStruct)
+	if err := d.Set("qualified_sql_name", qn.QualifiedName()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func ownershipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	objectType := d.Get("object_type").(string)
+
+	builder := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), objectType)
+
+	if v, ok := d.GetOk("role_name"); ok {
+		builder.RoleName(v.(string))
+	}
+
+	if v, ok := d.GetOk("object"); ok {
+		builder.Object(v.(materialize.IdentifierSchemaStruct))
+	}
+
+	if err := builder.Alter(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return ownershipRead(ctx, d, meta)
+}
+
+func ownershipUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	object := d.Get("object").(materialize.IdentifierSchemaStruct)
+	objectType := d.Get("object_type").(string)
+	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), objectType)
+
+	b.Object(object)
+
+	if d.HasChange("role_name") {
+		_, newRole := d.GetChange("role_name")
+
+		b.RoleName(newRole.(string))
+
+		if err := b.Alter(); err != nil {
+			log.Printf("[ERROR] updating ownership of %v", d.Id())
+			return diag.FromErr(err)
+		}
+	}
+
+	return ownershipRead(ctx, d, meta)
+}
+
+func ownershipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// ownership cannot be removed, rather remove the resource from state
+	d.SetId("")
+	return nil
+}

--- a/pkg/resources/resource_ownership_test.go
+++ b/pkg/resources/resource_ownership_test.go
@@ -1,0 +1,113 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+var inOwnership = map[string]interface{}{
+	"object":      []interface{}{map[string]interface{}{"name": "item", "schema_name": "public", "database_name": "database"}},
+	"object_type": "TABLE",
+	"role_name":   "my_role",
+}
+
+// func TestResourceOwnershipCreate(t *testing.T) {
+// 	r := require.New(t)
+// 	d := schema.TestResourceDataRaw(t, Ownership().Schema, inOwnership)
+// 	r.NotNil(d)
+
+// 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+// 		// Create
+// 		mock.ExpectExec(
+// 			`ALTER TABLE "database"."schema"."table" OWNER TO my_role;`,
+// 		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+// 		// Query Id
+// 		ir := mock.NewRows([]string{"id"}).
+// 			AddRow("u1")
+// 		mock.ExpectQuery(`
+// 			SELECT o.id
+// 			FROM mz_tables o
+// 			JOIN mz_schemas
+// 				ON o.schema_id = mz_schemas.id
+// 			JOIN mz_databases
+// 				ON mz_schemas.database_id = mz_databases.id
+// 			WHERE o.name = 'table'
+// 			AND mz_databases.name = 'database'
+// 			AND mz_schemas.name = 'schema'
+// 		`).WillReturnRows(ir)
+
+// 		// Query Params
+// 		ip := sqlmock.NewRows([]string{"owner_id", "name"}).AddRow("u1", "my_role")
+// 		mock.ExpectQuery(`
+// 			SELECT
+// 				o.owner_id,
+// 				r.name
+// 			FROM mz_tables o
+// 			JOIN mz_roles r
+// 				ON o.owner_id = r.id
+// 			WHERE o.id = 'u1'
+// 		`).WillReturnRows(ip)
+
+// 		if err := ownershipCreate(context.TODO(), d, db); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 	})
+// }
+
+// func TestResourceOwnershipUpdate(t *testing.T) {
+// 	r := require.New(t)
+// 	d := schema.TestResourceDataRaw(t, Ownership().Schema, inOwnership)
+
+// 	// Set current state
+// 	d.SetId("ownership|table|u1")
+// 	d.Set("role_name", "my_old_role")
+// 	d.Set("object", []interface{}{map[string]interface{}{"name": "item", "schema_name": "public", "database_name": "database"}})
+// 	r.NotNil(d)
+
+// 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+// 		mock.ExpectExec(
+// 			`ALTER TABLE "database"."schema"."table" OWNER TO my_role;`,
+// 		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+// 		// Query Params
+// 		ip := sqlmock.NewRows([]string{"owner_id", "name"}).AddRow("u1", "my_role")
+// 		mock.ExpectQuery(`
+// 			SELECT
+// 				o.owner_id,
+// 				r.name
+// 			FROM mz_tables o
+// 			JOIN mz_roles r
+// 				ON o.owner_id = r.id
+// 			WHERE o.id = 'u1'
+// 		`).WillReturnRows(ip)
+
+// 		if err := ownershipCreate(context.TODO(), d, db); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 	})
+// }
+
+func TestResourceOwnershipDelete(t *testing.T) {
+	r := require.New(t)
+
+	d := schema.TestResourceDataRaw(t, Ownership().Schema, inOwnership)
+	r.NotNil(d)
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		if err := ownershipDelete(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if d.Id() != "" {
+		t.Errorf("State id not set to empty string")
+	}
+}


### PR DESCRIPTION
Adding resource for [ownership](https://materialize.com/docs/sql/alter-owner/). Ownership behaves a little different than the other resources (a lot of this will also apply to [grants](https://github.com/MaterializeInc/terraform-provider-materialize/issues/135)) so also doing some refactoring that might be good to apply to the other resources at some point in the future.

* Have the object builders execute the SQL rather than just returning strings. This will lead somewhat into the next point but this helped clean things up and prevent too much logic from leaking into Terraform layer and the `resources` package.
* This resource will require generating a custom id (will also apply to grants).
* This is only specific to `ownership` but the `DeleteContext` only removes the id from state, since there is no concept of dropping ownership.