### PR TITLE
Fix: replace the ssh_tunnel connection when the `user` argument changes

### DIFF
--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -25,6 +25,7 @@ var connectionSshTunnelSchema = map[string]*schema.Schema{
 		Description: "The user of the SSH tunnel.",
 		Type:        schema.TypeString,
 		Required:    true,
+		ForceNew:    true,
 	},
 	"port": {
 		Description: "The port of the SSH tunnel.",
@@ -134,7 +135,7 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), connectionName, schemaName, databaseName)
 
-	if d.HasChange("name") || d.HasChange("user") {
+	if d.HasChange("name") {
 		_, newConnectionName := d.GetChange("name")
 		b.Rename(newConnectionName.(string))
 	}

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -134,7 +134,7 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), connectionName, schemaName, databaseName)
 
-	if d.HasChange("name") {
+	if d.HasChange("name") || d.HasChange("user") {
 		_, newConnectionName := d.GetChange("name")
 		b.Rename(newConnectionName.(string))
 	}


### PR DESCRIPTION
Attempting to update the ssh connection `user` in-place with terraform will succeed with the apply, but it will silently failed behind the scenes because the [alter connection API only supports rotating the keys](https://materialize.com/docs/sql/alter-connection/). For this reason, we should be replacing the resource when the user changes