### PR TITLE
Support `FOR SCHEMAS` for PostgreSQL Source

### DIFF
--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -58,14 +58,14 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 
 ### Optional
 
-- `cluster_name` (String) The cluster to maintain this sink. If not specified, the size option must be specified.
+- `cluster_name` (String) The cluster to maintain this sink. If not specified, the `size` option must be specified.
 - `database_name` (String) The identifier for the sink database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the sink schema. Defaults to `public`.
-- `size` (String) The size of the sink.
+- `size` (String) The size of the sink. If not specified, the `cluster_name` option must be specified.
 - `snapshot` (Boolean) Whether to emit the consolidated results of the query before the sink was created at the start of the sink.
 
 ### Read-Only

--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -54,7 +54,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 
 ### Optional
 
-- `cluster_name` (String) The cluster to maintain this source. If not specified, the size option must be specified.
+- `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `envelope` (Block List, Max: 1) How Materialize should interpret records (e.g. append-only, upsert).. (see [below for nested schema](#nestedblock--envelope))
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.
@@ -72,7 +72,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 - `key_format` (Block List, Max: 1) Set the key format explicitly. (see [below for nested schema](#nestedblock--key_format))
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
-- `size` (String) The size of the source.
+- `size` (String) The size of the source. If not specified, the `cluster_name` option must be specified.
 - `start_offset` (List of Number) Read partitions from the specified offset.
 - `start_timestamp` (Number) Use the specified value to set "START OFFSET" based on the Kafka timestamp.
 - `value_format` (Block List, Max: 1) Set the value format explicitly. (see [below for nested schema](#nestedblock--value_format))

--- a/docs/resources/source_load_generator.md
+++ b/docs/resources/source_load_generator.md
@@ -43,13 +43,13 @@ resource "materialize_source_load_generator" "example_source_load_generator" {
 ### Optional
 
 - `auction_options` (Block List) Auction Options. (see [below for nested schema](#nestedblock--auction_options))
-- `cluster_name` (String) The cluster to maintain this source. If not specified, the size option must be specified.
+- `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
 - `counter_options` (Block List) Counter Options. (see [below for nested schema](#nestedblock--counter_options))
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `marketing_options` (Block List) Marketing Options. (see [below for nested schema](#nestedblock--marketing_options))
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
-- `size` (String) The size of the source.
+- `size` (String) The size of the source. If not specified, the `cluster_name` option must be specified.
 - `tpch_options` (Block List) TPCH Options. (see [below for nested schema](#nestedblock--tpch_options))
 
 ### Read-Only

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -51,6 +51,7 @@ resource "materialize_source_postgres" "example_source_postgres" {
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.
 - `ownership_role` (String) The owernship role of the object.
+- `schema` (List of String) Creates subsources for specific schemas.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
 - `size` (String) The size of the source.
 - `table` (Block List) Creates subsources for specific tables. (see [below for nested schema](#nestedblock--table))

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -47,13 +47,13 @@ resource "materialize_source_postgres" "example_source_postgres" {
 
 ### Optional
 
-- `cluster_name` (String) The cluster to maintain this source. If not specified, the size option must be specified.
+- `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.
 - `ownership_role` (String) The owernship role of the object.
 - `schema` (List of String) Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
-- `size` (String) The size of the source.
+- `size` (String) The size of the source. If not specified, the `cluster_name` option must be specified.
 - `table` (Block List) Creates subsources for specific tables. If neither table or schema is specified, will default to ALL TABLES (see [below for nested schema](#nestedblock--table))
 - `text_columns` (List of String) Decode data as text for specific columns that contain PostgreSQL types that are unsupported in Materialize. Can only be updated in place when also updating a corresponding `table` attribute.
 

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -54,13 +54,8 @@ resource "materialize_source_postgres" "example_source_postgres" {
 - `schema` (List of String) Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
 - `size` (String) The size of the source.
-<<<<<<< HEAD
 - `table` (Block List) Creates subsources for specific tables. If neither table or schema is specified, will default to ALL TABLES (see [below for nested schema](#nestedblock--table))
-- `text_columns` (List of String) Decode data as text for specific columns that contain PostgreSQL types that are unsupported in Materialize.
-=======
-- `table` (Block List) Creates subsources for specific tables. (see [below for nested schema](#nestedblock--table))
 - `text_columns` (List of String) Decode data as text for specific columns that contain PostgreSQL types that are unsupported in Materialize. Can only be updated in place when also updating a corresponding `table` attribute.
->>>>>>> main
 
 ### Read-Only
 

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -51,10 +51,10 @@ resource "materialize_source_postgres" "example_source_postgres" {
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.
 - `ownership_role` (String) The owernship role of the object.
-- `schema` (List of String) Creates subsources for specific schemas.
+- `schema` (List of String) Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
 - `size` (String) The size of the source.
-- `table` (Block List) Creates subsources for specific tables. (see [below for nested schema](#nestedblock--table))
+- `table` (Block List) Creates subsources for specific tables. If neither table or schema is specified, will default to ALL TABLES (see [below for nested schema](#nestedblock--table))
 - `text_columns` (List of String) Decode data as text for specific columns that contain PostgreSQL types that are unsupported in Materialize.
 
 ### Read-Only

--- a/pkg/materialize/source_postgres.go
+++ b/pkg/materialize/source_postgres.go
@@ -15,6 +15,7 @@ type SourcePostgresBuilder struct {
 	publication        string
 	textColumns        []string
 	table              []TableStruct
+	schema             []string
 	exposeProgress     string
 }
 
@@ -55,6 +56,11 @@ func (b *SourcePostgresBuilder) Table(t []TableStruct) *SourcePostgresBuilder {
 	return b
 }
 
+func (b *SourcePostgresBuilder) Schema(t []string) *SourcePostgresBuilder {
+	b.schema = t
+	return b
+}
+
 func (b *SourcePostgresBuilder) ExposeProgress(e string) *SourcePostgresBuilder {
 	b.exposeProgress = e
 	return b
@@ -92,6 +98,9 @@ func (b *SourcePostgresBuilder) Create() error {
 			}
 		}
 		q.WriteString(`)`)
+	} else if len(b.schema) > 0 {
+		s := strings.Join(b.schema, ", ")
+		q.WriteString(fmt.Sprintf(` FOR SCHEMAS (%s)`, s))
 	} else {
 		q.WriteString(` FOR ALL TABLES`)
 	}

--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -27,6 +27,24 @@ func TestSourcePostgresAllTablesCreate(t *testing.T) {
 	})
 }
 
+func TestSourcePostgresSchemasCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" \(PUBLICATION 'mz_source'\) FOR SCHEMAS \(schema_1, schema_2\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		b := NewSourcePostgresBuilder(db, sourcePostgres)
+		b.ClusterName("cluster")
+		b.Schema([]string{"schema_1", "schema_2"})
+		b.PostgresConnection(IdentifierSchemaStruct{Name: "pg_connection", SchemaName: "schema", DatabaseName: "database"})
+		b.Publication("mz_source")
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestSourcePostgresSpecificTablesCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -17,24 +16,10 @@ var sinkKafkaSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("sink", false),
 	"database_name":      DatabaseNameSchema("sink", false),
 	"qualified_sql_name": QualifiedNameSchema("sink"),
-	"cluster_name": {
-		Description:  "The cluster to maintain this sink. If not specified, the size option must be specified.",
-		Type:         schema.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ExactlyOneOf: []string{"cluster_name", "size"},
-		ForceNew:     true,
-	},
-	"size": {
-		Description:  "The size of the sink.",
-		Type:         schema.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ExactlyOneOf: []string{"cluster_name", "size"},
-		ValidateFunc: validation.StringInSlice(append(sourceSizes, localSizes...), true),
-	},
-	"from":             IdentifierSchema("from", "The name of the source, table or materialized view you want to send to the sink.", true),
-	"kafka_connection": IdentifierSchema("kafka_connection", "The name of the Kafka connection to use in the sink.", true),
+	"cluster_name":       ObjectClusterNameSchema("sink"),
+	"size":               ObjectSizeSchema("sink"),
+	"from":               IdentifierSchema("from", "The name of the source, table or materialized view you want to send to the sink.", true),
+	"kafka_connection":   IdentifierSchema("kafka_connection", "The name of the Kafka connection to use in the sink.", true),
 	"topic": {
 		Description: "The Kafka topic you want to subscribe to.",
 		Type:        schema.TypeString,

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -16,8 +16,8 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("source", false),
 	"database_name":      DatabaseNameSchema("source", false),
 	"qualified_sql_name": QualifiedNameSchema("source"),
-	"cluster_name":       SourceClusterNameSchema(),
-	"size":               SourceSizeSchema(),
+	"cluster_name":       ObjectClusterNameSchema("source"),
+	"size":               ObjectSizeSchema("source"),
 	"kafka_connection":   IdentifierSchema("kafka_connection", "The Kafka connection to use in the source.", true),
 	"topic": {
 		Description: "The Kafka topic you want to subscribe to.",

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -55,8 +55,8 @@ var sourceLoadgenSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("source", false),
 	"database_name":      DatabaseNameSchema("source", false),
 	"qualified_sql_name": QualifiedNameSchema("source"),
-	"cluster_name":       SourceClusterNameSchema(),
-	"size":               SourceSizeSchema(),
+	"cluster_name":       ObjectClusterNameSchema("source"),
+	"size":               ObjectSizeSchema("source"),
 	"load_generator_type": {
 		Description:  fmt.Sprintf("The load generator types: %s.", loadGeneratorTypes),
 		Type:         schema.TypeString,

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -64,9 +64,18 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 				},
 			},
 		},
-		Optional: true,
-		MinItems: 1,
-		ForceNew: true,
+		Optional:      true,
+		MinItems:      1,
+		ForceNew:      true,
+		ConflictsWith: []string{"schema"},
+	},
+	"schema": {
+		Description:   "Creates subsources for specific schemas.",
+		Type:          schema.TypeList,
+		Elem:          &schema.Schema{Type: schema.TypeString},
+		Optional:      true,
+		ForceNew:      true,
+		ConflictsWith: []string{"table"},
 	},
 	"expose_progress": {
 		Description: "The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.",
@@ -122,6 +131,10 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	if v, ok := d.GetOk("table"); ok {
 		tables := materialize.GetTableStruct(v.([]interface{}))
 		b.Table(tables)
+	}
+
+	if v, ok := d.GetOk("schema"); ok {
+		b.Schema(v.([]string))
 	}
 
 	if v, ok := d.GetOk("expose_progress"); ok {

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -16,8 +16,8 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 	"schema_name":         SchemaNameSchema("source", false),
 	"database_name":       DatabaseNameSchema("source", false),
 	"qualified_sql_name":  QualifiedNameSchema("source"),
-	"cluster_name":        SourceClusterNameSchema(),
-	"size":                SourceSizeSchema(),
+	"cluster_name":        ObjectClusterNameSchema("source"),
+	"size":                ObjectSizeSchema("source"),
 	"postgres_connection": IdentifierSchema("posgres_connection", "The PostgreSQL connection to use in the source.", true),
 	"publication": {
 		Description: "The PostgreSQL publication (the replication data set containing the tables to be streamed to Materialize).",

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -18,20 +18,22 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 	"database_name":      DatabaseNameSchema("source", false),
 	"qualified_sql_name": QualifiedNameSchema("source"),
 	"cluster_name": {
-		Description:  "The cluster to maintain this source. If not specified, the size option must be specified.",
-		Type:         schema.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ExactlyOneOf: []string{"cluster_name", "size"},
-		ForceNew:     true,
+		Description:   "The cluster to maintain this source. If not specified, the size option must be specified.",
+		Type:          schema.TypeString,
+		Optional:      true,
+		Computed:      true,
+		AtLeastOneOf:  []string{"cluster_name", "size"},
+		ConflictsWith: []string{"size"},
+		ForceNew:      true,
 	},
 	"size": {
-		Description:  "The size of the source.",
-		Type:         schema.TypeString,
-		Optional:     true,
-		Computed:     true,
-		ExactlyOneOf: []string{"cluster_name", "size"},
-		ValidateFunc: validation.StringInSlice(append(sourceSizes, localSizes...), true),
+		Description:   "The size of the source.",
+		Type:          schema.TypeString,
+		Optional:      true,
+		Computed:      true,
+		AtLeastOneOf:  []string{"cluster_name", "size"},
+		ConflictsWith: []string{"cluster_name"},
+		ValidateFunc:  validation.StringInSlice(append(sourceSizes, localSizes...), true),
 	},
 	"postgres_connection": IdentifierSchema("posgres_connection", "The PostgreSQL connection to use in the source.", true),
 	"publication": {
@@ -48,7 +50,7 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"table": {
-		Description: "Creates subsources for specific tables.",
+		Description: "Creates subsources for specific tables. If neither table or schema is specified, will default to ALL TABLES",
 		Type:        schema.TypeList,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -70,7 +72,7 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		ConflictsWith: []string{"schema"},
 	},
 	"schema": {
-		Description:   "Creates subsources for specific schemas.",
+		Description:   "Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES",
 		Type:          schema.TypeList,
 		Elem:          &schema.Schema{Type: schema.TypeString},
 		Optional:      true,

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -315,9 +315,9 @@ func SubsourceSchema() *schema.Schema {
 	}
 }
 
-func SourceClusterNameSchema() *schema.Schema {
+func ObjectClusterNameSchema(objectType string) *schema.Schema {
 	return &schema.Schema{
-		Description:   "The cluster to maintain this source. If not specified, the size option must be specified.",
+		Description:   fmt.Sprintf("The cluster to maintain this %s. If not specified, the `size` option must be specified.", objectType),
 		Type:          schema.TypeString,
 		Optional:      true,
 		Computed:      true,
@@ -327,9 +327,9 @@ func SourceClusterNameSchema() *schema.Schema {
 	}
 }
 
-func SourceSizeSchema() *schema.Schema {
+func ObjectSizeSchema(objectType string) *schema.Schema {
 	return &schema.Schema{
-		Description:   "The size of the source.",
+		Description:   fmt.Sprintf("The size of the %s. If not specified, the `cluster_name` option must be specified.", objectType),
 		Type:          schema.TypeString,
 		Optional:      true,
 		Computed:      true,


### PR DESCRIPTION
Support `FOR SCHEMAS` as an alternative for `FOR TABLES` for the Postgres Source

Replaces: https://github.com/MaterializeInc/terraform-provider-materialize/pull/195