### PR TITLE
Fix Materialize Tests

### DIFF
--- a/pkg/materialize/cluster_replica_test.go
+++ b/pkg/materialize/cluster_replica_test.go
@@ -21,7 +21,9 @@ func TestClusterReplicaCreate(t *testing.T) {
 		b.IntrospectionDebugging()
 		b.IdleArrangementMergeEffort(1)
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -29,6 +31,8 @@ func TestClusterReplicaDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP CLUSTER REPLICA "cluster"."replica";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		NewClusterReplicaBuilder(db, "replica", "cluster").Drop()
+		if err := NewClusterReplicaBuilder(db, "replica", "cluster").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -10,16 +10,20 @@ import (
 
 func TestClusterCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE CLUSTER "cluster" REPLICAS ();`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE CLUSTER "cluster" REPLICAS \(\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		NewClusterBuilder(db, "cluster").Create()
+		if err := NewClusterBuilder(db, "cluster").Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
-func TestClusteDrop(t *testing.T) {
+func TestClusterDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP CLUSTER "cluster";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		NewClusterBuilder(db, "cluster").Drop()
+		if err := NewClusterBuilder(db, "cluster").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/connection_aws_privatelink_test.go
+++ b/pkg/materialize/connection_aws_privatelink_test.go
@@ -11,13 +11,15 @@ import (
 func TestConnectionAwsPrivatelinkCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."privatelink_conn" TO AWS PRIVATELINK (SERVICE NAME 'com.amazonaws.us-east-1.materialize.example',AVAILABILITY ZONES ('use1-az1', 'use1-az2'));`,
+			`CREATE CONNECTION "database"."schema"."privatelink_conn" TO AWS PRIVATELINK \(SERVICE NAME 'com.amazonaws.us-east-1.materialize.example',AVAILABILITY ZONES \('use1-az1', 'use1-az2'\)\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionAwsPrivatelinkBuilder(db, "privatelink_conn", "schema", "database")
 		b.PrivateLinkServiceName("com.amazonaws.us-east-1.materialize.example")
 		b.PrivateLinkAvailabilityZones([]string{"use1-az1", "use1-az2"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/connection_confluent_schema_registry_test.go
+++ b/pkg/materialize/connection_confluent_schema_registry_test.go
@@ -11,7 +11,7 @@ import (
 func TestConnectionConfluentSchemaRegistryCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL 'http://localhost:8081', USERNAME = 'user', PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."csr_conn" TO CONFLUENT SCHEMA REGISTRY \(URL 'http://localhost:8081', USERNAME = 'user', PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionConfluentSchemaRegistryBuilder(db, "csr_conn", "schema", "database")
@@ -26,7 +26,7 @@ func TestConnectionConfluentSchemaRegistryCreate(t *testing.T) {
 func TestConnectionConfluentSchemaRegistryUsernameSecretCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL 'http://localhost:8081', USERNAME = SECRET "database"."schema"."user", PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."csr_conn" TO CONFLUENT SCHEMA REGISTRY \(URL 'http://localhost:8081', USERNAME = SECRET "database"."schema"."user", PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionConfluentSchemaRegistryBuilder(db, "csr_conn", "schema", "database")
@@ -34,6 +34,8 @@ func TestConnectionConfluentSchemaRegistryUsernameSecretCreate(t *testing.T) {
 		b.ConfluentSchemaRegistryUsername(ValueSecretStruct{Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "user", DatabaseName: "database"}})
 		b.ConfluentSchemaRegistryPassword(IdentifierSchemaStruct{SchemaName: "schema", Name: "password", DatabaseName: "database"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/connection_kafka_test.go
+++ b/pkg/materialize/connection_kafka_test.go
@@ -11,7 +11,7 @@ import (
 func TestConnectionKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092'), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -25,14 +25,16 @@ func TestConnectionKafkaCreate(t *testing.T) {
 		b.KafkaSASLUsername(ValueSecretStruct{Text: "user"})
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaMultipleBrokersCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092', 'localhost:9093'), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092', 'localhost:9093'\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -49,14 +51,16 @@ func TestConnectionKafkaMultipleBrokersCreate(t *testing.T) {
 		b.KafkaSASLUsername(ValueSecretStruct{Text: "user"})
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaSshCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092' USING SSH TUNNEL "database"."schema"."ssh_conn"), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092' USING SSH TUNNEL "database"."schema"."ssh_conn"\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -71,14 +75,16 @@ func TestConnectionKafkaSshCreate(t *testing.T) {
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
 		b.KafkaSSHTunnel(IdentifierSchemaStruct{Name: "ssh_conn", DatabaseName: "database", SchemaName: "schema"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaBrokersCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092', 'localhost:9093'), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092', 'localhost:9093'\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -95,14 +101,16 @@ func TestConnectionKafkaBrokersCreate(t *testing.T) {
 		b.KafkaSASLUsername(ValueSecretStruct{Text: "user"})
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaBrokersSshCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092' USING SSH TUNNEL "database"."schema"."ssh_conn",'localhost:9093' USING SSH TUNNEL "database"."schema"."ssh_conn"), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092' USING SSH TUNNEL "database"."schema"."ssh_conn",'localhost:9093' USING SSH TUNNEL "database"."schema"."ssh_conn"\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -120,14 +128,16 @@ func TestConnectionKafkaBrokersSshCreate(t *testing.T) {
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
 		b.KafkaSSHTunnel(IdentifierSchemaStruct{Name: "ssh_conn", DatabaseName: "database", SchemaName: "schema"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaSslCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('localhost:9092'), PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = SECRET "database"."schema"."ca", SSL CERTIFICATE = SECRET "database"."schema"."cert", SSL KEY = SECRET "database"."schema"."key");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = SECRET "database"."schema"."ca", SSL CERTIFICATE = SECRET "database"."schema"."cert", SSL KEY = SECRET "database"."schema"."key"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -141,14 +151,16 @@ func TestConnectionKafkaSslCreate(t *testing.T) {
 		b.KafkaSSLCert(ValueSecretStruct{Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "cert", DatabaseName: "database"}})
 		b.KafkaSSLCa(ValueSecretStruct{Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "ca", DatabaseName: "database"}})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionKafkaAwsPrivatelinkCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA (BROKERS ('b-1.hostname-1:9096' USING AWS PRIVATELINK "database"."schema"."privatelink_conn" (PORT 9001, AVAILABILITY ZONE 'use1-az1'), 'b-1.hostname-1:9097' USING AWS PRIVATELINK "database"."schema"."privatelink_conn" (PORT 9002, AVAILABILITY ZONE 'use1-az2')), SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password");`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('b-1.hostname-1:9096' USING AWS PRIVATELINK "database"."schema"."privatelink_conn" \(PORT 9001, AVAILABILITY ZONE 'use1-az1'\), 'b-1.hostname-1:9097' USING AWS PRIVATELINK "database"."schema"."privatelink_conn" \(PORT 9002, AVAILABILITY ZONE 'use1-az2'\)\), SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, "kafka_conn", "schema", "database")
@@ -170,7 +182,9 @@ func TestConnectionKafkaAwsPrivatelinkCreate(t *testing.T) {
 		b.KafkaSASLUsername(ValueSecretStruct{Text: "user"})
 		b.KafkaSASLPassword(IdentifierSchemaStruct{SchemaName: "schema", Name: "password", DatabaseName: "database"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 }

--- a/pkg/materialize/connection_postgres_test.go
+++ b/pkg/materialize/connection_postgres_test.go
@@ -11,7 +11,7 @@ import (
 func TestConnectionPostgresCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES (HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", DATABASE 'default');`,
+			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES \(HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", DATABASE 'default'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionPostgresBuilder(db, "postgres_conn", "schema", "database")
@@ -21,14 +21,16 @@ func TestConnectionPostgresCreate(t *testing.T) {
 		b.PostgresPassword(IdentifierSchemaStruct{Name: "password", SchemaName: "schema", DatabaseName: "database"})
 		b.PostgresDatabase("default")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionPostgresSshCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES (HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", SSH TUNNEL "database"."schema"."ssh_conn", DATABASE 'default');`,
+			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES \(HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", SSH TUNNEL "database"."schema"."ssh_conn", DATABASE 'default'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionPostgresBuilder(db, "postgres_conn", "schema", "database")
@@ -39,14 +41,16 @@ func TestConnectionPostgresSshCreate(t *testing.T) {
 		b.PostgresDatabase("default")
 		b.PostgresSSHTunnel(IdentifierSchemaStruct{Name: "ssh_conn", SchemaName: "schema", DatabaseName: "database"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionPostgresPrivateLinkCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES (HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", AWS PRIVATELINK "database"."schema"."private_link", DATABASE 'default');`,
+			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES \(HOST 'postgres_host', PORT 5432, USER 'user', PASSWORD SECRET "database"."schema"."password", AWS PRIVATELINK "database"."schema"."private_link", DATABASE 'default'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionPostgresBuilder(db, "postgres_conn", "schema", "database")
@@ -57,14 +61,16 @@ func TestConnectionPostgresPrivateLinkCreate(t *testing.T) {
 		b.PostgresDatabase("default")
 		b.PostgresAWSPrivateLink(IdentifierSchemaStruct{Name: "private_link", SchemaName: "schema", DatabaseName: "database"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestConnectionPostgresSslCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES (HOST 'postgres_host', PORT 5432, USER SECRET "database"."schema"."user", PASSWORD SECRET "database"."schema"."password", SSL MODE 'verify-full', SSL CERTIFICATE AUTHORITY SECRET "database"."schema"."root", SSL CERTIFICATE SECRET "database"."schema"."cert", SSL KEY SECRET "database"."schema"."key", DATABASE 'default');`,
+			`CREATE CONNECTION "database"."schema"."postgres_conn" TO POSTGRES \(HOST 'postgres_host', PORT 5432, USER SECRET "database"."schema"."user", PASSWORD SECRET "database"."schema"."password", SSL MODE 'verify-full', SSL CERTIFICATE AUTHORITY SECRET "database"."schema"."root", SSL CERTIFICATE SECRET "database"."schema"."cert", SSL KEY SECRET "database"."schema"."key", DATABASE 'default'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionPostgresBuilder(db, "postgres_conn", "schema", "database")
@@ -78,6 +84,8 @@ func TestConnectionPostgresSslCreate(t *testing.T) {
 		b.PostgresSSLCert(ValueSecretStruct{Secret: IdentifierSchemaStruct{Name: "cert", SchemaName: "schema", DatabaseName: "database"}})
 		b.PostgresSSLKey(IdentifierSchemaStruct{Name: "key", SchemaName: "schema", DatabaseName: "database"})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/connection_ssh_tunnel_test.go
+++ b/pkg/materialize/connection_ssh_tunnel_test.go
@@ -11,7 +11,7 @@ import (
 func TestConnectionSshTunnelCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."ssh_conn" TO SSH TUNNEL (HOST 'localhost', USER 'user', PORT 123);`,
+			`CREATE CONNECTION "database"."schema"."ssh_conn" TO SSH TUNNEL \(HOST 'localhost', USER 'user', PORT 123\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionSshTunnelBuilder(db, "ssh_conn", "schema", "database")
@@ -19,6 +19,8 @@ func TestConnectionSshTunnelCreate(t *testing.T) {
 		b.SSHPort(123)
 		b.SSHUser("user")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/database_test.go
+++ b/pkg/materialize/database_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestDatabaseCreateQuery(t *testing.T) {
+func TestDatabaseCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE DATABASE "database";`).WillReturnResult(sqlmock.NewResult(1, 1))
-		b := NewDatabaseBuilder(db, "database")
 
-		b.Create()
+		if err := NewDatabaseBuilder(db, "database").Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/index_test.go
+++ b/pkg/materialize/index_test.go
@@ -11,7 +11,7 @@ import (
 func TestIndexCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE INDEX index IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT (Column LONG);`,
+			`CREATE INDEX index IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT \(Column LONG\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewIndexBuilder(db, "index", false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
@@ -24,21 +24,35 @@ func TestIndexCreate(t *testing.T) {
 			},
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestIndexDefaultCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT ();`,
+			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT \(\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewIndexBuilder(db, "", true, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
 		b.ClusterName("cluster")
 		b.Method("ARRANGEMENT")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
+}
 
+func TestIndexDrop(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`DROP INDEX "database"."schema"."index" RESTRICT;`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		b := NewIndexBuilder(db, "index", false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
+		if err := b.Drop(); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/pkg/materialize/materialized_view_test.go
+++ b/pkg/materialize/materialized_view_test.go
@@ -17,6 +17,18 @@ func TestMaterializedViewCreate(t *testing.T) {
 		b := NewMaterializedViewBuilder(db, "materialized_view", "schema", "database")
 		b.SelectStmt("SELECT 1 FROM t1")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestMaterializedViewDrop(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`DROP MATERIALIZED VIEW "database"."schema"."materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		if err := NewMaterializedViewBuilder(db, "materialized_view", "schema", "database").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/role_test.go
+++ b/pkg/materialize/role_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestRoleCreateQuery(t *testing.T) {
+func TestRoleCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`CREATE ROLE "role" INHERIT CREATEROLE CREATEDB CREATECLUSTER;`,
@@ -19,6 +19,32 @@ func TestRoleCreateQuery(t *testing.T) {
 		b.CreateDb()
 		b.CreateCluster()
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRoleAlter(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`ALTER ROLE "role" CREATECLUSTER;`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		if err := NewRoleBuilder(db, "role").Alter("CREATECLUSTER"); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRoleDrop(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`DROP ROLE "role";`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		if err := NewRoleBuilder(db, "role").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/schema_test.go
+++ b/pkg/materialize/schema_test.go
@@ -13,9 +13,10 @@ func TestSchemaCreate(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE SCHEMA "database"."schema";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
-		b := NewSchemaBuilder(db, "schema", "database")
 
-		b.Create()
+		if err := NewSchemaBuilder(db, "schema", "database").Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -24,9 +25,9 @@ func TestSchemaDrop(t *testing.T) {
 		mock.ExpectExec(
 			`DROP SCHEMA "database"."schema";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
-		b := NewSchemaBuilder(db, "schema", "database")
 
-		b.Create()
-
+		if err := NewSchemaBuilder(db, "schema", "database").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/secret_test.go
+++ b/pkg/materialize/secret_test.go
@@ -16,7 +16,9 @@ func TestSecretCreate(t *testing.T) {
 		b := NewSecretBuilder(db, "secret", "schema", "database")
 		b.Value(`c2VjcmV0Cg`)
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -29,7 +31,9 @@ func TestSecretCreateEscapedValue(t *testing.T) {
 		b := NewSecretBuilder(db, "secret", "schema", "database")
 		b.Value(`c2Vjcm'V0Cg`)
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -41,7 +45,9 @@ func TestSecretRename(t *testing.T) {
 
 		b := NewSecretBuilder(db, "secret", "schema", "database")
 
-		b.Rename("new_secret")
+		if err := b.Rename("new_secret"); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -53,7 +59,9 @@ func TestSecretUpdateValue(t *testing.T) {
 
 		b := NewSecretBuilder(db, "secret", "schema", "database")
 
-		b.UpdateValue(`c2VjcmV0Cgdd`)
+		if err := b.UpdateValue(`c2VjcmV0Cgdd`); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -65,7 +73,9 @@ func TestSecretUpdateEscapedValue(t *testing.T) {
 
 		b := NewSecretBuilder(db, "secret", "schema", "database")
 
-		b.UpdateValue(`c2Vjcm'V0Cgdd`)
+		if err := b.UpdateValue(`c2Vjcm'V0Cgdd`); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
@@ -75,8 +85,8 @@ func TestSecretDrop(t *testing.T) {
 			`DROP SECRET "database"."schema"."secret";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewSecretBuilder(db, "secret", "schema", "database")
-
-		b.Drop()
+		if err := NewSecretBuilder(db, "secret", "schema", "database").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -11,7 +11,7 @@ import (
 func TestSinkKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SINK "database"."schema"."sink" FROM "database"."schema"."table" INTO KAFKA CONNECTION "database"."schema"."kafka_connection" KEY (key_1, key_2) (TOPIC 'test_avro_topic') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."public"."csr_connection" ENVELOPE UPSERT WITH ( SIZE = 'xsmall' SNAPSHOT = false);`,
+			`CREATE SINK "database"."schema"."sink" FROM "database"."schema"."table" INTO KAFKA CONNECTION "database"."schema"."kafka_connection" KEY \(key_1, key_2\) \(TOPIC 'test_avro_topic'\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."public"."csr_connection" ENVELOPE UPSERT WITH \( SIZE = 'xsmall' SNAPSHOT = false\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSinkKafkaBuilder(db, "sink", "schema", "database")
@@ -24,6 +24,8 @@ func TestSinkKafkaCreate(t *testing.T) {
 		b.Envelope(KafkaSinkEnvelopeStruct{Upsert: true})
 		b.Snapshot(false)
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/source_kafka_test.go
+++ b/pkg/materialize/source_kafka_test.go
@@ -11,7 +11,7 @@ import (
 func TestResourceSourceKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM KAFKA CONNECTION "database"."schema"."kafka_connection" (TOPIC 'events') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_connection" INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP ENVELOPE UPSERT WITH (SIZE = 'xsmall');`,
+			`CREATE SOURCE "database"."schema"."source" FROM KAFKA CONNECTION "database"."schema"."kafka_connection" \(TOPIC 'events'\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_connection" INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP ENVELOPE UPSERT WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceKafkaBuilder(db, "source", "schema", "database")
@@ -26,7 +26,8 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 		b.IncludeTimestamp()
 		b.Envelope(KafkaSourceEnvelopeStruct{Upsert: true})
 
-		b.Create()
-
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/source_load_generator_test.go
+++ b/pkg/materialize/source_load_generator_test.go
@@ -11,7 +11,7 @@ import (
 func TestSourceLoadgenCounterCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s', MAX CARDINALITY 8) WITH (SIZE = 'xsmall');`,
+			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR COUNTER \(TICK INTERVAL '1s', MAX CARDINALITY 8\) WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceLoadgenBuilder(db, "source", "schema", "database")
@@ -22,14 +22,16 @@ func TestSourceLoadgenCounterCreate(t *testing.T) {
 			MaxCardinality: 8,
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestSourceLoadgenAuctionCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR AUCTION (TICK INTERVAL '1s', SCALE FACTOR 0.01) FOR ALL TABLES WITH (SIZE = 'xsmall');`,
+			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR AUCTION \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) FOR ALL TABLES WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceLoadgenBuilder(db, "source", "schema", "database")
@@ -40,14 +42,16 @@ func TestSourceLoadgenAuctionCreate(t *testing.T) {
 			ScaleFactor:  0.01,
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestSourceLoadgenTPCHParamsCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR TPCH (TICK INTERVAL '1s', SCALE FACTOR 0.01) FOR TABLES (schema1.table_1 AS s1_table_1, schema2.table_1 AS s2_table_1) WITH (SIZE = 'xsmall');`,
+			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR TPCH \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) FOR TABLES \(schema1.table_1 AS s1_table_1, schema2.table_1 AS s2_table_1\) WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceLoadgenBuilder(db, "source", "schema", "database")
@@ -68,6 +72,8 @@ func TestSourceLoadgenTPCHParamsCreate(t *testing.T) {
 			},
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -11,7 +11,7 @@ import (
 func TestSourcePostgresAllTablesCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" (PUBLICATION 'mz_source') FOR ALL TABLES;`,
+			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" \(PUBLICATION 'mz_source'\) FOR ALL TABLES;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourcePostgresBuilder(db, "source", "schema", "database")
@@ -19,14 +19,16 @@ func TestSourcePostgresAllTablesCreate(t *testing.T) {
 		b.PostgresConnection(IdentifierSchemaStruct{Name: "pg_connection", SchemaName: "schema", DatabaseName: "database"})
 		b.Publication("mz_source")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
 func TestSourcePostgresSpecificTablesCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" (PUBLICATION 'mz_source', TEXT COLUMNS (table.unsupported_type_1, table.unsupported_type_2)) FOR TABLES (schema1.table_1 AS s1_table_1, schema2.table_1 AS s2_table_1) WITH (SIZE = 'xsmall');`,
+			`CREATE SOURCE "database"."schema"."source" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" \(PUBLICATION 'mz_source', TEXT COLUMNS \(table.unsupported_type_1, table.unsupported_type_2\)\) FOR TABLES \(schema1.table_1 AS s1_table_1, schema2.table_1 AS s2_table_1\) WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourcePostgresBuilder(db, "source", "schema", "database")
@@ -45,7 +47,9 @@ func TestSourcePostgresSpecificTablesCreate(t *testing.T) {
 			},
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 }

--- a/pkg/materialize/table_test.go
+++ b/pkg/materialize/table_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestTableCreateQuery(t *testing.T) {
+func TestTableCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE TABLE "database"."schema"."table" (column_1 int, column_2 text NOT NULL);`,
+			`CREATE TABLE "database"."schema"."table" \(column_1 int, column_2 text NOT NULL\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewTableBuilder(db, "table", "schema", "database")
@@ -27,30 +27,32 @@ func TestTableCreateQuery(t *testing.T) {
 			},
 		})
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
-func TestTableRenameQuery(t *testing.T) {
+func TestTableRename(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`ALTER TABLE "database"."schema"."table" RENAME TO "database"."schema"."new_table";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewTableBuilder(db, "table", "schema", "database")
-
-		b.Create()
+		if err := NewTableBuilder(db, "table", "schema", "database").Rename("new_table"); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
-func TestTableDropQuery(t *testing.T) {
+func TestTableDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`DROP TABLE "database"."schema"."table";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewTableBuilder(db, "table", "schema", "database")
-
-		b.Create()
+		if err := NewTableBuilder(db, "table", "schema", "database").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/pkg/materialize/view_test.go
+++ b/pkg/materialize/view_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestViewCreateQuery(t *testing.T) {
+func TestViewCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`CREATE VIEW "database"."schema"."view" AS SELECT 1 FROM t1;`,
@@ -17,30 +17,32 @@ func TestViewCreateQuery(t *testing.T) {
 		b := NewViewBuilder(db, "view", "schema", "database")
 		b.SelectStmt("SELECT 1 FROM t1")
 
-		b.Create()
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
-func TestViewRenameQuery(t *testing.T) {
+func TestViewRename(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`ALTER VIEW "database"."schema"."view" RENAME TO "database"."schema"."new_view";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewViewBuilder(db, "view", "schema", "database")
-
-		b.Rename("new_view")
+		if err := NewViewBuilder(db, "view", "schema", "database").Rename("new_view"); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 
-func TestViewDropQuery(t *testing.T) {
+func TestViewDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`DROP VIEW "database"."schema"."view";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewViewBuilder(db, "view", "schema", "database")
-
-		b.Drop()
+		if err := NewViewBuilder(db, "view", "schema", "database").Drop(); err != nil {
+			t.Fatal(err)
+		}
 	})
 }


### PR DESCRIPTION
Realized after the refactor all the tests in the `materialize` package would always pass. Updating so failures are correctly captured.