### PR TITLE
Include Subsource Dependencies

### DIFF
--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -81,6 +81,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the source.
+- `subsource` (List of Object) Subsources of a source. (see [below for nested schema](#nestedatt--subsource))
 
 <a id="nestedblock--kafka_connection"></a>
 ### Nested Schema for `kafka_connection`
@@ -311,6 +312,18 @@ Optional:
 
 - `database_name` (String) The schema_registry_connection database name.
 - `schema_name` (String) The schema_registry_connection schema name.
+
+
+
+
+<a id="nestedatt--subsource"></a>
+### Nested Schema for `subsource`
+
+Read-Only:
+
+- `database_name` (String)
+- `name` (String)
+- `schema_name` (String)
 
 ## Import
 

--- a/docs/resources/source_load_generator.md
+++ b/docs/resources/source_load_generator.md
@@ -56,6 +56,7 @@ resource "materialize_source_load_generator" "example_source_load_generator" {
 
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the source.
+- `subsource` (List of Object) Subsources of a source. (see [below for nested schema](#nestedatt--subsource))
 
 <a id="nestedblock--auction_options"></a>
 ### Nested Schema for `auction_options`
@@ -130,6 +131,17 @@ Required:
 Optional:
 
 - `alias` (String) The alias of the table.
+
+
+
+<a id="nestedatt--subsource"></a>
+### Nested Schema for `subsource`
+
+Read-Only:
+
+- `database_name` (String)
+- `name` (String)
+- `schema_name` (String)
 
 ## Import
 

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -60,6 +60,7 @@ resource "materialize_source_postgres" "example_source_postgres" {
 
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the source.
+- `subsource` (List of Object) Subsources of a source. (see [below for nested schema](#nestedatt--subsource))
 
 <a id="nestedblock--postgres_connection"></a>
 ### Nested Schema for `postgres_connection`
@@ -84,6 +85,16 @@ Required:
 Optional:
 
 - `alias` (String) The alias of the table.
+
+
+<a id="nestedatt--subsource"></a>
+### Nested Schema for `subsource`
+
+Read-Only:
+
+- `database_name` (String)
+- `name` (String)
+- `schema_name` (String)
 
 ## Import
 

--- a/pkg/materialize/dependency.go
+++ b/pkg/materialize/dependency.go
@@ -1,0 +1,51 @@
+package materialize
+
+import (
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type DependencyParams struct {
+	ObjectId          sql.NullString `db:"object_id"`
+	ReferenceObjectId sql.NullString `db:"referenced_object_id"`
+	ObjectName        sql.NullString `db:"object_name"`
+	SchemaName        sql.NullString `db:"schema_name"`
+	DatabaseName      sql.NullString `db:"database_name"`
+	Type              sql.NullString `db:"type"`
+}
+
+var dependencyQuery = NewBaseQuery(`
+	SELECT
+		mz_object_dependencies.object_id,
+		mz_object_dependencies.referenced_object_id,
+		mz_objects.name AS object_name,
+		mz_schemas.name AS schema_name,
+		mz_databases.name AS database_name,
+		mz_objects.type
+	FROM mz_internal.mz_object_dependencies
+	JOIN mz_objects
+		ON mz_object_dependencies.referenced_object_id = mz_objects.id
+	JOIN mz_schemas
+		ON mz_objects.schema_id = mz_schemas.id
+	JOIN mz_databases
+		ON mz_schemas.database_id = mz_databases.id`)
+
+func ListDependencies(conn *sqlx.DB, objectId, objectType string) ([]DependencyParams, error) {
+	p := map[string]string{
+		"mz_object_dependencies.object_id": objectId,
+	}
+
+	if objectType != "" {
+		p["mz_objects.type"] = objectType
+	}
+
+	q := dependencyQuery.QueryPredicate(p)
+
+	var d []DependencyParams
+	if err := conn.Select(&d, q); err != nil {
+		return d, err
+	}
+
+	return d, nil
+}

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -62,6 +62,27 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
+	// Subsources
+	deps, err := materialize.ListDependencies(meta.(*sqlx.DB), i, "source")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	depMaps := []map[string]interface{}{}
+	for _, dep := range deps {
+		depMap := map[string]interface{}{}
+
+		depMap["name"] = dep.ObjectName.String
+		depMap["schema_name"] = dep.SchemaName.String
+		depMap["database_name"] = dep.DatabaseName.String
+
+		depMaps = append(depMaps, depMap)
+	}
+
+	if err := d.Set("subsource", depMaps); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -155,6 +155,7 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 		Optional:    true,
 		ForceNew:    true,
 	},
+	"subsource":      SubSourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -155,7 +155,7 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 		Optional:    true,
 		ForceNew:    true,
 	},
-	"subsource":      SubSourceSchema(),
+	"subsource":      SubsourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -56,6 +56,10 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 		pp := `WHERE mz_sources.id = 'u1'`
 		testhelpers.MockSourceScan(mock, pp)
 
+		// Query Subsources
+		ps := `WHERE mz_object_dependencies.object_id = 'u1' AND mz_objects.type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
 		if err := sourceKafkaCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -142,6 +142,7 @@ var sourceLoadgenSchema = map[string]*schema.Schema{
 		ForceNew:     true,
 		ExactlyOneOf: []string{"counter_options", "auction_options", "marketing_options", "tpch_options"},
 	},
+	"subsource":      SubSourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -142,7 +142,7 @@ var sourceLoadgenSchema = map[string]*schema.Schema{
 		ForceNew:     true,
 		ExactlyOneOf: []string{"counter_options", "auction_options", "marketing_options", "tpch_options"},
 	},
-	"subsource":      SubSourceSchema(),
+	"subsource":      SubsourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_load_generator_test.go
+++ b/pkg/resources/resource_source_load_generator_test.go
@@ -44,6 +44,10 @@ func TestResourceSourceLoadgenCreate(t *testing.T) {
 		pp := `WHERE mz_sources.id = 'u1'`
 		testhelpers.MockSourceScan(mock, pp)
 
+		// Query Subsources
+		ps := `WHERE mz_object_dependencies.object_id = 'u1' AND mz_objects.type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
 		if err := sourceLoadgenCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -74,6 +74,7 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		Optional:    true,
 		ForceNew:    true,
 	},
+	"subsource":      SubSourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -74,7 +74,7 @@ var sourcePostgresSchema = map[string]*schema.Schema{
 		Optional:    true,
 		ForceNew:    true,
 	},
-	"subsource":      SubSourceSchema(),
+	"subsource":      SubsourceSchema(),
 	"ownership_role": OwnershipRole(),
 }
 

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -43,6 +43,10 @@ func TestResourceSourcePostgresCreate(t *testing.T) {
 		pp := `WHERE mz_sources.id = 'u1'`
 		testhelpers.MockSourceScan(mock, pp)
 
+		// Query Subsources
+		ps := `WHERE mz_object_dependencies.object_id = 'u1' AND mz_objects.type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
 		if err := sourcePostgresCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/resource_source_test.go
+++ b/pkg/resources/resource_source_test.go
@@ -29,6 +29,10 @@ func TestResourceSourceUpdate(t *testing.T) {
 		pp := `WHERE mz_sources.id = 'u1'`
 		testhelpers.MockSourceScan(mock, pp)
 
+		// Query Subsources
+		ps := `WHERE mz_object_dependencies.object_id = 'u1' AND mz_objects.type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
 		if err := sourceUpdate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -285,3 +285,22 @@ func SinkFormatSpecSchema(elem string, description string, required bool) *schem
 		Description: description,
 	}
 }
+
+func SubSourceSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "Subsources of a source.",
+		Type:        schema.TypeList,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Description: "The name of the subsource.",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"schema_name":   SchemaNameSchema("source", false),
+				"database_name": DatabaseNameSchema("source", false),
+			},
+		},
+		Computed: true,
+	}
+}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -286,7 +286,7 @@ func SinkFormatSpecSchema(elem string, description string, required bool) *schem
 	}
 }
 
-func SubSourceSchema() *schema.Schema {
+func SubsourceSchema() *schema.Schema {
 	return &schema.Schema{
 		Description: "Subsources of a source.",
 		Type:        schema.TypeList,

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -389,6 +389,29 @@ func MockSourceScan(mock sqlmock.Sqlmock, predicate string) {
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
+func MockSubsourceScan(mock sqlmock.Sqlmock, predicate string) {
+	b := `
+	SELECT
+		mz_object_dependencies.object_id,
+		mz_object_dependencies.referenced_object_id,
+		mz_objects.name AS object_name,
+		mz_schemas.name AS schema_name,
+		mz_databases.name AS database_name,
+		mz_objects.type
+	FROM mz_internal.mz_object_dependencies
+	JOIN mz_objects
+		ON mz_object_dependencies.referenced_object_id = mz_objects.id
+	JOIN mz_schemas
+		ON mz_objects.schema_id = mz_schemas.id
+	JOIN mz_databases
+		ON mz_schemas.database_id = mz_databases.id`
+
+	q := mockQueryBuilder(b, predicate, "")
+	ir := mock.NewRows([]string{"object_id", "referenced_object_id", "object_name", "schema_name", "database_name", "type"}).
+		AddRow("u1", "u2", "object", "schema", "database", "source")
+	mock.ExpectQuery(q).WillReturnRows(ir)
+}
+
 func MockTableColumnScan(mock sqlmock.Sqlmock, predicate string) {
 	b := `
 	SELECT


### PR DESCRIPTION
Include `subsources` as a computed field for source resources. Prep work to allow add/drop of subsources https://github.com/MaterializeInc/terraform-provider-materialize/issues/228.

Debating if this should include additional filtering. Right now every source would include at least one subsource (the progress source). And resources with explicit subsources will contain multiple

```
resource "materialize_source_postgres" "example_source_postgres" {
  name = "source_postgres"
  ...
  table {
    name  = "table1"
    alias = "s1_table1"
  }
  table {
    name  = "table2"
    alias = "s2_table1"
  }
}
```

Would include
```
"subsource": [
    {
    "database_name": "materialize",
    "name": "s1_table1",
    "schema_name": "public"
    },
    {
    "database_name": "materialize",
    "name": "s2_table1",
    "schema_name": "public"
    },
    {
    "database_name": "materialize",
    "name": "source_postgres_progress",
    "schema_name": "public"
    }
]
```
Because we are adding subsources as a computed field, the user would only be able to add/drop subsources via another attribute. This means we could support `ADD|DROP TABLE` like the above postgres source example. I'm still not sure how best to support `ADD|DROP SUBSOURCE`.