### PR TITLE
Fix Kafka Conn Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ resource "materialize_connection_kafka" "kafka_connection" {
   kafka_broker {
     broker = "b-1.hostname-1:9096"
   }
-  sasl_username = "example"
+  sasl_username = {
+    text = "user"
+  }
   sasl_password {
     name          = "kafka_password"
     database_name = "materialize"


### PR DESCRIPTION
Just noticed that we had the same example in the README.md as with https://github.com/MaterializeInc/terraform-provider-materialize/pull/162