### PR TITLE
Change Kafka source json format to bytes

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -31,5 +31,3 @@ Read-Only:
 
 - `id` (String)
 - `name` (String)
-
-

--- a/docs/data-sources/cluster_replica.md
+++ b/docs/data-sources/cluster_replica.md
@@ -34,5 +34,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `size` (String)
-
-

--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -48,5 +48,3 @@ Read-Only:
 - `name` (String)
 - `schema_name` (String)
 - `type` (String)
-
-

--- a/docs/data-sources/current_cluster.md
+++ b/docs/data-sources/current_cluster.md
@@ -19,5 +19,3 @@ description: |-
 
 - `id` (String) The ID of this resource.
 - `name` (String)
-
-

--- a/docs/data-sources/current_database.md
+++ b/docs/data-sources/current_database.md
@@ -19,5 +19,3 @@ description: |-
 
 - `id` (String) The ID of this resource.
 - `name` (String)
-
-

--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -31,5 +31,3 @@ Read-Only:
 
 - `id` (String)
 - `name` (String)
-
-

--- a/docs/data-sources/egress_ips.md
+++ b/docs/data-sources/egress_ips.md
@@ -27,5 +27,3 @@ output "ips" {
 
 - `egress_ips` (List of String) The egress IPs in the account
 - `id` (String) The ID of this resource.
-
-

--- a/docs/data-sources/index.md
+++ b/docs/data-sources/index.md
@@ -48,5 +48,3 @@ Read-Only:
 - `obj_database` (String)
 - `obj_name` (String)
 - `obj_schema` (String)
-
-

--- a/docs/data-sources/materialized_view.md
+++ b/docs/data-sources/materialized_view.md
@@ -47,5 +47,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `schema_name` (String)
-
-

--- a/docs/data-sources/schema.md
+++ b/docs/data-sources/schema.md
@@ -40,5 +40,3 @@ Read-Only:
 - `database_name` (String)
 - `id` (String)
 - `name` (String)
-
-

--- a/docs/data-sources/secret.md
+++ b/docs/data-sources/secret.md
@@ -47,5 +47,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `schema_name` (String)
-
-

--- a/docs/data-sources/sink.md
+++ b/docs/data-sources/sink.md
@@ -52,5 +52,3 @@ Read-Only:
 - `schema_name` (String)
 - `size` (String)
 - `type` (String)
-
-

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -52,5 +52,3 @@ Read-Only:
 - `schema_name` (String)
 - `size` (String)
 - `type` (String)
-
-

--- a/docs/data-sources/table.md
+++ b/docs/data-sources/table.md
@@ -34,5 +34,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `schema_name` (String)
-
-

--- a/docs/data-sources/type.md
+++ b/docs/data-sources/type.md
@@ -35,5 +35,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `schema_name` (String)
-
-

--- a/docs/data-sources/view.md
+++ b/docs/data-sources/view.md
@@ -47,5 +47,3 @@ Read-Only:
 - `id` (String)
 - `name` (String)
 - `schema_name` (String)
-
-

--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -105,8 +105,8 @@ Optional:
 Optional:
 
 - `avro` (Block List, Max: 1) Avro format. (see [below for nested schema](#nestedblock--format--avro))
+- `bytes` (Boolean) BYTES format.
 - `csv` (Block List, Max: 2) CSV format. (see [below for nested schema](#nestedblock--format--csv))
-- `json` (Boolean) JSON format.
 - `protobuf` (Block List, Max: 1) Protobuf format. (see [below for nested schema](#nestedblock--format--protobuf))
 - `text` (Boolean) Text format.
 
@@ -175,8 +175,8 @@ Optional:
 Optional:
 
 - `avro` (Block List, Max: 1) Avro format. (see [below for nested schema](#nestedblock--key_format--avro))
+- `bytes` (Boolean) BYTES format.
 - `csv` (Block List, Max: 2) CSV format. (see [below for nested schema](#nestedblock--key_format--csv))
-- `json` (Boolean) JSON format.
 - `protobuf` (Block List, Max: 1) Protobuf format. (see [below for nested schema](#nestedblock--key_format--protobuf))
 - `text` (Boolean) Text format.
 
@@ -245,8 +245,8 @@ Optional:
 Optional:
 
 - `avro` (Block List, Max: 1) Avro format. (see [below for nested schema](#nestedblock--value_format--avro))
+- `bytes` (Boolean) BYTES format.
 - `csv` (Block List, Max: 2) CSV format. (see [below for nested schema](#nestedblock--value_format--csv))
-- `json` (Boolean) JSON format.
 - `protobuf` (Block List, Max: 1) Protobuf format. (see [below for nested schema](#nestedblock--value_format--protobuf))
 - `text` (Boolean) Text format.
 

--- a/docs/resources/type.md
+++ b/docs/resources/type.md
@@ -47,5 +47,3 @@ Required:
 
 - `key_type` (String) Creates a custom map whose keys are of `KEY TYPE`. `KEY TYPE` must resolve to text.
 - `value_type` (String) Creates a custom map whose values are of `VALUE TYPE`.
-
-

--- a/integration/source.tf
+++ b/integration/source.tf
@@ -58,6 +58,20 @@ resource "materialize_source_kafka" "example_source_kafka_format_text" {
   }
 }
 
+resource "materialize_source_kafka" "example_source_kafka_format_bytes" {
+  name = "source_kafka_bytes"
+  size = "2"
+  kafka_connection {
+    name          = materialize_connection_kafka.kafka_connection.name
+    schema_name   = materialize_connection_kafka.kafka_connection.schema_name
+    database_name = materialize_connection_kafka.kafka_connection.database_name
+  }
+  topic = "topic1"
+  format {
+    bytes = true
+  }
+}
+
 resource "materialize_source_kafka" "example_source_kafka_format_avro" {
   name = "source_kafka_avro"
   size = "2"

--- a/pkg/materialize/format_specs.go
+++ b/pkg/materialize/format_specs.go
@@ -17,7 +17,7 @@ type CsvFormatSpec struct {
 	Header      []string
 }
 
-type FormatSpecStruct struct {
+type SourceFormatSpecStruct struct {
 	Avro     *AvroFormatSpec
 	Protobuf *ProtobufFormatSpec
 	Csv      *CsvFormatSpec
@@ -36,8 +36,8 @@ type SinkFormatSpecStruct struct {
 	Json bool
 }
 
-func GetFormatSpecStruc(v interface{}) FormatSpecStruct {
-	var format FormatSpecStruct
+func GetFormatSpecStruc(v interface{}) SourceFormatSpecStruct {
+	var format SourceFormatSpecStruct
 	var databaseName string
 	var schemaName string
 

--- a/pkg/materialize/format_specs.go
+++ b/pkg/materialize/format_specs.go
@@ -21,7 +21,7 @@ type FormatSpecStruct struct {
 	Avro     *AvroFormatSpec
 	Protobuf *ProtobufFormatSpec
 	Csv      *CsvFormatSpec
-	Json     bool
+	Bytes    bool
 	Text     bool
 }
 
@@ -83,7 +83,7 @@ func GetFormatSpecStruc(v interface{}) FormatSpecStruct {
 		}
 	}
 	if v, ok := u["json"]; ok {
-		format.Json = v.(bool)
+		format.Bytes = v.(bool)
 	}
 	if v, ok := u["text"]; ok {
 		format.Text = v.(bool)

--- a/pkg/materialize/format_specs.go
+++ b/pkg/materialize/format_specs.go
@@ -82,7 +82,7 @@ func GetFormatSpecStruc(v interface{}) FormatSpecStruct {
 			Header:      csv["header"].([]string),
 		}
 	}
-	if v, ok := u["json"]; ok {
+	if v, ok := u["bytes"]; ok {
 		format.Bytes = v.(bool)
 	}
 	if v, ok := u["text"]; ok {

--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -38,9 +38,9 @@ type SourceKafkaBuilder struct {
 	includePartition bool
 	includeOffset    bool
 	includeTimestamp bool
-	format           FormatSpecStruct
-	keyFormat        FormatSpecStruct
-	valueFormat      FormatSpecStruct
+	format           SourceFormatSpecStruct
+	keyFormat        SourceFormatSpecStruct
+	valueFormat      SourceFormatSpecStruct
 	envelope         KafkaSourceEnvelopeStruct
 	primaryKey       []string
 	startOffset      []int
@@ -99,7 +99,7 @@ func (b *SourceKafkaBuilder) IncludeTimestamp() *SourceKafkaBuilder {
 	return b
 }
 
-func (b *SourceKafkaBuilder) Format(f FormatSpecStruct) *SourceKafkaBuilder {
+func (b *SourceKafkaBuilder) Format(f SourceFormatSpecStruct) *SourceKafkaBuilder {
 	b.format = f
 	return b
 }
@@ -109,12 +109,12 @@ func (b *SourceKafkaBuilder) Envelope(e KafkaSourceEnvelopeStruct) *SourceKafkaB
 	return b
 }
 
-func (b *SourceKafkaBuilder) KeyFormat(k FormatSpecStruct) *SourceKafkaBuilder {
+func (b *SourceKafkaBuilder) KeyFormat(k SourceFormatSpecStruct) *SourceKafkaBuilder {
 	b.keyFormat = k
 	return b
 }
 
-func (b *SourceKafkaBuilder) ValueFormat(v FormatSpecStruct) *SourceKafkaBuilder {
+func (b *SourceKafkaBuilder) ValueFormat(v SourceFormatSpecStruct) *SourceKafkaBuilder {
 	b.valueFormat = v
 	return b
 }

--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -188,8 +188,8 @@ func (b *SourceKafkaBuilder) Create() error {
 		}
 	}
 
-	if b.format.Json {
-		q.WriteString(` FORMAT JSON`)
+	if b.format.Bytes {
+		q.WriteString(` FORMAT BYTES`)
 	}
 
 	if b.format.Text {
@@ -232,8 +232,8 @@ func (b *SourceKafkaBuilder) Create() error {
 		}
 	}
 
-	if b.keyFormat.Json {
-		q.WriteString(` KEY FORMAT JSON`)
+	if b.keyFormat.Bytes {
+		q.WriteString(` KEY FORMAT BYTES`)
 	}
 
 	if b.keyFormat.Text {
@@ -276,8 +276,8 @@ func (b *SourceKafkaBuilder) Create() error {
 		}
 	}
 
-	if b.valueFormat.Json {
-		q.WriteString(` VALUE FORMAT JSON`)
+	if b.valueFormat.Bytes {
+		q.WriteString(` VALUE FORMAT BYTES`)
 	}
 
 	if b.valueFormat.Text {

--- a/pkg/materialize/source_kafka_test.go
+++ b/pkg/materialize/source_kafka_test.go
@@ -18,7 +18,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 		b.Size("xsmall")
 		b.KafkaConnection(IdentifierSchemaStruct{Name: "kafka_connection", DatabaseName: "database", SchemaName: "schema"})
 		b.Topic("events")
-		b.Format(FormatSpecStruct{Avro: &AvroFormatSpec{SchemaRegistryConnection: IdentifierSchemaStruct{Name: "csr_connection", DatabaseName: "database", SchemaName: "schema"}}})
+		b.Format(SourceFormatSpecStruct{Avro: &AvroFormatSpec{SchemaRegistryConnection: IdentifierSchemaStruct{Name: "csr_connection", DatabaseName: "database", SchemaName: "schema"}}})
 		b.IncludeKey()
 		b.IncludeHeaders()
 		b.IncludePartition()

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -46,7 +46,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 
 		// Query Id
 		ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "source_type", "size", "envelope_type", "connection_name", "cluster_name"}).
-			AddRow("u1", "source", "schema", "database", "kafka", "small", "JSON", "conn", "cluster")
+			AddRow("u1", "source", "schema", "database", "kafka", "small", "BYTES", "conn", "cluster")
 		mock.ExpectQuery(`
 			SELECT
 				mz_sources.id,
@@ -73,7 +73,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 
 		// Query Params
 		ip := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "source_type", "size", "envelope_type", "connection_name", "cluster_name"}).
-			AddRow("u1", "source", "schema", "database", "kafka", "small", "JSON", "conn", "cluster")
+			AddRow("u1", "source", "schema", "database", "kafka", "small", "BYTES", "conn", "cluster")
 		mock.ExpectQuery(readSource).WillReturnRows(ip)
 
 		if err := sourceKafkaCreate(context.TODO(), d, db); err != nil {

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -199,8 +199,8 @@ func FormatSpecSchema(elem string, description string, required bool) *schema.Sc
 						},
 					},
 				},
-				"json": {
-					Description: "JSON format.",
+				"bytes": {
+					Description: "BYTES format.",
 					Type:        schema.TypeBool,
 					Optional:    true,
 					ForceNew:    true,


### PR DESCRIPTION
Changing the Kafka source JSON format to BYTES as discussed [here](https://materializeinc.slack.com/archives/C015RHB3LDR/p1686554388443089).

Leaving out format JSON for the moment as support for the more ergonomic FORMAT JSON is in progress ([#7186](https://github.com/MaterializeInc/materialize/issues/7186))!