### PR TITLE
Remove Kafka Source Primary Key

### DIFF
--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -42,7 +42,6 @@ type SourceKafkaBuilder struct {
 	keyFormat        SourceFormatSpecStruct
 	valueFormat      SourceFormatSpecStruct
 	envelope         KafkaSourceEnvelopeStruct
-	primaryKey       []string
 	startOffset      []int
 	startTimestamp   int
 	exposeProgress   string
@@ -117,11 +116,6 @@ func (b *SourceKafkaBuilder) KeyFormat(k SourceFormatSpecStruct) *SourceKafkaBui
 
 func (b *SourceKafkaBuilder) ValueFormat(v SourceFormatSpecStruct) *SourceKafkaBuilder {
 	b.valueFormat = v
-	return b
-}
-
-func (b *SourceKafkaBuilder) PrimaryKey(p []string) *SourceKafkaBuilder {
-	b.primaryKey = p
 	return b
 }
 
@@ -292,12 +286,6 @@ func (b *SourceKafkaBuilder) Create() error {
 
 	if b.valueFormat.Text {
 		q.WriteString(` VALUE FORMAT TEXT`)
-	}
-
-	// Key Constraint
-	if len(b.primaryKey) > 0 {
-		k := strings.Join(b.primaryKey[:], ", ")
-		q.WriteString(fmt.Sprintf(` PRIMARY KEY (%s) NOT ENFORCED`, k))
 	}
 
 	// Time-based Offsets

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -109,13 +109,6 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 		Optional: true,
 		ForceNew: true,
 	},
-	"primary_key": {
-		Description: "Declare a set of columns as a primary key.",
-		Type:        schema.TypeList,
-		Elem:        &schema.Schema{Type: schema.TypeString},
-		Optional:    true,
-		ForceNew:    true,
-	},
 	"start_offset": {
 		Description: "Read partitions from the specified offset.",
 		Type:        schema.TypeList,
@@ -218,11 +211,6 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	if v, ok := d.GetOk("envelope"); ok {
 		envelope := materialize.GetSourceKafkaEnelopeStruct(v)
 		b.Envelope(envelope)
-	}
-
-	if v, ok := d.GetOk("primary_key"); ok {
-		pk := materialize.GetSliceValueString(v.([]interface{}))
-		b.PrimaryKey(pk)
 	}
 
 	if v, ok := d.GetOk("start_offset"); ok {

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -28,7 +28,6 @@ var inSourceKafka = map[string]interface{}{
 	"include_timestamp": true,
 	"format":            []interface{}{map[string]interface{}{"avro": []interface{}{map[string]interface{}{"value_strategy": "avro_key_fullname", "schema_registry_connection": []interface{}{map[string]interface{}{"name": "csr_conn", "database_name": "database", "schema_name": "schema"}}}}}},
 	"envelope":          []interface{}{map[string]interface{}{"upsert": true}},
-	"primary_key":       []interface{}{"key_1", "key_2", "key_3"},
 	"start_offset":      []interface{}{1, 2, 3},
 	"start_timestamp":   -1000,
 }
@@ -41,7 +40,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'topic', START TIMESTAMP -1000\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_conn" VALUE STRATEGY avro_key_fullname PRIMARY KEY \(key_1, key_2, key_3\) NOT ENFORCED START OFFSET \[1, 2, 3\] INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP ENVELOPE UPSERT WITH \(SIZE = 'small'\);`,
+			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'topic', START TIMESTAMP -1000\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_conn" VALUE STRATEGY avro_key_fullname START OFFSET \[1, 2, 3\] INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP ENVELOPE UPSERT WITH \(SIZE = 'small'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id


### PR DESCRIPTION
Remove `primary_key` as a valid attribute from the Kafka source resource.