### PR TITLE
Fix AZ Computed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
   materialized:
     image: materialize/materialized:latest
     container_name: materialized
+    command:
+      - --availability-zone=test1
+      - --availability-zone=test2
     ports:
       - 6875:6875
       - 6878:6878

--- a/integration/cluster_replica.tf
+++ b/integration/cluster_replica.tf
@@ -5,10 +5,10 @@ resource "materialize_cluster_replica" "cluster_replica_1" {
 }
 
 resource "materialize_cluster_replica" "cluster_replica_2" {
-  name         = "r2"
-  cluster_name = materialize_cluster.cluster.name
-  size         = "4"
-  # availability_zone             = "use1-az1"
+  name                          = "r2"
+  cluster_name                  = materialize_cluster.cluster.name
+  size                          = "4"
+  availability_zone             = "test2"
   introspection_interval        = "2s"
   introspection_debugging       = true
   idle_arrangement_merge_effort = 1

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -24,6 +24,7 @@ var clusterReplicaSchema = map[string]*schema.Schema{
 		Description: "If you want the replica to reside in a specific availability zone.",
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		ForceNew:    true,
 	},
 	"introspection_interval": {

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -34,8 +34,8 @@ var tableSchema = map[string]*schema.Schema{
 				},
 				"nullable": {
 					Description: "	Do not allow the column to contain NULL values. Columns without this constraint can contain NULL values.",
-					Type:     schema.TypeBool,
-					Optional: true,
+					Type:        schema.TypeBool,
+					Optional:    true,
 				},
 			},
 		},

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -72,7 +72,7 @@ func viewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 
-  b := materialize.NewViewBuilder(s.ViewName.String, s.SchemaName.String, s.DatabaseName.String)
+	b := materialize.NewViewBuilder(s.ViewName.String, s.SchemaName.String, s.DatabaseName.String)
 	if err := d.Set("qualified_sql_name", b.QualifiedName()); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Make `availability_zone` computed for cluster replicas. The issue is if availability zones are not set in Terraform for replicas, one will be assigned at creation which will lead to a diff in state. Was not an issue with the local image since no availability zone is set.

Also turning on availability zones for the Materialize image so this will be caught in future integration tests.