### PR TITLE
Value Secret Sensitive

### DIFF
--- a/docs/resources/connection_confluent_schema_registry.md
+++ b/docs/resources/connection_confluent_schema_registry.md
@@ -106,7 +106,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate--secret))
-- `text` (String) The `ssl_certificate` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate--secret"></a>
 ### Nested Schema for `ssl_certificate.secret`
@@ -128,7 +128,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate_authority` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate_authority--secret))
-- `text` (String) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate_authority--secret"></a>
 ### Nested Schema for `ssl_certificate_authority.secret`
@@ -163,7 +163,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `username` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--username--secret))
-- `text` (String) The `username` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `username` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--username--secret"></a>
 ### Nested Schema for `username.secret`

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -145,7 +145,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `sasl_username` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--sasl_username--secret))
-- `text` (String) The `sasl_username` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `sasl_username` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--sasl_username--secret"></a>
 ### Nested Schema for `sasl_username.secret`
@@ -180,7 +180,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate--secret))
-- `text` (String) The `ssl_certificate` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate--secret"></a>
 ### Nested Schema for `ssl_certificate.secret`
@@ -202,7 +202,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate_authority` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate_authority--secret))
-- `text` (String) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate_authority--secret"></a>
 ### Nested Schema for `ssl_certificate_authority.secret`

--- a/docs/resources/connection_postgres.md
+++ b/docs/resources/connection_postgres.md
@@ -78,7 +78,7 @@ resource "materialize_connection_postgres" "example_postgres_connection" {
 Optional:
 
 - `secret` (Block List, Max: 1) The `user` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--user--secret))
-- `text` (String) The `user` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `user` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--user--secret"></a>
 ### Nested Schema for `user.secret`
@@ -139,7 +139,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate--secret))
-- `text` (String) The `ssl_certificate` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate--secret"></a>
 ### Nested Schema for `ssl_certificate.secret`
@@ -161,7 +161,7 @@ Optional:
 Optional:
 
 - `secret` (Block List, Max: 1) The `ssl_certificate_authority` secret value. Conflicts with `text` within this block. (see [below for nested schema](#nestedblock--ssl_certificate_authority--secret))
-- `text` (String) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
+- `text` (String, Sensitive) The `ssl_certificate_authority` text value. Conflicts with `secret` within this block
 
 <a id="nestedblock--ssl_certificate_authority--secret"></a>
 ### Nested Schema for `ssl_certificate_authority.secret`

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -130,6 +130,7 @@ func ValueSecretSchema(elem string, description string, required bool) *schema.S
 					Description:   fmt.Sprintf("The `%s` text value. Conflicts with `secret` within this block", elem),
 					Type:          schema.TypeString,
 					Optional:      true,
+					Sensitive:     true,
 					ConflictsWith: []string{fmt.Sprintf("%s.0.secret", elem)},
 				},
 				"secret": IdentifierSchema(


### PR DESCRIPTION
Connection attributes that can be referenced to secrets or text with `ValueSecretSchema` should be marked sensitive when when using text.