### PR TITLE
Fix Removed Grants

### DIFF
--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -48,7 +49,9 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	privilege := d.Get("privilege").(string)
 
 	if !materialize.HasPrivilege(priviledgeMap[key.roleId], privilege) {
-		return diag.Errorf("%s: object does not contain privilege: %s", i, privilege)
+		log.Printf("[DEBUG] %s: object does not contain privilege: %s", i, privilege)
+		// Remove id from state
+		d.SetId("")
 	}
 
 	return nil

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -71,8 +72,9 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if !slices.Contains(mapping[mapKey], key.privilege) {
+		log.Printf("[DEBUG] %s: object does not contain privilege: %s", i, key.privilege)
+		// Remove id from state
 		d.SetId("")
-		return diag.Errorf("%s: %s default privilege does contain privilege %s", mapping, i, key.privilege)
 	}
 
 	d.SetId(i)

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -80,8 +81,9 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 	mapping, _ := materialize.ParseSystemPrivileges(privileges)
 
 	if !slices.Contains(mapping[key.roleId], key.privilege) {
+		log.Printf("[DEBUG] %s: object does not contain privilege: %s", i, key.privilege)
+		// Remove id from state
 		d.SetId("")
-		return diag.Errorf("system role does contain privilege %s", key.privilege)
 	}
 
 	d.SetId(i)


### PR DESCRIPTION
If a grant is removed outside of Terraform, it would lead to an error in subsequent plan/applies rather than recreating the grant.

New Workflow
1. Grant via `apply`
```
resource "materialize_table_grant" "table_grant_insert" {
  role_name     = materialize_role.role_1.name
  privilege     = "INSERT"
  database_name = materialize_table.simple_table.database_name
  schema_name   = materialize_table.simple_table.schema_name
  table_name    = materialize_table.simple_table.name
}
```
2. Manually remove grant
```
REVOKE INSERT ON TABLE example_database.example_schema.simple_table FROM "role-1";
```
3. On next plan/apply
```
Terraform will perform the following actions:

  # materialize_table_grant.table_grant_insert will be created
  + resource "materialize_table_grant" "table_grant_insert" {
      + database_name = "example_database"
      + id            = (known after apply)
      + privilege     = "INSERT"
      + role_name     = "role-1"
      + schema_name   = "example_schema"
      + table_name    = "simple_table"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Fix applies to object, system and default grants