### PR TITLE
Fix Replica AZ Persist

### DIFF
--- a/integration/cluster_replica.tf
+++ b/integration/cluster_replica.tf
@@ -8,8 +8,7 @@ resource "materialize_cluster_replica" "cluster_replica_2" {
   name         = "r2"
   cluster_name = materialize_cluster.cluster.name
   size         = "4"
-  # TODO: Find availability zone that works with Docker
-  # availability_zone             = "us-east-1"
+  # availability_zone             = "use1-az1"
   introspection_interval        = "2s"
   introspection_debugging       = true
   idle_arrangement_merge_effort = 1

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -26,11 +26,6 @@ var localSizes = []string{
 	"32-32",
 }
 
-var regions = []string{
-	"us-east-1",
-	"eu-west-1",
-}
-
 // https://materialize.com/docs/sql/create-cluster-replica/#sizes
 var replicaSizes = []string{
 	"3xsmall",

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -21,11 +20,10 @@ var clusterReplicaSchema = map[string]*schema.Schema{
 	},
 	"size": SizeSchema("replica"),
 	"availability_zone": {
-		Description:  "If you want the replica to reside in a specific availability zone.",
-		Type:         schema.TypeString,
-		Optional:     true,
-		ForceNew:     true,
-		ValidateFunc: validation.StringInSlice(regions, true),
+		Description: "If you want the replica to reside in a specific availability zone.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    true,
 	},
 	"introspection_interval": {
 		Description: "The interval at which to collect introspection data.",

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -46,7 +46,7 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 
 		// Query Params
 		ip := sqlmock.NewRows([]string{"name", "cluster", "size", "availability_zone"}).
-			AddRow("replica", "cluster", "small", "us-east-1")
+			AddRow("replica", "cluster", "medium", "use1-az1")
 		mock.ExpectQuery(`
 			SELECT
 				mz_cluster_replicas.name,
@@ -61,6 +61,7 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 		if err := clusterReplicaCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}
+
 	})
 
 }


### PR DESCRIPTION
Correct availability zone persist for cluster replicas by removing validation.

Unfortunately we can't include availability zone on cluster replicas using the image so this can't be included in the integration tests. Ran a quick tests using cloud.

```
resource "materialize_cluster_replica" "cluster_replica_1" {
  name               = "r1"
  cluster_name       = materialize_cluster.cluster.name
  size               = "3xsmall"
  availability_zone = "use1-az4"
}
```

Apply successfully creates the replica with the proper 
```
SELECT * FROM mz_cluster_replicas WHERE cluster_id = 'u199';
  id  | name | cluster_id |  size   | availability_zone | owner_id
------+------+------------+---------+-------------------+----------
 u212 | r1   | u199       | 3xsmall | use1-az4          | u3
(1 row)
```

Then running a `plan` shows no changes
```
No changes. Your infrastructure matches the configuration.
```
Rerunning an `apply` also shows no changes
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
Destroy was successful


