### PR TITLE
[WIP] Rollback Ownership Failures

### DIFF
--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -72,6 +73,8 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CLUSTER", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -140,6 +141,8 @@ func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CLUSTER REPLICA", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -130,6 +131,8 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_confluent_schema_registry.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -104,6 +105,8 @@ func connectionConfluentSchemaRegistryCreate(ctx context.Context, d *schema.Reso
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -144,6 +145,8 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_postgres.go
+++ b/pkg/resources/resource_connection_postgres.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -140,6 +141,8 @@ func connectionPostgresCreate(ctx context.Context, d *schema.ResourceData, meta 
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -133,6 +134,8 @@ func connectionSshTunnelCreate(ctx context.Context, d *schema.ResourceData, meta
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -74,9 +74,8 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "DATABASE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
-			// drop object if ownership fails
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
 			b.Drop()
-			log.Printf("[DEBUG] drop object: %s", o.Name)
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -73,6 +74,9 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "DATABASE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			// drop object if ownership fails
+			b.Drop()
+			log.Printf("[DEBUG] drop object: %s", o.Name)
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -115,6 +116,8 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "MATERIALIZED VIEW", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -84,6 +85,8 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SCHEMA", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -101,6 +102,8 @@ func secretCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SECRET", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -159,6 +160,8 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SINK", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -247,6 +248,8 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -211,6 +212,8 @@ func sourceLoadgenCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -141,6 +142,8 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -144,6 +145,8 @@ func tableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TABLE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -153,6 +154,8 @@ func typeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TYPE", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -101,6 +102,8 @@ func viewCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "VIEW", o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
If a resource creation fails on the ownership transfer, rollback the resource. It would be good to DRY some of the resource operations up.