### PR TITLE
Add `FOR SCHEMAS` option to PostgreSQL source resource

### DIFF
--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -53,3 +53,22 @@ func TestSourcePostgresSpecificTablesCreate(t *testing.T) {
 	})
 
 }
+
+func TestSourcePostgresSpecificSchemasCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."source" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" \(PUBLICATION 'mz_source'\) FOR SCHEMAS \(schema1, schema2\) WITH \(SIZE = 'xsmall'\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		b := NewSourcePostgresBuilder(db, "source", "schema", "database")
+		b.Size("xsmall")
+		b.PostgresConnection(IdentifierSchemaStruct{Name: "pg_connection", SchemaName: "schema", DatabaseName: "database"})
+		b.Publication("mz_source")
+		b.Schema([]string{"schema1", "schema2"})
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+}

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -66,6 +66,15 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		Optional: true,
 		MinItems: 1,
 		ForceNew: true,
+		ConflictsWith: []string{"schema"},
+	},
+	"schema": {
+		Description: "Creates subsources for specific schemas.",
+		Type:        schema.TypeList,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Optional:    true,
+		ForceNew:    true,
+		ConflictsWith: []string{"table"},
 	},
 }
 
@@ -110,12 +119,16 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		b.Publication(v.(string))
 	}
 
+	if v, ok := d.GetOk("textColumns"); ok {
+		b.TextColumns(v.([]string))
+	}
+
 	if v, ok := d.GetOk("table"); ok {
 		tables := materialize.GetTableStruct(v.([]interface{}))
 		b.Table(tables)
 	}
 
-	if v, ok := d.GetOk("textColumns"); ok {
+	if v, ok := d.GetOk("schema"); ok {
 		b.TextColumns(v.([]string))
 	}
 

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -68,7 +68,7 @@ var typeSchema = map[string]*schema.Schema{
 
 func Type() *schema.Resource {
 	return &schema.Resource{
-		Description: "A custom types, which let you create named versions of anonymous types.",
+		Description: "A custom type, which lets you create named versions of anonymous types.",
 
 		CreateContext: typeCreate,
 		ReadContext:   typeRead,


### PR DESCRIPTION
Adding the `FOR SCHEMAS` option (v0.51) to the Postgres source resource, which allows creating subsources for specific schemas. This is exclusive with `FOR TABLES` and `FOR ALL TABLES`. 

One thing I didn't consider before writing this was whether `all_tables` should also be an argument, so we can enforce that it `ConflictsWith` the other two options.