### PR TITLE
Update Indexes Query

### DIFF
--- a/pkg/datasources/datasource_index_test.go
+++ b/pkg/datasources/datasource_index_test.go
@@ -26,54 +26,22 @@ func TestIndexDatasource(t *testing.T) {
 		ir := mock.NewRows([]string{"id", "name", "obj", "schema", "database"}).
 			AddRow("u1", "index", "obj", "schema", "database")
 		mock.ExpectQuery(`
-			SELECT DISTINCT
+			SELECT
 				mz_indexes.id,
 				mz_indexes.name,
-				COALESCE\(sources.o_name, views.o_name, mviews.o_name\),
-				COALESCE\(sources.s_name, views.s_name, mviews.s_name\),
-				COALESCE\(sources.d_name, views.d_name, mviews.d_name\)
+				mz_objects.name,
+				mz_schemas.name,
+				mz_databases.name
 			FROM mz_indexes
-			LEFT JOIN \(
-				SELECT
-					mz_sources.id,
-					mz_sources.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_sources
-				JOIN mz_schemas
-					ON mz_sources.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) sources
-				ON mz_indexes.on_id = sources.id
-			LEFT JOIN \(
-				SELECT
-					mz_views.id,
-					mz_views.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_views
-				JOIN mz_schemas
-					ON mz_views.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) views
-				ON mz_indexes.on_id = sources.id
-			LEFT JOIN \(
-				SELECT
-					mz_materialized_views.id,
-					mz_materialized_views.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_materialized_views
-				JOIN mz_schemas
-					ON mz_materialized_views.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) mviews
-				ON mz_indexes.on_id = sources.id
-			WHERE COALESCE\(sources.o_name, views.o_name, mviews.o_name\) IS NOT NULL
-			AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'`).WillReturnRows(ir)
+			JOIN mz_objects
+				ON mz_indexes.on_id = mz_objects.id
+			LEFT JOIN mz_schemas
+				ON mz_objects.schema_id = mz_schemas.id
+			LEFT JOIN mz_databases
+				ON mz_schemas.database_id = mz_databases.id
+			WHERE mz_objects.type IN \('source', 'view', 'materialized-view'\)
+			AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'
+		`).WillReturnRows(ir)
 
 		if err := indexRead(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_index_test.go
+++ b/pkg/resources/resource_index_test.go
@@ -39,52 +39,21 @@ func TestResourceIndexCreate(t *testing.T) {
 		ip := sqlmock.NewRows([]string{"name", "obj_name", "obj_schema", "obj_database"}).
 			AddRow("index", "obj", "schema", "database")
 		mock.ExpectQuery(`
-			SELECT DISTINCT
+			SELECT
 				mz_indexes.name,
-				COALESCE\(sources.o_name, views.o_name, mviews.o_name\),
-				COALESCE\(sources.s_name, views.s_name, mviews.s_name\),
-				COALESCE\(sources.d_name, views.d_name, mviews.d_name\)
+				mz_objects.name,
+				mz_schemas.name,
+				mz_databases.name
 			FROM mz_indexes
-			LEFT JOIN \(
-				SELECT
-					mz_sources.id,
-					mz_sources.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_sources
-				JOIN mz_schemas
-					ON mz_sources.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) sources
-				ON mz_indexes.on_id = sources.id
-			LEFT JOIN \(
-				SELECT
-					mz_views.id,
-					mz_views.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_views
-				JOIN mz_schemas
-					ON mz_views.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) views
-				ON mz_indexes.on_id = sources.id
-			LEFT JOIN \(
-				SELECT
-					mz_materialized_views.id,
-					mz_materialized_views.name AS o_name,
-					mz_schemas.name AS s_name,
-					mz_databases.name AS d_name
-				FROM mz_materialized_views
-				JOIN mz_schemas
-					ON mz_materialized_views.schema_id = mz_schemas.id
-				JOIN mz_databases
-					ON mz_schemas.database_id = mz_databases.id
-			\) mviews
-				ON mz_indexes.on_id = sources.id
-			WHERE mz_indexes.id = 'u1';`).WillReturnRows(ip)
+			JOIN mz_objects
+				ON mz_indexes.on_id = mz_objects.id
+			LEFT JOIN mz_schemas
+				ON mz_objects.schema_id = mz_schemas.id
+			LEFT JOIN mz_databases
+				ON mz_schemas.database_id = mz_databases.id
+			WHERE mz_objects.type IN \('source', 'view', 'materialized-view'\)
+			AND mz_indexes.id = 'u1';
+		`).WillReturnRows(ip)
 
 		if err := indexCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Simplify the indexes queries to use `mz_objects` rather than rely on an overly complicated multi-join query.