### PR TITLE
Fix identifier quoting

### DIFF
--- a/pkg/materialize/utils.go
+++ b/pkg/materialize/utils.go
@@ -4,18 +4,12 @@ import (
 	"strings"
 )
 
-func QuoteString(input string) (output string) {
-	output = "'" + strings.Replace(input, "'", "''", -1) + "'"
-	return
+func QuoteString(input string) string {
+	return "'" + strings.Replace(input, "'", "''", -1) + "'"
 }
 
-func QuoteIdentifier(input string) (output string) {
-	parts := strings.Split(input, ".")
-	for i, p := range parts {
-		parts[i] = `"` + strings.Replace(p, `"`, `""`, -1) + `"`
-	}
-	output = strings.Join(parts, ".")
-	return
+func QuoteIdentifier(input string) string {
+	return `"` + strings.Replace(input, `"`, `""`, -1) + `"`
 }
 
 func QualifiedName(fields ...string) string {

--- a/pkg/provider/acceptance_database_test.go
+++ b/pkg/provider/acceptance_database_test.go
@@ -13,27 +13,33 @@ import (
 )
 
 func TestAccDatabase_basic(t *testing.T) {
-	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	database2Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDatabaseResource(roleName, databaseName, database2Name, roleName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDatabaseExists("materialize_database.test"),
-					resource.TestCheckResourceAttr("materialize_database.test", "name", databaseName),
-					resource.TestCheckResourceAttr("materialize_database.test", "ownership_role", "mz_system"),
-					testAccCheckDatabaseExists("materialize_database.test_role"),
-					resource.TestCheckResourceAttr("materialize_database.test_role", "name", database2Name),
-					resource.TestCheckResourceAttr("materialize_database.test_role", "ownership_role", roleName),
-				),
-			},
-		},
-	})
+	for _, roleName := range []string{
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlpha) + "@materialize.com",
+	} {
+		t.Run(fmt.Sprintf("roleName=%s", roleName), func(t *testing.T) {
+			databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+			database2Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+			resource.ParallelTest(t, resource.TestCase{
+				PreCheck:          func() { testAccPreCheck(t) },
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy:      nil,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDatabaseResource(roleName, databaseName, database2Name, roleName),
+						Check: resource.ComposeTestCheckFunc(
+							testAccCheckDatabaseExists("materialize_database.test"),
+							resource.TestCheckResourceAttr("materialize_database.test", "name", databaseName),
+							resource.TestCheckResourceAttr("materialize_database.test", "ownership_role", "mz_system"),
+							testAccCheckDatabaseExists("materialize_database.test_role"),
+							resource.TestCheckResourceAttr("materialize_database.test_role", "name", database2Name),
+							resource.TestCheckResourceAttr("materialize_database.test_role", "ownership_role", roleName),
+						),
+					},
+				},
+			})
+		})
+	}
 }
 
 func TestAccDatabase_disappears(t *testing.T) {

--- a/pkg/resources/resource_grant_database_test.go
+++ b/pkg/resources/resource_grant_database_test.go
@@ -50,6 +50,25 @@ func TestResourceGrantDatabaseCreate(t *testing.T) {
 	})
 }
 
+func TestResourceGrantDatabaseCreateEmail(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":     "joe@materialize.com",
+		"privilege":     "CREATE",
+		"database_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantDatabase().Schema, in)
+	r.NotNil(d)
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`GRANT CREATE ON DATABASE "materialize" TO "joe@materialize.com";`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+	})
+}
+
 func TestResourceGrantDatabaseDelete(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
The `QuoteIdentifier` function was incorrectly splitting identifiers on `.` and then escaping each component. This appears to be cruft left over from an earlier version of the Terraform provider, which was less rigorous in its handling of IDs.

This is a fix for the follow-up report on #233, in which role grants to roles that contained dots (like `joe@materialize.com`) were failing.