### PR TITLE
Fix Index Object Schema

### DIFF
--- a/pkg/datasources/datasource_index.go
+++ b/pkg/datasources/datasource_index.go
@@ -75,9 +75,9 @@ func indexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 
 		indexMap["id"] = p.IndexId.String
 		indexMap["name"] = p.IndexName.String
-		indexMap["obj_name"] = p.Object.String
-		indexMap["obj_schema"] = p.SchemaName.String
-		indexMap["obj_database"] = p.DatabaseName.String
+		indexMap["obj_name"] = p.ObjectName.String
+		indexMap["obj_schema"] = p.ObjectSchemaName.String
+		indexMap["obj_database"] = p.ObjectDatabaseName.String
 
 		indexFormats = append(indexFormats, indexMap)
 	}

--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -108,11 +108,11 @@ func (b *IndexBuilder) Drop() error {
 }
 
 type IndexParams struct {
-	IndexId      sql.NullString `db:"id"`
-	IndexName    sql.NullString `db:"index_name"`
-	Object       sql.NullString `db:"obj_name"`
-	SchemaName   sql.NullString `db:"obj_schema_name"`
-	DatabaseName sql.NullString `db:"obj_database_name"`
+	IndexId            sql.NullString `db:"id"`
+	IndexName          sql.NullString `db:"index_name"`
+	ObjectName         sql.NullString `db:"obj_name"`
+	ObjectSchemaName   sql.NullString `db:"obj_schema_name"`
+	ObjectDatabaseName sql.NullString `db:"obj_database_name"`
 }
 
 var indexQuery = NewBaseQuery(`

--- a/pkg/provider/acceptance_index_test.go
+++ b/pkg/provider/acceptance_index_test.go
@@ -31,6 +31,7 @@ func TestAccIndex_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_index.test", "obj_name.0.database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_index.test", "col_expr.#", "1"),
 					resource.TestCheckResourceAttr("materialize_index.test", "col_expr.0.field", "id"),
+					resource.TestCheckResourceAttr("materialize_index.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_index.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_index.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, indexName)),
 				),
@@ -61,7 +62,7 @@ func TestAccIndex_disappears(t *testing.T) {
 
 func testAccIndexResource(view, index string) string {
 	return fmt.Sprintf(`
-resource "materialize_materialized_view" "test" {
+resource "materialize_view" "test" {
 	name = "%s"
 
 	statement = <<SQL
@@ -74,9 +75,9 @@ resource "materialize_index" "test" {
 	name = "%s"
 
 	obj_name {
-		name = materialize_materialized_view.test.name
-		schema_name = materialize_materialized_view.test.schema_name
-		database_name = materialize_materialized_view.test.database_name
+		name = materialize_view.test.name
+		schema_name = materialize_view.test.schema_name
+		database_name = materialize_view.test.database_name
 	}
 
 	col_expr {
@@ -101,7 +102,7 @@ func testAccCheckIndexExists(name string) resource.TestCheckFunc {
 func testAccCheckIndexDisappears(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP INDEX "%s";`, name))
+		_, err := db.Exec(fmt.Sprintf(`DROP INDEX "%s" RESTRICT;`, name))
 		return err
 	}
 }

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -103,15 +103,15 @@ func indexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("schema_name", s.Object.String); err != nil {
+	if err := d.Set("schema_name", s.ObjectSchemaName.String); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("database_name", s.DatabaseName.String); err != nil {
+	if err := d.Set("database_name", s.ObjectDatabaseName.String); err != nil {
 		return diag.FromErr(err)
 	}
 
-	qn := materialize.QualifiedName(s.DatabaseName.String, s.SchemaName.String, s.IndexName.String)
+	qn := materialize.QualifiedName(s.ObjectDatabaseName.String, s.ObjectSchemaName.String, s.IndexName.String)
 	if err := d.Set("qualified_sql_name", qn); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
The index acceptance test was flaky because there was an issue with the read. The object schema was mistakenly set to the object name. Fixed and updated `IndexParams` to have more descriptive fields.