### PR TITLE
Require `target_role_name` for Default Privileges

### DIFF
--- a/docs/resources/cluster_grant_default_privilege.md
+++ b/docs/resources/cluster_grant_default_privilege.md
@@ -28,9 +28,6 @@ resource "materialize_cluster_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
-
-### Optional
-
 - `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only

--- a/docs/resources/connection_grant_default_privilege.md
+++ b/docs/resources/connection_grant_default_privilege.md
@@ -30,12 +30,12 @@ resource "materialize_connection_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
 - `schema_name` (String) The default privilege will apply only to objects created in this schema, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/docs/resources/database_grant_default_privilege.md
+++ b/docs/resources/database_grant_default_privilege.md
@@ -29,11 +29,11 @@ resource "materialize_database_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/docs/resources/schema_grant_default_privilege.md
+++ b/docs/resources/schema_grant_default_privilege.md
@@ -30,12 +30,12 @@ resource "materialize_schema_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
 - `schema_name` (String) The default privilege will apply only to objects created in this schema, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/docs/resources/secret_grant_default_privilege.md
+++ b/docs/resources/secret_grant_default_privilege.md
@@ -30,12 +30,12 @@ resource "materialize_secret_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
 - `schema_name` (String) The default privilege will apply only to objects created in this schema, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/docs/resources/table_grant_default_privilege.md
+++ b/docs/resources/table_grant_default_privilege.md
@@ -30,12 +30,12 @@ resource "materialize_table_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
 - `schema_name` (String) The default privilege will apply only to objects created in this schema, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/docs/resources/type_grant_default_privilege.md
+++ b/docs/resources/type_grant_default_privilege.md
@@ -30,12 +30,12 @@ resource "materialize_type_grant_default_privilege" "example" {
 
 - `grantee_name` (String) The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.
 - `privilege` (String) The privilege to grant to the object.
+- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Optional
 
 - `database_name` (String) The default privilege will apply only to objects created in this database, if specified.
 - `schema_name` (String) The default privilege will apply only to objects created in this schema, if specified.
-- `target_role_name` (String) The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles
 
 ### Read-Only
 

--- a/pkg/materialize/privilege_default_privilege_test.go
+++ b/pkg/materialize/privilege_default_privilege_test.go
@@ -55,9 +55,9 @@ func TestParseDefaultPrivileges(t *testing.T) {
 
 func TestDefaultPrivilegeGrantSimple(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER DEFAULT PRIVILEGES FOR ROLE "emily" GRANT SELECT ON TABLES TO "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewDefaultPrivilegeBuilder(db, "TABLE", "joe", "SELECT")
+		b := NewDefaultPrivilegeBuilder(db, "TABLE", "joe", "emily", "SELECT")
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
 		}
@@ -68,8 +68,7 @@ func TestDefaultPrivilegeGrantComplex(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER DEFAULT PRIVILEGES FOR ROLE "interns" IN DATABASE "dev" GRANT ALL PRIVILEGES ON TABLES TO "intern_managers";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewDefaultPrivilegeBuilder(db, "TABLE", "intern_managers", "ALL PRIVILEGES")
-		b.TargetRole("interns")
+		b := NewDefaultPrivilegeBuilder(db, "TABLE", "intern_managers", "interns", "ALL PRIVILEGES")
 		b.DatabaseName("dev")
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
@@ -81,8 +80,7 @@ func TestDefaultPrivilegeRevokeSimple(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER DEFAULT PRIVILEGES FOR ROLE "developers" REVOKE USAGE ON SECRETS FROM "project_managers";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewDefaultPrivilegeBuilder(db, "SECRET", "project_managers", "USAGE")
-		b.TargetRole("developers")
+		b := NewDefaultPrivilegeBuilder(db, "SECRET", "project_managers", "developers", "USAGE")
 		if err := b.Revoke(); err != nil {
 			t.Fatal(err)
 		}
@@ -93,8 +91,7 @@ func TestDefaultPrivilegeGrantAllRoles(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO "managers";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewDefaultPrivilegeBuilder(db, "TABLE", "managers", "SELECT")
-		b.TargetRole("ALL")
+		b := NewDefaultPrivilegeBuilder(db, "TABLE", "managers", "ALL", "SELECT")
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/resource_grant_cluster_default_privilege.go
+++ b/pkg/resources/resource_grant_cluster_default_privilege.go
@@ -50,7 +50,7 @@ func GrantClusterDefaultPrivilege() *schema.Resource {
 
 func grantClusterDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CLUSTER", granteeName, targetName, privilege)
@@ -79,7 +79,7 @@ func grantClusterDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceD
 
 func grantClusterDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CLUSTER", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_connection_default_privilege.go
+++ b/pkg/resources/resource_grant_connection_default_privilege.go
@@ -62,7 +62,7 @@ func GrantConnectionDefaultPrivilege() *schema.Resource {
 
 func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteeName, targetName, privilege)
@@ -117,7 +117,7 @@ func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.Resour
 
 func grantConnectionDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_connection_default_privilege.go
+++ b/pkg/resources/resource_grant_connection_default_privilege.go
@@ -20,9 +20,8 @@ var grantConnectionDefaultPrivilegeSchema = map[string]*schema.Schema{
 	"target_role_name": {
 		Description: "The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
-		Computed:    true,
 	},
 	"database_name": {
 		Description: "The default privilege will apply only to objects created in this database, if specified.",
@@ -63,17 +62,12 @@ func GrantConnectionDefaultPrivilege() *schema.Resource {
 
 func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteeName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteeName, targetName, privilege)
 
-	var targetRole, database, schema string
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		targetRole = v.(string)
-		b.TargetRole(targetRole)
-	}
-
+	var database, schema string
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		database = v.(string)
 		b.DatabaseName(database)
@@ -95,15 +89,12 @@ func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	var tId, dId, sId string
-
-	if targetRole != "" {
-		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	tId, err := materialize.RoleId(meta.(*sqlx.DB), targetName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	var dId, sId string
 	if database != "" {
 		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
 		if err != nil {
@@ -126,13 +117,10 @@ func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.Resour
 
 func grantConnectionDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteenName, privilege)
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		b.TargetRole(v.(string))
-	}
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "CONNECTION", granteenName, targetName, privilege)
 
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		b.DatabaseName(v.(string))

--- a/pkg/resources/resource_grant_database_default_privilege.go
+++ b/pkg/resources/resource_grant_database_default_privilege.go
@@ -56,7 +56,7 @@ func GrantDatabaseDefaultPrivilege() *schema.Resource {
 
 func grantDatabaseDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "DATABASE", granteeName, targetName, privilege)
@@ -100,7 +100,7 @@ func grantDatabaseDefaultPrivilegeCreate(ctx context.Context, d *schema.Resource
 
 func grantDatabaseDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "DATABASE", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_schema_default_privilege.go
+++ b/pkg/resources/resource_grant_schema_default_privilege.go
@@ -62,7 +62,7 @@ func GrantSchemaDefaultPrivilege() *schema.Resource {
 
 func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteeName, targetName, privilege)
@@ -117,7 +117,7 @@ func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 func grantSchemaDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_schema_default_privilege.go
+++ b/pkg/resources/resource_grant_schema_default_privilege.go
@@ -20,9 +20,8 @@ var grantSchemaDefaultPrivilegeSchema = map[string]*schema.Schema{
 	"target_role_name": {
 		Description: "The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
-		Computed:    true,
 	},
 	"database_name": {
 		Description: "The default privilege will apply only to objects created in this database, if specified.",
@@ -63,16 +62,12 @@ func GrantSchemaDefaultPrivilege() *schema.Resource {
 
 func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteeName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteeName, targetName, privilege)
 
-	var targetRole, database, schema string
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		targetRole = v.(string)
-		b.TargetRole(targetRole)
-	}
-
+	var database, schema string
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		database = v.(string)
 		b.DatabaseName(database)
@@ -94,15 +89,12 @@ func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	var tId, dId, sId string
-
-	if targetRole != "" {
-		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	tId, err := materialize.RoleId(meta.(*sqlx.DB), targetName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	var dId, sId string
 	if database != "" {
 		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
 		if err != nil {
@@ -125,13 +117,10 @@ func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 func grantSchemaDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteenName, privilege)
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		b.TargetRole(v.(string))
-	}
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SCHEMA", granteenName, targetName, privilege)
 
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		b.DatabaseName(v.(string))

--- a/pkg/resources/resource_grant_secret_default_privilege.go
+++ b/pkg/resources/resource_grant_secret_default_privilege.go
@@ -20,9 +20,8 @@ var grantSecretDefaultPrivilegeSchema = map[string]*schema.Schema{
 	"target_role_name": {
 		Description: "The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
-		Computed:    true,
 	},
 	"database_name": {
 		Description: "The default privilege will apply only to objects created in this database, if specified.",
@@ -63,16 +62,12 @@ func GrantSecretDefaultPrivilege() *schema.Resource {
 
 func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteeName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteeName, targetName, privilege)
 
-	var targetRole, database, schema string
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		targetRole = v.(string)
-		b.TargetRole(targetRole)
-	}
-
+	var database, schema string
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		database = v.(string)
 		b.DatabaseName(database)
@@ -94,15 +89,12 @@ func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	var tId, dId, sId string
-
-	if targetRole != "" {
-		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	tId, err := materialize.RoleId(meta.(*sqlx.DB), targetName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	var dId, sId string
 	if database != "" {
 		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
 		if err != nil {
@@ -125,13 +117,10 @@ func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 func grantSecretDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteenName, privilege)
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		b.TargetRole(v.(string))
-	}
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteenName, targetName, privilege)
 
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		b.DatabaseName(v.(string))

--- a/pkg/resources/resource_grant_secret_default_privilege.go
+++ b/pkg/resources/resource_grant_secret_default_privilege.go
@@ -62,7 +62,7 @@ func GrantSecretDefaultPrivilege() *schema.Resource {
 
 func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteeName, targetName, privilege)
@@ -117,7 +117,7 @@ func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 func grantSecretDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "SECRET", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_table_default_privilege.go
+++ b/pkg/resources/resource_grant_table_default_privilege.go
@@ -62,7 +62,7 @@ func GrantTableDefaultPrivilege() *schema.Resource {
 
 func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteeName, targetName, privilege)
@@ -117,7 +117,7 @@ func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDat
 
 func grantTableDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_table_default_privilege.go
+++ b/pkg/resources/resource_grant_table_default_privilege.go
@@ -20,9 +20,8 @@ var grantTableDefaultPrivilegeSchema = map[string]*schema.Schema{
 	"target_role_name": {
 		Description: "The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
-		Computed:    true,
 	},
 	"database_name": {
 		Description: "The default privilege will apply only to objects created in this database, if specified.",
@@ -63,24 +62,20 @@ func GrantTableDefaultPrivilege() *schema.Resource {
 
 func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteeName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteeName, targetName, privilege)
 
-	var targetRole, database, schema string
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		targetRole = v.(string)
-		b.TargetRole(targetRole)
+	var database, schema string
+	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
+		database = v.(string)
+		b.DatabaseName(database)
 	}
 
 	if v, ok := d.GetOk("schema_name"); ok && v.(string) != "" {
 		schema = v.(string)
 		b.SchemaName(schema)
-	}
-
-	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
-		database = v.(string)
-		b.DatabaseName(database)
 	}
 
 	// create resource
@@ -94,15 +89,12 @@ func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	var tId, dId, sId string
-
-	if targetRole != "" {
-		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	tId, err := materialize.RoleId(meta.(*sqlx.DB), targetName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	var dId, sId string
 	if database != "" {
 		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
 		if err != nil {
@@ -125,13 +117,10 @@ func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDat
 
 func grantTableDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteenName, privilege)
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		b.TargetRole(v.(string))
-	}
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TABLE", granteenName, targetName, privilege)
 
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		b.DatabaseName(v.(string))

--- a/pkg/resources/resource_grant_type_default_privilege.go
+++ b/pkg/resources/resource_grant_type_default_privilege.go
@@ -62,7 +62,7 @@ func GrantTypeDefaultPrivilege() *schema.Resource {
 
 func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteeName, targetName, privilege)
@@ -117,7 +117,7 @@ func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData
 
 func grantTypeDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
-	targetName := d.Get("target_role").(string)
+	targetName := d.Get("target_role_name").(string)
 	privilege := d.Get("privilege").(string)
 
 	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteenName, targetName, privilege)

--- a/pkg/resources/resource_grant_type_default_privilege.go
+++ b/pkg/resources/resource_grant_type_default_privilege.go
@@ -20,9 +20,8 @@ var grantTypeDefaultPrivilegeSchema = map[string]*schema.Schema{
 	"target_role_name": {
 		Description: "The default privilege will apply to objects created by this role. If this is left blank, then the current role is assumed. Use the `PUBLIC` pseudo-role to target objects created by all roles. If using `ALL` will apply to objects created by all roles",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
-		Computed:    true,
 	},
 	"database_name": {
 		Description: "The default privilege will apply only to objects created in this database, if specified.",
@@ -63,16 +62,12 @@ func GrantTypeDefaultPrivilege() *schema.Resource {
 
 func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteeName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteeName, privilege)
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteeName, targetName, privilege)
 
-	var targetRole, database, schema string
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		targetRole = v.(string)
-		b.TargetRole(targetRole)
-	}
-
+	var database, schema string
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		database = v.(string)
 		b.DatabaseName(database)
@@ -94,15 +89,12 @@ func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	var tId, dId, sId string
-
-	if targetRole != "" {
-		tId, err = materialize.RoleId(meta.(*sqlx.DB), targetRole)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	tId, err := materialize.RoleId(meta.(*sqlx.DB), targetName)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	var dId, sId string
 	if database != "" {
 		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
 		if err != nil {
@@ -125,13 +117,10 @@ func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData
 
 func grantTypeDefaultPrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	granteenName := d.Get("grantee_name").(string)
+	targetName := d.Get("target_role").(string)
 	privilege := d.Get("privilege").(string)
 
-	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteenName, privilege)
-
-	if v, ok := d.GetOk("target_role_name"); ok && v.(string) != "" {
-		b.TargetRole(v.(string))
-	}
+	b := materialize.NewDefaultPrivilegeBuilder(meta.(*sqlx.DB), "TYPE", granteenName, targetName, privilege)
 
 	if v, ok := d.GetOk("database_name"); ok && v.(string) != "" {
 		b.DatabaseName(v.(string))


### PR DESCRIPTION
The target role name should be required for default privileges:

https://materializeinc.slack.com/archives/CU7ELJ6E9/p1690581681226289