### PR TITLE
Allow SSH Key Rotation

### DIFF
--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -39,13 +39,11 @@ var connectionSshTunnelSchema = map[string]*schema.Schema{
 		Description: "The first public key associated with the SSH tunnel.",
 		Type:        schema.TypeString,
 		Computed:    true,
-		ForceNew:    true,
 	},
 	"public_key_2": {
 		Description: "The second public key associated with the SSH tunnel.",
 		Type:        schema.TypeString,
 		Computed:    true,
-		ForceNew:    true,
 	},
 	"ownership_role": OwnershipRoleSchema(),
 }


### PR DESCRIPTION
Allow SSH Connections to rotate keys without creating a recreating the resource. Key rotation would still need to occur outside of Terraform.

https://materialize.com/docs/sql/alter-connection/