### PR TITLE
Fix Default type grants case sensitivity

### DIFF
--- a/pkg/materialize/privilege_default_privilege.go
+++ b/pkg/materialize/privilege_default_privilege.go
@@ -116,7 +116,7 @@ var defaultPrivilegeQuery = NewBaseQuery(`
 
 func ScanDefaultPrivilege(conn *sqlx.DB, objectType, granteeId, targetRoleId, databaseId, schemaId string) ([]DefaultPrivilegeParams, error) {
 	p := map[string]string{
-		"mz_default_privileges.object_type": objectType,
+		"mz_default_privileges.object_type": strings.ToLower(objectType),
 		"mz_default_privileges.grantee":     granteeId,
 	}
 

--- a/pkg/resources/resource_grant_cluster_default_privilege_test.go
+++ b/pkg/resources/resource_grant_cluster_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantClusterDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'CLUSTER'
+			AND mz_default_privileges.object_type = 'cluster'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "CLUSTER")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "cluster")
 
 		if err := grantClusterDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_connection_default_privilege_test.go
+++ b/pkg/resources/resource_grant_connection_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantConnectionDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'CONNECTION'
+			AND mz_default_privileges.object_type = 'connection'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "CONNECTION")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "connection")
 
 		if err := grantConnectionDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_database_default_privilege_test.go
+++ b/pkg/resources/resource_grant_database_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantDatabaseDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'DATABASE'
+			AND mz_default_privileges.object_type = 'database'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "DATABASE")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "database")
 
 		if err := grantDatabaseDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -59,7 +59,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 	mapping, _ := materialize.ParseDefaultPrivileges(privileges)
 
 	mapKey := materialize.DefaultPrivilegeMapKey{
-		ObjectType: key.objectType, GranteeId: key.granteeId,
+		ObjectType: strings.ToLower(key.objectType), GranteeId: key.granteeId,
 	}
 
 	if key.databaseId != "" {
@@ -72,7 +72,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if !slices.Contains(mapping[mapKey], key.privilege) {
 		d.SetId("")
-		return diag.Errorf("%s: %s default privilege does contain privilege %s", mapping, i, key.privilege)
+		return diag.Errorf("%s: %s default privilege does not contain privilege %s", mapping, i, key.privilege)
 	}
 
 	d.SetId(i)

--- a/pkg/resources/resource_grant_schema_default_privilege_test.go
+++ b/pkg/resources/resource_grant_schema_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantSchemaDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'SCHEMA'
+			AND mz_default_privileges.object_type = 'schema'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "SCHEMA")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "schema")
 
 		if err := grantSchemaDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_secret_default_privilege_test.go
+++ b/pkg/resources/resource_grant_secret_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantSecretDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'SECRET'
+			AND mz_default_privileges.object_type = 'secret'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "SECRET")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "secret")
 
 		if err := grantSecretDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_table_default_privilege_test.go
+++ b/pkg/resources/resource_grant_table_default_privilege_test.go
@@ -39,9 +39,9 @@ func TestResourceGrantTableDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'TABLE'
+			AND mz_default_privileges.object_type = 'table'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "TABLE")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "table")
 
 		if err := grantTableDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_type_default_privilege_test.go
+++ b/pkg/resources/resource_grant_type_default_privilege_test.go
@@ -41,7 +41,7 @@ func TestResourceGrantTypeDefaultPrivilegeCreate(t *testing.T) {
 			WHERE mz_default_privileges.grantee = 'u1'
 			AND mz_default_privileges.object_type = 'type'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "TYPE")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "type")
 
 		if err := grantTypeDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_type_default_privilege_test.go
+++ b/pkg/resources/resource_grant_type_default_privilege_test.go
@@ -39,7 +39,7 @@ func TestResourceGrantTypeDefaultPrivilegeCreate(t *testing.T) {
 		// Query Params
 		qp := `
 			WHERE mz_default_privileges.grantee = 'u1'
-			AND mz_default_privileges.object_type = 'TYPE'
+			AND mz_default_privileges.object_type = 'type'
 			AND mz_default_privileges.role_id = 'u1'`
 		testhelpers.MockDefaultPrivilegeScan(mock, qp, "TYPE")
 

--- a/pkg/resources/resource_grant_type_default_privilege_test.go
+++ b/pkg/resources/resource_grant_type_default_privilege_test.go
@@ -41,7 +41,7 @@ func TestResourceGrantTypeDefaultPrivilegeCreate(t *testing.T) {
 			WHERE mz_default_privileges.grantee = 'u1'
 			AND mz_default_privileges.object_type = 'type'
 			AND mz_default_privileges.role_id = 'u1'`
-		testhelpers.MockDefaultPrivilegeScan(mock, qp, "type")
+		testhelpers.MockDefaultPrivilegeScan(mock, qp, "TYPE")
 
 		if err := grantTypeDefaultPrivilegeCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
It looks like that as stated in #246, the change to the `mz_default_privileges.object_type` value was causing an issue. 

We were generating the following query:

```sql
SELECT
                mz_default_privileges.object_type,
                mz_default_privileges.grantee AS grantee_id,
                mz_roles.name AS role_name,
                mz_default_privileges.database_id AS database_id,
                mz_default_privileges.schema_id AS schema_id,
                mz_default_privileges.privileges
        FROM mz_default_privileges
        LEFT JOIN mz_roles
                ON mz_default_privileges.role_id = mz_roles.id
        LEFT JOIN mz_schemas
                ON mz_default_privileges.schema_id = mz_schemas.id
        LEFT JOIN mz_databases
                ON mz_default_privileges.database_id = mz_databases.id WHERE mz_default_privileges.grantee = 'u42' AND mz_default_privileges.object_type = 'TYPE';
```

However, the `mz_default_privileges.object_type` value is stored in lowercase causing the problem.

Closes #246