### PR TITLE
RBAC Refactor

### DIFF
--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -155,9 +155,10 @@ func ScanIndex(conn *sqlx.DB, id string) (IndexParams, error) {
 
 func ListIndexes(conn *sqlx.DB, schemaName, databaseName string) ([]IndexParams, error) {
 	p := map[string]string{
-		"mz_databases.name": databaseName,
 		"mz_schemas.name":   schemaName,
+		"mz_databases.name": databaseName,
 	}
+
 	q := indexQuery.QueryPredicate(p)
 
 	var c []IndexParams

--- a/pkg/materialize/object.go
+++ b/pkg/materialize/object.go
@@ -1,7 +1,11 @@
 package materialize
 
+import "github.com/jmoiron/sqlx"
+
 // Any Materialize Database Object. Will contain name and optionally database and schema
+// Cluster name only applies to cluster replicas
 type ObjectSchemaStruct struct {
+	ObjectType   string
 	Name         string
 	SchemaName   string
 	DatabaseName string
@@ -19,6 +23,14 @@ func GetObjectSchemaStruct(v interface{}) ObjectSchemaStruct {
 	}
 
 	if v, ok := u["database_name"]; ok && v.(string) != "" {
+		conn.DatabaseName = v.(string)
+	}
+
+	if v, ok := u["cluster_name"]; ok && v.(string) != "" {
+		conn.DatabaseName = v.(string)
+	}
+
+	if v, ok := u["object_type"]; ok && v.(string) != "" {
 		conn.DatabaseName = v.(string)
 	}
 	return conn
@@ -41,4 +53,47 @@ func (g *ObjectSchemaStruct) QualifiedName() string {
 
 	fields = append(fields, g.Name)
 	return QualifiedName(fields...)
+}
+
+func ObjectId(conn *sqlx.DB, object ObjectSchemaStruct) (string, error) {
+	var i string
+	var e error
+
+	switch t := object.ObjectType; t {
+	case "DATABASE":
+		i, e = DatabaseId(conn, object)
+
+	case "SCHEMA":
+		i, e = SchemaId(conn, object)
+
+	case "TABLE":
+		i, e = TableId(conn, object)
+
+	case "VIEW":
+		i, e = ViewId(conn, object)
+
+	case "MATERIALIZED VIEW":
+		i, e = MaterializedViewId(conn, object)
+
+	case "TYPE":
+		i, e = TypeId(conn, object)
+
+	case "SOURCE":
+		i, e = SourceId(conn, object)
+
+	case "CONNECTION":
+		i, e = ConnectionId(conn, object)
+
+	case "SECRET":
+		i, e = SecretId(conn, object)
+
+	case "CLUSTER":
+		i, e = ClusterId(conn, object)
+	}
+
+	if e != nil {
+		return "", e
+	}
+
+	return i, nil
 }

--- a/pkg/materialize/object_test.go
+++ b/pkg/materialize/object_test.go
@@ -3,6 +3,9 @@ package materialize
 import (
 	"testing"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,4 +23,19 @@ func TestObjectName(t *testing.T) {
 
 	onc := ObjectSchemaStruct{Name: "name", ClusterName: "cluster"}
 	r.Equal(onc.QualifiedName(), `"cluster"."name"`)
+}
+
+func TestObjectId(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		o := ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"}
+
+		// Query Id
+		ip := `WHERE mz_databases.name = 'materialize'`
+		testhelpers.MockDatabaseScan(mock, ip)
+
+		_, err := ObjectId(db, o)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/pkg/materialize/privilege.go
+++ b/pkg/materialize/privilege.go
@@ -99,68 +99,6 @@ func HasPrivilege(privileges []string, checkPrivilege string) bool {
 	return false
 }
 
-type PrivilegeObjectStruct struct {
-	Type         string
-	Name         string
-	SchemaName   string
-	DatabaseName string
-}
-
-func GetPrivilegeObjectStruct(databaseName string, schemaName string, v interface{}) PrivilegeObjectStruct {
-	var p PrivilegeObjectStruct
-	u := v.([]interface{})[0].(map[string]interface{})
-
-	if v, ok := u["type"]; ok {
-		p.Type = v.(string)
-	}
-
-	if v, ok := u["name"]; ok {
-		p.Name = v.(string)
-	}
-
-	if v, ok := u["schema_name"]; ok && v.(string) != "" {
-		p.SchemaName = v.(string)
-	}
-
-	if v, ok := u["database_name"]; ok && v.(string) != "" {
-		p.DatabaseName = v.(string)
-	}
-
-	return p
-}
-
-func (i *PrivilegeObjectStruct) QualifiedName() string {
-	p := []string{}
-
-	if i.DatabaseName != "" {
-		p = append(p, i.DatabaseName)
-	}
-
-	if i.SchemaName != "" {
-		p = append(p, i.SchemaName)
-	}
-
-	p = append(p, i.Name)
-	return QualifiedName(p...)
-}
-
-// DDL
-type PrivilegeBuilder struct {
-	ddl       Builder
-	role      string
-	privilege string
-	object    PrivilegeObjectStruct
-}
-
-func NewPrivilegeBuilder(conn *sqlx.DB, role, privilege string, object PrivilegeObjectStruct) *PrivilegeBuilder {
-	return &PrivilegeBuilder{
-		ddl:       Builder{conn, Privilege},
-		role:      role,
-		privilege: privilege,
-		object:    object,
-	}
-}
-
 // https://materialize.com/docs/sql/grant-privilege/#compatibility
 func objectCompatibility(objectType string) string {
 	compatibility := []string{"SOURCE", "VIEW", "MATERIALIZED VIEW"}
@@ -173,181 +111,98 @@ func objectCompatibility(objectType string) string {
 	return objectType
 }
 
+// DDL
+type PrivilegeBuilder struct {
+	ddl       Builder
+	role      string
+	privilege string
+	object    ObjectSchemaStruct
+}
+
+func NewPrivilegeBuilder(conn *sqlx.DB, role, privilege string, object ObjectSchemaStruct) *PrivilegeBuilder {
+	return &PrivilegeBuilder{
+		ddl:       Builder{conn, Privilege},
+		role:      role,
+		privilege: privilege,
+		object:    object,
+	}
+}
+
 func (b *PrivilegeBuilder) Grant() error {
-	t := objectCompatibility(b.object.Type)
+	t := objectCompatibility(b.object.ObjectType)
 	q := fmt.Sprintf(`GRANT %s ON %s %s TO %s;`, b.privilege, t, b.object.QualifiedName(), b.role)
 	return b.ddl.exec(q)
 }
 
 func (b *PrivilegeBuilder) Revoke() error {
-	t := objectCompatibility(b.object.Type)
+	t := objectCompatibility(b.object.ObjectType)
 	q := fmt.Sprintf(`REVOKE %s ON %s %s FROM %s;`, b.privilege, t, b.object.QualifiedName(), b.role)
 	return b.ddl.exec(q)
 }
 
-func PrivilegeId(conn *sqlx.DB, object PrivilegeObjectStruct, roleId, privilege string) (string, error) {
-	var id string
-
-	switch t := object.Type; t {
-	case "DATABASE":
-		o := ObjectSchemaStruct{Name: object.Name}
-		i, err := DatabaseId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "SCHEMA":
-		o := ObjectSchemaStruct{Name: object.Name, DatabaseName: object.DatabaseName}
-		i, err := SchemaId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "TABLE":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := TableId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "VIEW":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := ViewId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "MATERIALIZED VIEW":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := MaterializedViewId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "TYPE":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := TypeId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "SOURCE":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := SourceId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "CONNECTION":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := ConnectionId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "SECRET":
-		o := ObjectSchemaStruct{Name: object.Name, SchemaName: object.SchemaName, DatabaseName: object.DatabaseName}
-		i, err := SecretId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-
-	case "CLUSTER":
-		o := ObjectSchemaStruct{Name: object.Name}
-		i, err := ClusterId(conn, o)
-		if err != nil {
-			return "", err
-		}
-		id = i
-	}
-
-	f := fmt.Sprintf(`GRANT|%s|%s|%s|%s`, object.Type, id, roleId, privilege)
-	return f, nil
+func (b *PrivilegeBuilder) GrantKey(objectId, roleId, privilege string) string {
+	return fmt.Sprintf(`GRANT|%[1]s|%[2]s|%[3]s|%[4]s`, b.object.ObjectType, objectId, roleId, privilege)
 }
 
 func ScanPrivileges(conn *sqlx.DB, objectType, objectId string) (string, error) {
-	var params string
+	var p string
+	var e error
 
 	switch t := objectType; t {
 	case "DATABASE":
-		p, err := ScanDatabase(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanDatabase(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "SCHEMA":
-		p, err := ScanSchema(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanSchema(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "TABLE":
-		p, err := ScanTable(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanTable(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "VIEW":
-		p, err := ScanView(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanView(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "MATERIALIZED VIEW":
-		p, err := ScanMaterializedView(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanMaterializedView(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "TYPE":
-		p, err := ScanType(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanType(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "SOURCE":
-		p, err := ScanSource(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanSource(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "CONNECTION":
-		p, err := ScanConnection(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanConnection(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "SECRET":
-		p, err := ScanSecret(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanSecret(conn, objectId)
+		p = params.Privileges.String
+		e = err
 
 	case "CLUSTER":
-		p, err := ScanCluster(conn, objectId)
-		if err != nil {
-			return "", err
-		}
-		params = p.Privileges.String
+		params, err := ScanCluster(conn, objectId)
+		p = params.Privileges.String
+		e = err
 	}
 
-	return params, nil
+	if e != nil {
+		return "", e
+	}
+
+	return p, nil
 }

--- a/pkg/materialize/privilege_default_privilege_test.go
+++ b/pkg/materialize/privilege_default_privilege_test.go
@@ -8,7 +8,6 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
 	"github.com/jmoiron/sqlx"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParseDefaultPrivileges(t *testing.T) {
@@ -52,63 +51,6 @@ func TestParseDefaultPrivileges(t *testing.T) {
 	if !reflect.DeepEqual(output, expected) {
 		t.Fatal("ouptut does not equal expected")
 	}
-}
-
-func TestDefaultPrivilegeId(t *testing.T) {
-	r := require.New(t)
-	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		gp := `WHERE mz_roles.name = 'grantee'`
-		testhelpers.MockRoleScan(mock, gp)
-
-		i, err := DefaultPrivilegeId(db, "TABLE", "grantee", "", "", "", "SELECT")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r.Equal(i, `GRANT DEFAULT|TABLE|u1||||SELECT`)
-	})
-}
-
-func TestDefaultPrivilegeIdRole(t *testing.T) {
-	r := require.New(t)
-	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		gp := `WHERE mz_roles.name = 'grantee'`
-		testhelpers.MockRoleScan(mock, gp)
-
-		tp := `WHERE mz_roles.name = 'target'`
-		testhelpers.MockRoleScan(mock, tp)
-
-		i, err := DefaultPrivilegeId(db, "TABLE", "grantee", "target", "", "", "SELECT")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r.Equal(i, `GRANT DEFAULT|TABLE|u1|u1|||SELECT`)
-	})
-}
-
-func TestDefaultPrivilegeIdRoleQualified(t *testing.T) {
-	r := require.New(t)
-	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		gp := `WHERE mz_roles.name = 'grantee'`
-		testhelpers.MockRoleScan(mock, gp)
-
-		tp := `WHERE mz_roles.name = 'target'`
-		testhelpers.MockRoleScan(mock, tp)
-
-		dp := `WHERE mz_databases.name = 'database'`
-		testhelpers.MockDatabaseScan(mock, dp)
-
-		sp := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
-		testhelpers.MockSchemaScan(mock, sp)
-
-		i, err := DefaultPrivilegeId(db, "TABLE", "grantee", "target", "database", "schema", "SELECT")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r.Equal(i, `GRANT DEFAULT|TABLE|u1|u1|u1|u1|SELECT`)
-	})
 }
 
 func TestDefaultPrivilegeGrantSimple(t *testing.T) {

--- a/pkg/materialize/privilege_role.go
+++ b/pkg/materialize/privilege_role.go
@@ -31,6 +31,10 @@ func (b *RolePrivilegeBuilder) Revoke() error {
 	return b.ddl.exec(q)
 }
 
+func (b *RolePrivilegeBuilder) GrantKey(roleId, memberId string) string {
+	return fmt.Sprintf(`ROLE MEMBER|%[1]s|%[2]s`, roleId, memberId)
+}
+
 type RolePrivilegeParams struct {
 	RoleId  sql.NullString `db:"role_id"`
 	Member  sql.NullString `db:"member"`
@@ -43,21 +47,6 @@ var rolePrivilegeQuery = NewBaseQuery(`
 		mz_role_members.member,
 		mz_role_members.grantor
 	FROM mz_role_members`)
-
-func RolePrivilegeId(conn *sqlx.DB, roleName, memberName string) (string, error) {
-	r, err := RoleId(conn, roleName)
-	if err != nil {
-		return "", err
-	}
-
-	m, err := RoleId(conn, memberName)
-	if err != nil {
-		return "", err
-	}
-
-	f := fmt.Sprintf(`ROLE MEMBER|%[1]s|%[2]s`, r, m)
-	return f, nil
-}
 
 func ScanRolePrivilege(conn *sqlx.DB, roleId, memberId string) ([]RolePrivilegeParams, error) {
 	p := map[string]string{

--- a/pkg/materialize/privilege_system_privilege.go
+++ b/pkg/materialize/privilege_system_privilege.go
@@ -32,21 +32,15 @@ func (b *SystemPrivilegeBuilder) Revoke() error {
 	return b.ddl.exec(q)
 }
 
+func (b *SystemPrivilegeBuilder) GrantKey(roleId, privilege string) string {
+	return fmt.Sprintf(`GRANT SYSTEM|%[1]s|%[2]s`, roleId, privilege)
+}
+
 type SytemPrivilegeParams struct {
 	Privileges sql.NullString `db:"privileges"`
 }
 
 var systemPrivilegeQuery = `SELECT privileges FROM mz_system_privileges`
-
-func SystemPrivilegeId(conn *sqlx.DB, roleName, privilege string) (string, error) {
-	r, err := RoleId(conn, roleName)
-	if err != nil {
-		return "", err
-	}
-
-	f := fmt.Sprintf(`GRANT SYSTEM|%[1]s|%[2]s`, r, privilege)
-	return f, nil
-}
 
 func ScanSystemPrivileges(conn *sqlx.DB) ([]SytemPrivilegeParams, error) {
 	var c []SytemPrivilegeParams

--- a/pkg/materialize/privilege_system_privilege_test.go
+++ b/pkg/materialize/privilege_system_privilege_test.go
@@ -53,23 +53,6 @@ func TestSystemPrivilegeRevoke(t *testing.T) {
 	})
 }
 
-func TestSystemPrivilegeId(t *testing.T) {
-	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		// Query Id
-		ip := `WHERE mz_roles.name = 'joe'`
-		testhelpers.MockRoleScan(mock, ip)
-
-		i, err := SystemPrivilegeId(db, "joe", "CREATECLUSTER")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if i != "GRANT SYSTEM|u1|CREATECLUSTER" {
-			t.Fatalf("unexpected id %s", i)
-		}
-	})
-}
-
 func TestScanSystemPrivileges(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		testhelpers.MockSystemPrivilege(mock)

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -47,7 +47,7 @@ func TestPrivilegeGrant(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT CREATE ON DATABASE "materialize" TO joe;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewPrivilegeBuilder(db, "joe", "CREATE", PrivilegeObjectStruct{Type: "DATABASE", Name: "materialize"})
+		b := NewPrivilegeBuilder(db, "joe", "CREATE", ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"})
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
 		}
@@ -58,28 +58,9 @@ func TestPrivilegeRevoke(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE CREATE ON DATABASE "materialize" FROM joe;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewPrivilegeBuilder(db, "joe", "CREATE", PrivilegeObjectStruct{Type: "DATABASE", Name: "materialize"})
+		b := NewPrivilegeBuilder(db, "joe", "CREATE", ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"})
 		if err := b.Revoke(); err != nil {
 			t.Fatal(err)
-		}
-	})
-}
-
-func TestPrivilegeId(t *testing.T) {
-	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		o := PrivilegeObjectStruct{Type: "DATABASE", Name: "materialize"}
-
-		// Query Id
-		ip := `WHERE mz_databases.name = 'materialize'`
-		testhelpers.MockDatabaseScan(mock, ip)
-
-		i, err := PrivilegeId(db, o, "u10", "SELECT")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if i != "GRANT|DATABASE|u1|u10|SELECT" {
-			t.Fatalf("unexpected id %s", i)
 		}
 	})
 }

--- a/pkg/provider/acceptance_cluster_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_cluster_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantClusterDefaultPrivilege_basic(t *testing.T) {
@@ -44,8 +41,8 @@ func TestAccGrantClusterDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantClusterDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantClusterDefaultPrivilegeExists("materialize_cluster_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantClusterDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("CLUSTER", "materialize_cluster_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("CLUSTER", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -70,43 +67,4 @@ resource "materialize_cluster_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantClusterDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "CLUSTER", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantClusterDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON CLUSTERS FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_cluster_replica_test.go
+++ b/pkg/provider/acceptance_cluster_replica_test.go
@@ -56,7 +56,13 @@ func TestAccClusterReplica_disappears(t *testing.T) {
 				Config: testAccClusterReplicaResource(roleName, clusterName, replicaName, replica2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterReplicaExists("materialize_cluster_replica.test"),
-					testAccCheckClusterReplicaDisappears(clusterName, replicaName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType:  "CLUSTER REPLICA",
+							Name:        replicaName,
+							ClusterName: clusterName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -99,14 +105,6 @@ func testAccCheckClusterReplicaExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("cluster replica not found: %s", name)
 		}
 		_, err := materialize.ScanClusterReplica(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckClusterReplicaDisappears(clusterName, replicaName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CLUSTER REPLICA "%s"."%s";`, clusterName, replicaName))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -96,9 +96,9 @@ func TestAccCluster_disappears(t *testing.T) {
 				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, clusterSize, clusterReplicationFactor),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
-					testAccCheckClusterDisappears(clusterName),
+					testAccCheckObjectDisappears(materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}),
 					testAccCheckClusterExists("materialize_cluster.test_managed_cluster"),
-					testAccCheckClusterDisappears(clusterName+"_managed"),
+					testAccCheckObjectDisappears(materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName + "_managed"}),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -140,22 +140,6 @@ func testAccCheckClusterExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("cluster not found: %s", name)
 		}
 		_, err := materialize.ScanCluster(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckClusterDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CLUSTER "%s";`, name))
-		return err
-	}
-}
-
-func testAccCheckManagedClusterDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CLUSTER "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
+++ b/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
@@ -83,7 +83,12 @@ func TestAccConnConfluentSchemaRegistry_disappears(t *testing.T) {
 				Config: testAccConnConfluentSchemaRegistryResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnConfluentSchemaRegistryExists("materialize_connection_confluent_schema_registry.test"),
-					testAccCheckConnConfluentSchemaRegistryDisappears(connectionName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "CONNECTION",
+							Name:       connectionName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -120,14 +125,6 @@ func testAccCheckConnConfluentSchemaRegistryExists(name string) resource.TestChe
 			return fmt.Errorf("connection confluent schema registry not found: %s", name)
 		}
 		_, err := materialize.ScanConnection(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckConnConfluentSchemaRegistryDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CONNECTION "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_connection_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_connection_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantConnectionDefaultPrivilege_basic(t *testing.T) {
@@ -46,8 +43,8 @@ func TestAccGrantConnectionDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantConnectionDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantConnectionDefaultPrivilegeExists("materialize_connection_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantConnectionDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("CONNECTION", "materialize_connection_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("CONNECTION", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -72,43 +69,4 @@ resource "materialize_connection_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantConnectionDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "CONNECTION", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantConnectionDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON CONNECTIONS FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -84,7 +84,12 @@ func TestAccConnKafka_disappears(t *testing.T) {
 				Config: testAccConnKafkaResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnKafkaExists("materialize_connection_kafka.test"),
-					testAccCheckConnKafkaDisappears(connectionName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "CONNECTION",
+							Name:       connectionName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -127,14 +132,6 @@ func testAccCheckConnKafkaExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("connection kafka not found: %s", name)
 		}
 		_, err := materialize.ScanConnection(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckConnKafkaDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CONNECTION "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_connection_postgres_test.go
+++ b/pkg/provider/acceptance_connection_postgres_test.go
@@ -92,7 +92,12 @@ func TestAccConnPostgres_disappears(t *testing.T) {
 				Config: testAccConnPostgresResource(roleName, secretName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnPostgresExists("materialize_connection_postgres.test"),
-					testAccCheckConnPostgresDisappears(connectionName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "CONNECTION",
+							Name:       connectionName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -154,14 +159,6 @@ func testAccCheckConnPostgresExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("connection postgres not found: %s", name)
 		}
 		_, err := materialize.ScanConnection(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckConnPostgresDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CONNECTION "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_connection_ssh_tunnel_test.go
+++ b/pkg/provider/acceptance_connection_ssh_tunnel_test.go
@@ -85,7 +85,12 @@ func TestAccConnSshTunnel_disappears(t *testing.T) {
 				Config: testAccConnSshTunnelResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnSshTunnelExists("materialize_connection_ssh_tunnel.test"),
-					testAccCheckConnSshTunnelDisappears(connectionName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "CONNECTION",
+							Name:       connectionName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -128,14 +133,6 @@ func testAccCheckConnSshTunnelExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("connection ssh tunnel not found: %s", name)
 		}
 		_, err := materialize.ScanConnectionSshTunnel(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckConnSshTunnelDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP CONNECTION "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_database_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_database_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantDatabaseDefaultPrivilege_basic(t *testing.T) {
@@ -51,8 +48,8 @@ func TestAccGrantDatabaseDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantDatabaseDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantDatabaseDefaultPrivilegeExists("materialize_database_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantDatabaseDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("DATABASE", "materialize_database_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("DATABASE", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -77,43 +74,4 @@ resource "materialize_database_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantDatabaseDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "DATABASE", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantDatabaseDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON DATABASES FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_database_grant_test.go
+++ b/pkg/provider/acceptance_database_grant_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantDatabase_basic(t *testing.T) {
@@ -27,7 +25,11 @@ func TestAccGrantDatabase_basic(t *testing.T) {
 					{
 						Config: testAccGrantDatabaseResource(roleName, databaseName, privilege),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckGrantDatabaseExists("materialize_database_grant.database_grant", roleName, databaseName, privilege),
+							testAccCheckGrantExists(
+								materialize.ObjectSchemaStruct{
+									ObjectType: "DATABASE",
+									Name:       databaseName,
+								}, "materialize_database_grant.database_grant", roleName, privilege),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "role_name", roleName),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "privilege", privilege),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "database_name", databaseName),
@@ -43,6 +45,12 @@ func TestAccGrantDatabase_disappears(t *testing.T) {
 	privilege := randomPrivilege("DATABASE")
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	o := materialize.ObjectSchemaStruct{
+		ObjectType: "DATABASE",
+		Name:       databaseName,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -51,8 +59,8 @@ func TestAccGrantDatabase_disappears(t *testing.T) {
 			{
 				Config: testAccGrantDatabaseResource(roleName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantDatabaseExists("materialize_database_grant.database_grant", roleName, databaseName, privilege),
-					testAccCheckGrantDatanaseRevoked(roleName, databaseName, privilege),
+					testAccCheckGrantExists(o, "materialize_database_grant.database_grant", roleName, privilege),
+					testAccCheckGrantRevoked(o, roleName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -77,44 +85,4 @@ resource "materialize_database_grant" "database_grant" {
 	database_name = materialize_database.test.name
 }
 `, roleName, databaseName, privilege)
-}
-
-func testAccCheckGrantDatabaseExists(grantName, roleName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		o := materialize.ObjectSchemaStruct{Name: databaseName}
-		id, err := materialize.DatabaseId(db, o)
-		if err != nil {
-			return err
-		}
-
-		roleId, err := materialize.RoleId(db, roleName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanPrivileges(db, "DATABASE", id)
-		if err != nil {
-			return err
-		}
-
-		priviledgeMap := materialize.ParsePrivileges(g)
-		if !materialize.HasPrivilege(priviledgeMap[roleId], privilege) {
-			return fmt.Errorf("database object %s does not include privilege %s", g, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantDatanaseRevoked(roleName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`REVOKE %s ON DATABASE %s FROM "%s";`, privilege, databaseName, roleName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_database_test.go
+++ b/pkg/provider/acceptance_database_test.go
@@ -55,7 +55,12 @@ func TestAccDatabase_disappears(t *testing.T) {
 				Config: testAccDatabaseResource(roleName, databaseName, database2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseExists("materialize_database.test"),
-					testAccCheckDatabaseDisappears(databaseName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "DATABASE",
+							Name:       databaseName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -90,14 +95,6 @@ func testAccCheckDatabaseExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("database not found: %s", name)
 		}
 		_, err := materialize.ScanDatabase(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckDatabaseDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP DATABASE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -85,7 +85,12 @@ func TestAccMaterializedView_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaterializedViewExists("materialize_materialized_view.test"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "name", viewName),
-					testAccCheckMaterializedViewDisappears(viewName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "MATERIALIZED VIEW",
+							Name:       viewName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -124,14 +129,6 @@ func testAccCheckMaterializedViewExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Materialized View not found: %s", name)
 		}
 		_, err := materialize.ScanMaterializedView(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckMaterializedViewDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP MATERIALIZED VIEW "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_role_test.go
+++ b/pkg/provider/acceptance_role_test.go
@@ -42,7 +42,12 @@ func TestAccRole_disappears(t *testing.T) {
 				Config: testAccRoleResource(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists("materialize_role.test"),
-					testAccCheckRoleDisappears(roleName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "ROLE",
+							Name:       roleName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -66,14 +71,6 @@ func testAccCheckRoleExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("role not found: %s", name)
 		}
 		_, err := materialize.ScanRole(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckRoleDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP ROLE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_schema_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_schema_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantSchemaDefaultPrivilege_basic(t *testing.T) {
@@ -46,8 +43,8 @@ func TestAccGrantSchemaDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantSchemaDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSchemaDefaultPrivilegeExists("materialize_schema_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantSchemaDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("SCHEMA", "materialize_schema_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("SCHEMA", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -72,43 +69,4 @@ resource "materialize_schema_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantSchemaDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "SCHEMA", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantSchemaDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON SCHEMAS FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_schema_grant_test.go
+++ b/pkg/provider/acceptance_schema_grant_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantSchema_basic(t *testing.T) {
@@ -24,7 +22,11 @@ func TestAccGrantSchema_basic(t *testing.T) {
 			{
 				Config: testAccGrantSchemaResource(roleName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSchemaExists("materialize_schema_grant.schema_grant", roleName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(materialize.ObjectSchemaStruct{
+						ObjectType:   "SCHEMA",
+						Name:         schemaName,
+						DatabaseName: databaseName,
+					}, "materialize_schema_grant.schema_grant", roleName, privilege),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "schema_name", schemaName),
@@ -40,6 +42,13 @@ func TestAccGrantSchema_disappears(t *testing.T) {
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	o := materialize.ObjectSchemaStruct{
+		ObjectType:   "SCHEMA",
+		Name:         schemaName,
+		DatabaseName: databaseName,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -48,8 +57,8 @@ func TestAccGrantSchema_disappears(t *testing.T) {
 			{
 				Config: testAccGrantSchemaResource(roleName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSchemaExists("materialize_schema_grant.schema_grant", roleName, schemaName, databaseName, privilege),
-					testAccCheckGrantSchemaRevoked(roleName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(o, "materialize_schema_grant.schema_grant", roleName, privilege),
+					testAccCheckGrantRevoked(o, roleName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -80,44 +89,4 @@ resource "materialize_schema_grant" "schema_grant" {
 	schema_name   = materialize_schema.test.name
 }
 `, roleName, databaseName, schemaName, privilege)
-}
-
-func testAccCheckGrantSchemaExists(grantName, roleName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		o := materialize.ObjectSchemaStruct{Name: schemaName, DatabaseName: databaseName}
-		id, err := materialize.SchemaId(db, o)
-		if err != nil {
-			return err
-		}
-
-		roleId, err := materialize.RoleId(db, roleName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanPrivileges(db, "SCHEMA", id)
-		if err != nil {
-			return err
-		}
-
-		priviledgeMap := materialize.ParsePrivileges(g)
-		if !materialize.HasPrivilege(priviledgeMap[roleId], privilege) {
-			return fmt.Errorf("schema object %s does not include privilege %s", g, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantSchemaRevoked(roleName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`REVOKE %s ON SCHEMA "%s"."%s" FROM "%s";`, privilege, databaseName, schemaName, roleName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_schema_test.go
+++ b/pkg/provider/acceptance_schema_test.go
@@ -54,7 +54,12 @@ func TestAccSchema_disappears(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_schema.test", "name", schemaName),
 					resource.TestCheckResourceAttr("materialize_schema.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_schema.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."%s"`, schemaName)),
-					testAccCheckSchemaDisappears(schemaName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "SCHEMA",
+							Name:       schemaName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -91,14 +96,6 @@ func testAccCheckSchemaExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Schema not found: %s", name)
 		}
 		_, err := materialize.ScanSchema(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckSchemaDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP SCHEMA "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_secret_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_secret_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantSecretDefaultPrivilege_basic(t *testing.T) {
@@ -46,8 +43,8 @@ func TestAccGrantSecretDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantSecretDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSecretDefaultPrivilegeExists("materialize_secret_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantSecretDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("SECRET", "materialize_secret_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("SECRET", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -72,43 +69,4 @@ resource "materialize_secret_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantSecretDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "SECRET", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantSecretDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON SECRETS FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_secret_grant_test.go
+++ b/pkg/provider/acceptance_secret_grant_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantSecret_basic(t *testing.T) {
@@ -25,7 +23,13 @@ func TestAccGrantSecret_basic(t *testing.T) {
 			{
 				Config: testAccGrantSecretResource(roleName, secretName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSecretExists("materialize_secret_grant.secret_grant", roleName, secretName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(
+						materialize.ObjectSchemaStruct{
+							ObjectType:   "SECRET",
+							Name:         secretName,
+							SchemaName:   schemaName,
+							DatabaseName: databaseName,
+						}, "materialize_secret_grant.secret_grant", roleName, privilege),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "secret_name", secretName),
@@ -43,6 +47,14 @@ func TestAccGrantSecret_disappears(t *testing.T) {
 	secretName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	o := materialize.ObjectSchemaStruct{
+		ObjectType:   "SECRET",
+		Name:         secretName,
+		SchemaName:   schemaName,
+		DatabaseName: databaseName,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -51,8 +63,8 @@ func TestAccGrantSecret_disappears(t *testing.T) {
 			{
 				Config: testAccGrantSecretResource(roleName, secretName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantSecretExists("materialize_secret_grant.secret_grant", roleName, secretName, schemaName, databaseName, privilege),
-					testAccCheckGrantSecretRevoked(roleName, secretName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(o, "materialize_secret_grant.secret_grant", roleName, privilege),
+					testAccCheckGrantRevoked(o, roleName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -92,44 +104,4 @@ resource "materialize_secret_grant" "secret_grant" {
 	secret_name   = materialize_secret.test.name
 }
 `, roleName, databaseName, schemaName, secretName, privilege)
-}
-
-func testAccCheckGrantSecretExists(grantName, roleName, secretName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		o := materialize.ObjectSchemaStruct{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
-		id, err := materialize.SecretId(db, o)
-		if err != nil {
-			return err
-		}
-
-		roleId, err := materialize.RoleId(db, roleName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanPrivileges(db, "SECRET", id)
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g)
-		if !materialize.HasPrivilege(privilegeMap[roleId], privilege) {
-			return fmt.Errorf("secret object %s does not include privilege %s", g, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantSecretRevoked(roleName, secretName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`REVOKE %s ON SECRET "%s"."%s"."%s" FROM "%s";`, privilege, databaseName, schemaName, secretName, roleName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_secret_test.go
+++ b/pkg/provider/acceptance_secret_test.go
@@ -84,7 +84,12 @@ func TestAccSecret_disappears(t *testing.T) {
 				Config: testAccSecretResource(roleName, secretName, "sekret", secret2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists("materialize_secret.test"),
-					testAccCheckSecretDisappears(secretName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "SECRET",
+							Name:       secretName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -121,14 +126,6 @@ func testAccCheckSecretExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("secret not found: %s", name)
 		}
 		_, err := materialize.ScanSecret(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckSecretDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP SECRET "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -94,7 +94,12 @@ func TestAccSinkKafka_disappears(t *testing.T) {
 				Config: testAccSinkKafkaResource(roleName, connName, tableName, sinkName, sink2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkKafkaExists("materialize_sink_kafka.test"),
-					testAccCheckSinkKafkaDisappears(sinkName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "SINK",
+							Name:       sinkName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -97,7 +97,12 @@ func TestAccSourceKafka_disappears(t *testing.T) {
 				Config: testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceKafkaExists("materialize_source_kafka.test"),
-					testAccCheckSourceKafkaDisappears(sourceName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "SOURCE",
+							Name:       sourceName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -169,14 +174,6 @@ func testAccCheckSourceKafkaExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("source kafka not found: %s", name)
 		}
 		_, err := materialize.ScanSource(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckSourceKafkaDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP SOURCE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -102,7 +102,12 @@ func TestAccSourcePostgres_disappears(t *testing.T) {
 				Config: testAccSourcePostgresResource(roleName, secretName, connName, sourceName, source2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourcePostgresExists("materialize_source_postgres.test"),
-					testAccCheckSourcePostgresDisappears(sourceName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "SOURCE",
+							Name:       sourceName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -185,14 +190,6 @@ func testAccCheckSourcePostgresExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("source postgres not found: %s", name)
 		}
 		_, err := materialize.ScanSource(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckSourcePostgresDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP SOURCE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_table_grant_test.go
+++ b/pkg/provider/acceptance_table_grant_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantTable_basic(t *testing.T) {
@@ -25,7 +23,13 @@ func TestAccGrantTable_basic(t *testing.T) {
 			{
 				Config: testAccGrantTableResource(roleName, tableName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantTableExists("materialize_table_grant.table_grant", roleName, tableName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(
+						materialize.ObjectSchemaStruct{
+							ObjectType:   "TABLE",
+							Name:         tableName,
+							SchemaName:   schemaName,
+							DatabaseName: databaseName,
+						}, "materialize_table_grant.table_grant", roleName, privilege),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "table_name", tableName),
@@ -43,6 +47,14 @@ func TestAccGrantTable_disappears(t *testing.T) {
 	tableName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	o := materialize.ObjectSchemaStruct{
+		ObjectType:   "TABLE",
+		Name:         tableName,
+		SchemaName:   schemaName,
+		DatabaseName: databaseName,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -51,8 +63,8 @@ func TestAccGrantTable_disappears(t *testing.T) {
 			{
 				Config: testAccGrantTableResource(roleName, tableName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantTableExists("materialize_table_grant.table_grant", roleName, tableName, schemaName, databaseName, privilege),
-					testAccCheckGrantTableRevoked(roleName, tableName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(o, "materialize_table_grant.table_grant", roleName, privilege),
+					testAccCheckGrantRevoked(o, roleName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -95,44 +107,4 @@ resource "materialize_table_grant" "table_grant" {
 	table_name    = materialize_table.test.name
 }
 `, roleName, databaseName, schemaName, tableName, privilege)
-}
-
-func testAccCheckGrantTableExists(grantName, roleName, tableName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		o := materialize.ObjectSchemaStruct{Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
-		id, err := materialize.TableId(db, o)
-		if err != nil {
-			return err
-		}
-
-		roleId, err := materialize.RoleId(db, roleName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanPrivileges(db, "TABLE", id)
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g)
-		if !materialize.HasPrivilege(privilegeMap[roleId], privilege) {
-			return fmt.Errorf("schema object %s does not include privilege %s", g, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantTableRevoked(roleName, tableName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`REVOKE %s ON TABLE "%s"."%s"."%s" FROM "%s";`, privilege, databaseName, schemaName, tableName, roleName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_table_test.go
+++ b/pkg/provider/acceptance_table_test.go
@@ -92,7 +92,12 @@ func TestAccTable_disappears(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_table.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, tableName)),
 					resource.TestCheckResourceAttr("materialize_table.test", "column.#", "3"),
-					testAccCheckTableDisappears(tableName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "TABLE",
+							Name:       tableName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -145,14 +150,6 @@ func testAccCheckTableExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Table not found: %s", name)
 		}
 		_, err := materialize.ScanTable(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckTableDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP TABLE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_type_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_type_grant_default_privilege_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantTypeDefaultPrivilege_basic(t *testing.T) {
@@ -46,8 +43,8 @@ func TestAccGrantTypeDefaultPrivilege_disappears(t *testing.T) {
 			{
 				Config: testAccGrantTypeDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantTypeDefaultPrivilegeExists("materialize_type_grant_default_privilege.test", granteeName, targetName, privilege),
-					testAccCheckGrantTypeDefaultPrivilegeRevoked(granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeExists("TYPE", "materialize_type_grant_default_privilege.test", granteeName, targetName, privilege),
+					testAccCheckGrantDefaultPrivilegeRevoked("TYPE", granteeName, targetName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -72,43 +69,4 @@ resource "materialize_type_grant_default_privilege" "test" {
 	target_role_name = materialize_role.test_target.name
 }
 `, granteeName, targetName, privilege)
-}
-
-func testAccCheckGrantTypeDefaultPrivilegeExists(grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		granteeId, err := materialize.RoleId(db, grantName)
-		if err != nil {
-			return err
-		}
-
-		targetId, err := materialize.RoleId(db, targetName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanDefaultPrivilege(db, "TYPE", granteeId, targetId, "", "")
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
-		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
-			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantTypeDefaultPrivilegeRevoked(granteeName, targetName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON TYPES FROM %[3]s;`, targetName, privilege, granteeName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_type_grant_test.go
+++ b/pkg/provider/acceptance_type_grant_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/jmoiron/sqlx"
 )
 
 func TestAccGrantType_basic(t *testing.T) {
@@ -25,7 +23,13 @@ func TestAccGrantType_basic(t *testing.T) {
 			{
 				Config: testAccGrantTypeResource(roleName, typeName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantTypeExists("materialize_type_grant.type_grant", roleName, typeName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(
+						materialize.ObjectSchemaStruct{
+							ObjectType:   "TYPE",
+							Name:         typeName,
+							SchemaName:   schemaName,
+							DatabaseName: databaseName,
+						}, "materialize_type_grant.type_grant", roleName, privilege),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "type_name", typeName),
@@ -43,6 +47,14 @@ func TestAccGrantType_disappears(t *testing.T) {
 	typeName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	o := materialize.ObjectSchemaStruct{
+		ObjectType:   "TYPE",
+		Name:         typeName,
+		SchemaName:   schemaName,
+		DatabaseName: databaseName,
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -51,8 +63,8 @@ func TestAccGrantType_disappears(t *testing.T) {
 			{
 				Config: testAccGrantTypeResource(roleName, typeName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantTypeExists("materialize_type_grant.type_grant", roleName, typeName, schemaName, databaseName, privilege),
-					testAccCheckGrantTypeRevoked(roleName, typeName, schemaName, databaseName, privilege),
+					testAccCheckGrantExists(o, "materialize_type_grant.type_grant", roleName, privilege),
+					testAccCheckGrantRevoked(o, roleName, privilege),
 				),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
@@ -94,44 +106,4 @@ resource "materialize_type_grant" "type_grant" {
 	type_name     = materialize_type.test.name
 }
 `, roleName, databaseName, schemaName, typeName, privilege)
-}
-
-func testAccCheckGrantTypeExists(grantName, roleName, typeName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, ok := s.RootModule().Resources[grantName]
-		if !ok {
-			return fmt.Errorf("grant not found")
-		}
-
-		o := materialize.ObjectSchemaStruct{Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
-		id, err := materialize.TypeId(db, o)
-		if err != nil {
-			return err
-		}
-
-		roleId, err := materialize.RoleId(db, roleName)
-		if err != nil {
-			return err
-		}
-
-		g, err := materialize.ScanPrivileges(db, "TYPE", id)
-		if err != nil {
-			return err
-		}
-
-		privilegeMap := materialize.ParsePrivileges(g)
-		if !materialize.HasPrivilege(privilegeMap[roleId], privilege) {
-			return fmt.Errorf("type object %s does not include privilege %s", g, privilege)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGrantTypeRevoked(roleName, typeName, schemaName, databaseName, privilege string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`REVOKE %s ON TYPE "%s"."%s"."%s" FROM "%s";`, privilege, databaseName, schemaName, typeName, roleName))
-		return err
-	}
 }

--- a/pkg/provider/acceptance_type_test.go
+++ b/pkg/provider/acceptance_type_test.go
@@ -88,7 +88,12 @@ func TestAccType_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTypeExists("materialize_type.test"),
 					resource.TestCheckResourceAttr("materialize_type.test", "name", typeName),
-					testAccCheckTypeDisappears(typeName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "TYPE",
+							Name:       typeName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -129,14 +134,6 @@ func testAccCheckTypeExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Type not found: %s", name)
 		}
 		_, err := materialize.ScanType(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckTypeDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP TYPE "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/acceptance_view_test.go
+++ b/pkg/provider/acceptance_view_test.go
@@ -86,7 +86,12 @@ func TestAccView_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckViewExists("materialize_view.test"),
 					resource.TestCheckResourceAttr("materialize_view.test", "name", viewName),
-					testAccCheckViewDisappears(viewName),
+					testAccCheckObjectDisappears(
+						materialize.ObjectSchemaStruct{
+							ObjectType: "VIEW",
+							Name:       viewName,
+						},
+					),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -123,14 +128,6 @@ func testAccCheckViewExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("View not found: %s", name)
 		}
 		_, err := materialize.ScanView(db, r.Primary.ID)
-		return err
-	}
-}
-
-func testAccCheckViewDisappears(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*sqlx.DB)
-		_, err := db.Exec(fmt.Sprintf(`DROP VIEW "%s";`, name))
 		return err
 	}
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +41,93 @@ var testAccProviderFactories = map[string]func() (*schema.Provider, error){
 
 func testAccPreCheck(t *testing.T) {
 
+}
+
+func testAccCheckObjectDisappears(object materialize.ObjectSchemaStruct) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db := testAccProvider.Meta().(*sqlx.DB)
+		_, err := db.Exec(fmt.Sprintf(`DROP %[1]s %[2]s;`, object.ObjectType, object.QualifiedName()))
+		return err
+	}
+}
+
+func testAccCheckGrantRevoked(object materialize.ObjectSchemaStruct, roleName, privilege string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db := testAccProvider.Meta().(*sqlx.DB)
+		_, err := db.Exec(fmt.Sprintf(
+			`REVOKE %[1]s ON %[2]s %[3]s FROM "%[4]s";`,
+			privilege, object.ObjectType, object.QualifiedName(), roleName,
+		))
+		return err
+	}
+}
+
+func testAccCheckGrantExists(object materialize.ObjectSchemaStruct, grantName, roleName, privilege string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db := testAccProvider.Meta().(*sqlx.DB)
+		_, ok := s.RootModule().Resources[grantName]
+		if !ok {
+			return fmt.Errorf("grant not found")
+		}
+
+		id, err := materialize.ObjectId(db, object)
+		if err != nil {
+			return err
+		}
+
+		roleId, err := materialize.RoleId(db, roleName)
+		if err != nil {
+			return err
+		}
+
+		g, err := materialize.ScanPrivileges(db, object.ObjectType, id)
+		if err != nil {
+			return err
+		}
+
+		privilegeMap := materialize.ParsePrivileges(g)
+		if !materialize.HasPrivilege(privilegeMap[roleId], privilege) {
+			return fmt.Errorf("object %s does not include privilege %s", g, privilege)
+		}
+		return nil
+	}
+}
+
+func testAccCheckGrantDefaultPrivilegeRevoked(objectType, granteeName, targetName, privilege string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db := testAccProvider.Meta().(*sqlx.DB)
+		_, err := db.Exec(fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %[1]s REVOKE %[2]s ON %[3]sS FROM %[4]s;`, targetName, privilege, objectType, granteeName))
+		return err
+	}
+}
+
+func testAccCheckGrantDefaultPrivilegeExists(objectType, grantName, granteeName, targetName, privilege string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db := testAccProvider.Meta().(*sqlx.DB)
+		_, ok := s.RootModule().Resources[grantName]
+		if !ok {
+			return fmt.Errorf("default grant not found")
+		}
+
+		granteeId, err := materialize.RoleId(db, grantName)
+		if err != nil {
+			return err
+		}
+
+		targetId, err := materialize.RoleId(db, targetName)
+		if err != nil {
+			return err
+		}
+
+		g, err := materialize.ScanDefaultPrivilege(db, objectType, granteeId, targetId, "", "")
+		if err != nil {
+			return err
+		}
+
+		privilegeMap := materialize.ParsePrivileges(g[0].Privileges.String)
+		if !materialize.HasPrivilege(privilegeMap[granteeId], privilege) {
+			return fmt.Errorf("default privilege %s does not include privilege %s", g[0].Privileges.String, privilege)
+		}
+		return nil
+	}
 }

--- a/pkg/resources/resource_grant_cluster.go
+++ b/pkg/resources/resource_grant_cluster.go
@@ -52,9 +52,9 @@ func grantClusterCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	privilege := d.Get("privilege").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type: "CLUSTER",
-		Name: clusterName,
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType: "CLUSTER",
+		Name:       clusterName,
 	}
 
 	b := materialize.NewPrivilegeBuilder(meta.(*sqlx.DB), roleName, privilege, obj)
@@ -70,11 +70,13 @@ func grantClusterCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -88,9 +90,9 @@ func grantClusterDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type: "CLUSTER",
-			Name: clusterName,
+		materialize.ObjectSchemaStruct{
+			ObjectType: "CLUSTER",
+			Name:       clusterName,
 		},
 	)
 

--- a/pkg/resources/resource_grant_connection.go
+++ b/pkg/resources/resource_grant_connection.go
@@ -66,8 +66,8 @@ func grantConnectionCreate(ctx context.Context, d *schema.ResourceData, meta int
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "CONNECTION",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "CONNECTION",
 		Name:         connectionName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantConnectionCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantConnectionDelete(ctx context.Context, d *schema.ResourceData, meta int
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "CONNECTION",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "CONNECTION",
 			Name:         connectionName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_connection_default_privilege.go
+++ b/pkg/resources/resource_grant_connection_default_privilege.go
@@ -62,12 +62,13 @@ func GrantConnectionDefaultPrivilege() *schema.Resource {
 }
 
 func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	granteenName := d.Get("grantee_name").(string)
+	granteeName := d.Get("grantee_name").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteenName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteeName, privilege)
 
 	var targetRole, database, schema string
+
 	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
 		targetRole = v.(string)
 		b.TargetRole(targetRole)
@@ -88,12 +89,37 @@ func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	// set id
-	i, err := materialize.DefaultPrivilegeId(meta.(*sqlx.DB), "CONNECTION", granteenName, targetRole, database, schema, privilege)
+	// Query ids
+	gId, err := materialize.RoleId(meta.(*sqlx.DB), granteeName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	var tId, dId, sId string
+
+	if targetRole != "" {
+		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if database != "" {
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if schema != "" {
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	key := b.GrantKey("CONNECTION", gId, tId, dId, sId, privilege)
+	d.SetId(key)
 
 	return grantDefaultPrivilegeRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_grant_database.go
+++ b/pkg/resources/resource_grant_database.go
@@ -52,9 +52,9 @@ func grantDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	privilege := d.Get("privilege").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type: "DATABASE",
-		Name: databaseName,
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType: "DATABASE",
+		Name:       databaseName,
 	}
 
 	b := materialize.NewPrivilegeBuilder(meta.(*sqlx.DB), roleName, privilege, obj)
@@ -70,11 +70,13 @@ func grantDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -88,9 +90,9 @@ func grantDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type: "DATABASE",
-			Name: databaseName,
+		materialize.ObjectSchemaStruct{
+			ObjectType: "DATABASE",
+			Name:       databaseName,
 		},
 	)
 

--- a/pkg/resources/resource_grant_materialized_view.go
+++ b/pkg/resources/resource_grant_materialized_view.go
@@ -66,8 +66,8 @@ func grantMaterializedViewCreate(ctx context.Context, d *schema.ResourceData, me
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "MATERIALIZED VIEW",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "MATERIALIZED VIEW",
 		Name:         mviewName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantMaterializedViewCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantMaterializedViewDelete(ctx context.Context, d *schema.ResourceData, me
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "MATERIALIZED VIEW",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "MATERIALIZED VIEW",
 			Name:         mviewName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_role.go
+++ b/pkg/resources/resource_grant_role.go
@@ -99,11 +99,18 @@ func grantRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.RolePrivilegeId(meta.(*sqlx.DB), roleName, memberName)
+	rId, err := materialize.RoleId(meta.(*sqlx.DB), roleName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	mId, err := materialize.RoleId(meta.(*sqlx.DB), memberName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	key := b.GrantKey(rId, mId)
+	d.SetId(key)
 
 	return grantRoleRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_grant_schema.go
+++ b/pkg/resources/resource_grant_schema.go
@@ -59,8 +59,8 @@ func grantSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "SCHEMA",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "SCHEMA",
 		Name:         schemaName,
 		DatabaseName: databaseName,
 	}
@@ -78,11 +78,13 @@ func grantSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -97,8 +99,8 @@ func grantSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "SCHEMA",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "SCHEMA",
 			Name:         schemaName,
 			DatabaseName: databaseName,
 		},

--- a/pkg/resources/resource_grant_secret.go
+++ b/pkg/resources/resource_grant_secret.go
@@ -66,8 +66,8 @@ func grantSecretCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "SECRET",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "SECRET",
 		Name:         secretName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantSecretCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantSecretDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "SECRET",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "SECRET",
 			Name:         secretName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_secret_default_privilege.go
+++ b/pkg/resources/resource_grant_secret_default_privilege.go
@@ -62,10 +62,10 @@ func GrantSecretDefaultPrivilege() *schema.Resource {
 }
 
 func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	granteenName := d.Get("grantee_name").(string)
+	granteeName := d.Get("grantee_name").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteenName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteeName, privilege)
 
 	var targetRole, database, schema string
 	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
@@ -88,12 +88,37 @@ func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	// set id
-	i, err := materialize.DefaultPrivilegeId(meta.(*sqlx.DB), "SECRET", granteenName, targetRole, database, schema, privilege)
+	// Query ids
+	gId, err := materialize.RoleId(meta.(*sqlx.DB), granteeName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	var tId, dId, sId string
+
+	if targetRole != "" {
+		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if database != "" {
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if schema != "" {
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	key := b.GrantKey("SECRET", gId, tId, dId, sId, privilege)
+	d.SetId(key)
 
 	return grantDefaultPrivilegeRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_grant_source.go
+++ b/pkg/resources/resource_grant_source.go
@@ -66,8 +66,8 @@ func grantSourceCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "SOURCE",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "SOURCE",
 		Name:         sourceName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantSourceCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantSourceDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "SOURCE",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "SOURCE",
 			Name:         sourceName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -99,11 +99,13 @@ func grantSystemPrivilegeCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.SystemPrivilegeId(meta.(*sqlx.DB), roleName, privilege)
+	rId, err := materialize.RoleId(meta.(*sqlx.DB), roleName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(rId, privilege)
+	d.SetId(key)
 
 	return grantSystemPrivilegeRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_grant_table.go
+++ b/pkg/resources/resource_grant_table.go
@@ -66,8 +66,8 @@ func grantTableCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "TABLE",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "TABLE",
 		Name:         tableName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantTableCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantTableDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "TABLE",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "TABLE",
 			Name:         tableName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_table_default_privilege.go
+++ b/pkg/resources/resource_grant_table_default_privilege.go
@@ -62,10 +62,10 @@ func GrantTableDefaultPrivilege() *schema.Resource {
 }
 
 func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	granteenName := d.Get("grantee_name").(string)
+	granteeName := d.Get("grantee_name").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteenName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteeName, privilege)
 
 	var targetRole, database, schema string
 	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
@@ -88,12 +88,37 @@ func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	// set id
-	i, err := materialize.DefaultPrivilegeId(meta.(*sqlx.DB), "TABLE", granteenName, targetRole, database, schema, privilege)
+	// Query ids
+	gId, err := materialize.RoleId(meta.(*sqlx.DB), granteeName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	var tId, dId, sId string
+
+	if targetRole != "" {
+		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if database != "" {
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if schema != "" {
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	key := b.GrantKey("TABLE", gId, tId, dId, sId, privilege)
+	d.SetId(key)
 
 	return grantDefaultPrivilegeRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_grant_type.go
+++ b/pkg/resources/resource_grant_type.go
@@ -66,8 +66,8 @@ func grantTypeCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "TYPE",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "TYPE",
 		Name:         typeName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantTypeCreate(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantTypeDelete(ctx context.Context, d *schema.ResourceData, meta interface
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "TYPE",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "TYPE",
 			Name:         typeName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_type_default_privilege.go
+++ b/pkg/resources/resource_grant_type_default_privilege.go
@@ -62,10 +62,10 @@ func GrantTypeDefaultPrivilege() *schema.Resource {
 }
 
 func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	granteenName := d.Get("grantee_name").(string)
+	granteeName := d.Get("grantee_name").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteenName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteeName, privilege)
 
 	var targetRole, database, schema string
 	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
@@ -88,12 +88,37 @@ func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	// set id
-	i, err := materialize.DefaultPrivilegeId(meta.(*sqlx.DB), "TYPE", granteenName, targetRole, database, schema, privilege)
+	// Query ids
+	gId, err := materialize.RoleId(meta.(*sqlx.DB), granteeName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	var tId, dId, sId string
+
+	if targetRole != "" {
+		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if database != "" {
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if schema != "" {
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	key := b.GrantKey("TYPE", gId, tId, dId, sId, privilege)
+	d.SetId(key)
 
 	return grantDefaultPrivilegeRead(ctx, d, meta)
 }

--- a/pkg/resources/resource_view_grant.go
+++ b/pkg/resources/resource_view_grant.go
@@ -66,8 +66,8 @@ func grantViewCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.PrivilegeObjectStruct{
-		Type:         "VIEW",
+	obj := materialize.ObjectSchemaStruct{
+		ObjectType:   "VIEW",
 		Name:         viewName,
 		SchemaName:   schemaName,
 		DatabaseName: databaseName,
@@ -86,11 +86,13 @@ func grantViewCreate(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
-	i, err := materialize.PrivilegeId(meta.(*sqlx.DB), obj, roleId, privilege)
+	i, err := materialize.ObjectId(meta.(*sqlx.DB), obj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.SetId(i)
+
+	key := b.GrantKey(i, roleId, privilege)
+	d.SetId(key)
 
 	return grantRead(ctx, d, meta)
 }
@@ -106,8 +108,8 @@ func grantViewDelete(ctx context.Context, d *schema.ResourceData, meta interface
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.PrivilegeObjectStruct{
-			Type:         "VIEW",
+		materialize.ObjectSchemaStruct{
+			ObjectType:   "VIEW",
 			Name:         viewName,
 			SchemaName:   schemaName,
 			DatabaseName: databaseName,


### PR DESCRIPTION
Cleanup and refactor following the giant RBAC PR https://github.com/MaterializeInc/terraform-provider-materialize/pull/218. A lot of the acceptance testing (especially around grants) were redundant. The privileges also introduced a new struct `PrivilegeObjectStruct` which was very similar to the existing struct we use for materialize objects. Removing that as it was confusing and made it harder to use functionality across objects and privileges.