### PR TITLE
Allow RBAC for Integration Tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,8 +19,9 @@ jobs:
         run: make testacc
         env:
             MZ_HOST: localhost
-            MZ_USER: materialize
+            MZ_USER: mz_system
             MZ_TESTING: "true"
+            MZ_PORT: 6877
 
       - name: Docker Compose Down
         run: docker compose down

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,9 @@ To run the acceptance tests which will simulate running Terraform commands you w
 
 ```bash
 export MZ_HOST=localhost
-export MZ_USER=materialize
+export MZ_USER=mz_system
 export MZ_TESTING="true"
+export MZ_PORT=6877
 
 # Start all containers
 docker-compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - --availability-zone=test2
     ports:
       - 6875:6875
+      - 6877:6877
       - 6878:6878
     healthcheck: {test: curl -f localhost:6878/api/readyz, interval: 1s, start_period: 35s}
 

--- a/integration/index.tf
+++ b/integration/index.tf
@@ -10,7 +10,8 @@ resource "materialize_index" "loadgen_index" {
 }
 
 resource "materialize_index" "materialized_view_index" {
-  name = "simple"
+  name         = "simple"
+  cluster_name = "default"
 
   obj_name {
     name          = materialize_materialized_view.simple_materialized_view.name

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -8,9 +8,9 @@ terraform {
 
 provider "materialize" {
   host     = "materialized"
-  username = "materialize"
+  username = "mz_system"
   password = "password"
-  port     = 6875
+  port     = 6877
   database = "materialize"
   testing  = true
 }

--- a/integration/materialized_view.tf
+++ b/integration/materialized_view.tf
@@ -2,6 +2,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
   name          = "simple_materialized_view"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
+  cluster_name  = "default"
 
   statement = <<SQL
 SELECT

--- a/pkg/provider/acceptance_index_test.go
+++ b/pkg/provider/acceptance_index_test.go
@@ -73,6 +73,7 @@ resource "materialize_view" "test" {
 
 resource "materialize_index" "test" {
 	name = "%s"
+	cluster_name = "default"
 
 	obj_name {
 		name = materialize_view.test.name

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -85,6 +85,7 @@ func testAccMaterializedViewResource(name string) string {
 resource "materialize_materialized_view" "test" {
 	name = "%s"
 	statement = "SELECT 1 AS id"
+	cluster_name = "default"
 }
 `, name)
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -70,8 +70,9 @@ func Provider() *schema.Provider {
 			"materialize_connection_postgres":                  resources.ConnectionPostgres(),
 			"materialize_connection_ssh_tunnel":                resources.ConnectionSshTunnel(),
 			"materialize_database":                             resources.Database(),
-			"materialize_index":                                resources.Index(),
 			// TODO Expose RBAC resources when ready
+			// "materialize_grant_database": resources.GrantDatabase(),
+			"materialize_index": resources.Index(),
 			// "materialize_ownership":                            resources.Ownership(),
 			"materialize_materialized_view": resources.MaterializedView(),
 			// "materialize_role":                                 resources.Role(),
@@ -112,14 +113,20 @@ func connectionString(host, username, password string, port int, database string
 	c := strings.Builder{}
 	c.WriteString(fmt.Sprintf("postgres://%s:%s@%s:%d/%s", username, password, host, port, database))
 
+	params := []string{}
+
 	if testing {
-		c.WriteString("?sslmode=disable")
+		params = append(params, "sslmode=disable")
+		params = append(params, "enable_rbac_checks=true")
+		params = append(params, "enable_ld_rbac_checks=true")
 	} else {
-		c.WriteString("?sslmode=require")
+		params = append(params, "sslmode=require")
 	}
 
-	c.WriteString(fmt.Sprintf("&application_name=%s", application))
+	params = append(params, fmt.Sprintf("application_name=%s", application))
+	p := strings.Join(params[:], "&")
 
+	c.WriteString(fmt.Sprintf("?%s", p))
 	return c.String()
 }
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -16,7 +16,7 @@ func TestConnectionString(t *testing.T) {
 func TestConnectionStringTesting(t *testing.T) {
 	r := require.New(t)
 	c := connectionString("host", "user", "pass", 6875, "database", true, "tf")
-	r.Equal(`postgres://user:pass@host:6875/database?sslmode=disable&application_name=tf`, c)
+	r.Equal(`postgres://user:pass@host:6875/database?sslmode=disable&enable_rbac_checks=true&enable_ld_rbac_checks=true&application_name=tf`, c)
 }
 
 func TestProvider(t *testing.T) {

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -33,8 +33,8 @@ var tableSchema = map[string]*schema.Schema{
 				},
 				"nullable": {
 					Description: "	Do not allow the column to contain NULL values. Columns without this constraint can contain NULL values.",
-					Type:     schema.TypeBool,
-					Optional: true,
+					Type:        schema.TypeBool,
+					Optional:    true,
 				},
 			},
 		},


### PR DESCRIPTION
Tweak the Docker image to have RBAC enabled in preparation for enabling `roles` and `grant` resources.

NOTE: Needed to explicitly add the cluster for resources in the acceptance and integration tests. It may make sense to also add cluster as an optional attribute when connecting to the provider.