### PR TITLE
Handle missing resources on refresh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,11 @@ page_title: "Provider: Materialize"
 description: Manage Materialize with Terraform.
 ---
 
-# Materialize Provider
+# Materialize provider
 
 This repository contains a Terraform provider for managing resources in a [Materialize](https://materialize.com/) account.
 
-## Example Provider Configuration
+## Example provider configuration
 
 Configure the provider by adding the following block to your Terraform project:
 
@@ -34,11 +34,11 @@ provider "materialize" {
 - `testing` (Boolean) Enable to test the provider locally
 - `username` (String) Materialize username. Can also come from the `MZ_USER` environment variable.
 
-## Order Precedence
+## Order precedence
 
 The Materialize provider will use the following order of precedence when determining which credentials to use:
-1) Provider Configuration
-2) Environment Variables
+1) Provider configuration
+2) Environment variables
 
 ## Modules
 
@@ -49,6 +49,6 @@ To help with your projects, you can use these Materialize maintained Terraform m
 * [EC2 SSH Bastion](https://registry.terraform.io/modules/MaterializeInc/ec2-ssh-bastion/aws/latest)
 * [RDS Postgres](https://registry.terraform.io/modules/MaterializeInc/rds-postgres/aws/latest)
 
-## Helpful Links/Information
+## Getting support
 
-* [Report Bugs](https://github.com/MaterializeInc/terraform-provider-materialize/issues)
+If you run into a snag or need support as you try out the Materialize Terraform provider, join the Materialize [Slack community](https://materialize.com/s/chat) or [open an issue](https://github.com/MaterializeInc/terraform-provider-materialize/issues)!

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -33,7 +34,10 @@ func Cluster() *schema.Resource {
 func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	i := d.Id()
 	s, err := materialize.ScanCluster(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -68,7 +69,10 @@ func clusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interf
 	i := d.Id()
 
 	s, err := materialize.ScanClusterReplica(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -14,7 +15,10 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	i := d.Id()
 
 	s, err := materialize.ScanConnection(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -65,7 +65,10 @@ func connectionAwsPrivatelinkRead(ctx context.Context, d *schema.ResourceData, m
 	i := d.Id()
 
 	s, err := materialize.ScanConnectionAwsPrivatelink(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -63,7 +64,10 @@ func connectionSshTunnelRead(ctx context.Context, d *schema.ResourceData, meta i
 	i := d.Id()
 
 	s, err := materialize.ScanConnectionSshTunnel(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -34,7 +35,10 @@ func databaseRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	i := d.Id()
 
 	s, err := materialize.ScanDatabase(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -94,7 +95,10 @@ func Index() *schema.Resource {
 func indexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	i := d.Id()
 	s, err := materialize.ScanIndex(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -50,7 +51,10 @@ func materializedViewRead(ctx context.Context, d *schema.ResourceData, meta inte
 	i := d.Id()
 
 	s, err := materialize.ScanMaterializedView(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_ownership.go
+++ b/pkg/resources/resource_ownership.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -92,7 +93,10 @@ func ownershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 	i := d.Id()
 
 	s, err := materialize.ScanOwnership(meta.(*sqlx.DB), i, objectType)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_role.go
+++ b/pkg/resources/resource_role.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -60,7 +61,10 @@ func Role() *schema.Resource {
 func roleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	i := d.Id()
 	s, err := materialize.ScanRole(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -35,7 +36,10 @@ func Schema() *schema.Resource {
 func schemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	i := d.Id()
 	s, err := materialize.ScanSchema(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -44,7 +45,10 @@ func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	i := d.Id()
 
 	s, err := materialize.ScanSecret(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_sink.go
+++ b/pkg/resources/resource_sink.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -14,7 +15,10 @@ func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	i := d.Id()
 
 	s, err := materialize.ScanSink(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -24,7 +24,10 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	i := d.Id()
 
 	s, err := materialize.ScanSource(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -64,7 +65,10 @@ func tableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	i := d.Id()
 
 	s, err := materialize.ScanTable(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -85,7 +86,10 @@ func typeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	i := d.Id()
 
 	s, err := materialize.ScanType(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -44,7 +45,10 @@ func viewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	i := d.Id()
 
 	s, err := materialize.ScanView(meta.(*sqlx.DB), i)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Gracefully handle the situation where a resource has gone missing outside of Terraform (e.g., because the user manually ran a `DROP` command).

This logic was applied to table resources as a one-off in #155, but that code appears to have gotten lost in 9235b4b. This commit re-adds the logic for all resource types.

No tests, because our current testing infrastructure is not powerful enough to handle this. Will put up a test in a separate PR that enhances the testing infrastructure (see #165).

Fix #157.