### PR TITLE
Object Mapping

### DIFF
--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -21,7 +21,7 @@ type ClusterBuilder struct {
 	idleArrangementMergeEffort int
 }
 
-func NewClusterBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ClusterBuilder {
+func NewClusterBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterBuilder {
 	return &ClusterBuilder{
 		ddl:         Builder{conn, Cluster},
 		clusterName: obj.Name,
@@ -191,7 +191,7 @@ var clusterQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_clusters.owner_id = mz_roles.id`)
 
-func ClusterId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func ClusterId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := clusterQuery.QueryPredicate(map[string]string{"mz_clusters.name": obj.Name})
 
 	var c ClusterParams

--- a/pkg/materialize/cluster_replica.go
+++ b/pkg/materialize/cluster_replica.go
@@ -21,7 +21,7 @@ type ClusterReplicaBuilder struct {
 	idleArrangementMergeEffort int
 }
 
-func NewClusterReplicaBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ClusterReplicaBuilder {
+func NewClusterReplicaBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterReplicaBuilder {
 	return &ClusterReplicaBuilder{
 		ddl:         Builder{conn, ClusterReplica},
 		replicaName: obj.Name,
@@ -134,7 +134,7 @@ var clusterReplicaQuery = NewBaseQuery(`
 	JOIN mz_clusters
 		ON mz_cluster_replicas.cluster_id = mz_clusters.id`)
 
-func ClusterReplicaId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func ClusterReplicaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_cluster_replicas.name": obj.Name,
 		"mz_clusters.name":         obj.ClusterName,

--- a/pkg/materialize/cluster_replica_test.go
+++ b/pkg/materialize/cluster_replica_test.go
@@ -14,7 +14,7 @@ func TestClusterReplicaCreate(t *testing.T) {
 			`CREATE CLUSTER REPLICA "cluster"."replica" SIZE = 'xsmall', DISK, AVAILABILITY ZONE = 'us-east-1', INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = TRUE, IDLE ARRANGEMENT MERGE EFFORT = 1;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "replica", ClusterName: "cluster"}
+		o := MaterializeObject{Name: "replica", ClusterName: "cluster"}
 		b := NewClusterReplicaBuilder(db, o)
 		b.Size("xsmall")
 		b.Disk(true)
@@ -33,7 +33,7 @@ func TestClusterReplicaDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP CLUSTER REPLICA "cluster"."replica";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "replica", ClusterName: "cluster"}
+		o := MaterializeObject{Name: "replica", ClusterName: "cluster"}
 		if err := NewClusterReplicaBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -12,7 +12,7 @@ func TestClusterCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" REPLICAS \(\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		if err := NewClusterBuilder(db, o).Create(); err != nil {
 			t.Fatal(err)
 		}
@@ -23,7 +23,7 @@ func TestClusterManagedSizeCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" SIZE 'xsmall';`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
 		if err := b.Create(); err != nil {
@@ -36,7 +36,7 @@ func TestClusterManagedSizeDiskCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" SIZE 'xsmall', DISK;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
 		b.Disk(true)
@@ -50,7 +50,7 @@ func TestClusterManagedSizeReplicationCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" SIZE 'xsmall', REPLICATION FACTOR 2;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
 		b.ReplicationFactor(2)
@@ -64,7 +64,7 @@ func TestClusterManagedAllCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" SIZE 'xsmall', REPLICATION FACTOR 2, AVAILABILITY ZONES = \['us-east-1'\], INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = TRUE, IDLE ARRANGEMENT MERGE EFFORT = 1;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
 		b.ReplicationFactor(2)
@@ -82,7 +82,7 @@ func TestClusterDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP CLUSTER "cluster";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "cluster"}
+		o := MaterializeObject{Name: "cluster"}
 		if err := NewClusterBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/connection.go
+++ b/pkg/materialize/connection.go
@@ -30,7 +30,7 @@ type Connection struct {
 	DatabaseName   string
 }
 
-func NewConnection(conn *sqlx.DB, obj ObjectSchemaStruct) *Connection {
+func NewConnection(conn *sqlx.DB, obj MaterializeObject) *Connection {
 	return &Connection{
 		ddl:            Builder{conn, BaseConnection},
 		ConnectionName: obj.Name,
@@ -80,7 +80,7 @@ var connectionQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_connections.owner_id = mz_roles.id`)
 
-func ConnectionId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func ConnectionId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_connections.name": obj.Name,
 		"mz_databases.name":   obj.DatabaseName,

--- a/pkg/materialize/connection_aws_privatelink.go
+++ b/pkg/materialize/connection_aws_privatelink.go
@@ -14,7 +14,7 @@ type ConnectionAwsPrivatelinkBuilder struct {
 	privateLinkAvailabilityZones []string
 }
 
-func NewConnectionAwsPrivatelinkBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ConnectionAwsPrivatelinkBuilder {
+func NewConnectionAwsPrivatelinkBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionAwsPrivatelinkBuilder {
 	b := Builder{conn, BaseConnection}
 	return &ConnectionAwsPrivatelinkBuilder{
 		Connection: Connection{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/connection_aws_privatelink_test.go
+++ b/pkg/materialize/connection_aws_privatelink_test.go
@@ -14,7 +14,7 @@ func TestConnectionAwsPrivatelinkCreate(t *testing.T) {
 			`CREATE CONNECTION "database"."schema"."privatelink_conn" TO AWS PRIVATELINK \(SERVICE NAME 'com.amazonaws.us-east-1.materialize.example',AVAILABILITY ZONES \('use1-az1', 'use1-az2'\)\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "privatelink_conn", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "privatelink_conn", SchemaName: "schema", DatabaseName: "database"}
 		b := NewConnectionAwsPrivatelinkBuilder(db, o)
 		b.PrivateLinkServiceName("com.amazonaws.us-east-1.materialize.example")
 		b.PrivateLinkAvailabilityZones([]string{"use1-az1", "use1-az2"})

--- a/pkg/materialize/connection_confluent_schema_registry.go
+++ b/pkg/materialize/connection_confluent_schema_registry.go
@@ -20,7 +20,7 @@ type ConnectionConfluentSchemaRegistryBuilder struct {
 	validate                              bool
 }
 
-func NewConnectionConfluentSchemaRegistryBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ConnectionConfluentSchemaRegistryBuilder {
+func NewConnectionConfluentSchemaRegistryBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionConfluentSchemaRegistryBuilder {
 	b := Builder{conn, BaseConnection}
 	return &ConnectionConfluentSchemaRegistryBuilder{
 		Connection: Connection{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/connection_confluent_schema_registry_test.go
+++ b/pkg/materialize/connection_confluent_schema_registry_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var connConfluentSchema = ObjectSchemaStruct{Name: "csr_conn", SchemaName: "schema", DatabaseName: "database"}
+var connConfluentSchema = MaterializeObject{Name: "csr_conn", SchemaName: "schema", DatabaseName: "database"}
 
 func TestConnectionConfluentSchemaRegistryCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {

--- a/pkg/materialize/connection_kafka.go
+++ b/pkg/materialize/connection_kafka.go
@@ -46,7 +46,7 @@ type ConnectionKafkaBuilder struct {
 	validate            bool
 }
 
-func NewConnectionKafkaBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ConnectionKafkaBuilder {
+func NewConnectionKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionKafkaBuilder {
 	b := Builder{conn, BaseConnection}
 	return &ConnectionKafkaBuilder{
 		Connection: Connection{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/connection_kafka_test.go
+++ b/pkg/materialize/connection_kafka_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var connKafka = ObjectSchemaStruct{Name: "kafka_conn", SchemaName: "schema", DatabaseName: "database"}
+var connKafka = MaterializeObject{Name: "kafka_conn", SchemaName: "schema", DatabaseName: "database"}
 
 func TestConnectionKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {

--- a/pkg/materialize/connection_postgres.go
+++ b/pkg/materialize/connection_postgres.go
@@ -24,7 +24,7 @@ type ConnectionPostgresBuilder struct {
 	validate               bool
 }
 
-func NewConnectionPostgresBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ConnectionPostgresBuilder {
+func NewConnectionPostgresBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionPostgresBuilder {
 	b := Builder{conn, BaseConnection}
 	return &ConnectionPostgresBuilder{
 		Connection: Connection{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/connection_postgres_test.go
+++ b/pkg/materialize/connection_postgres_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var connPostgres = ObjectSchemaStruct{Name: "postgres_conn", SchemaName: "schema", DatabaseName: "database"}
+var connPostgres = MaterializeObject{Name: "postgres_conn", SchemaName: "schema", DatabaseName: "database"}
 
 func TestConnectionPostgresCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {

--- a/pkg/materialize/connection_ssh_tunnel.go
+++ b/pkg/materialize/connection_ssh_tunnel.go
@@ -15,7 +15,7 @@ type ConnectionSshTunnelBuilder struct {
 	sshPort int
 }
 
-func NewConnectionSshTunnelBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ConnectionSshTunnelBuilder {
+func NewConnectionSshTunnelBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionSshTunnelBuilder {
 	b := Builder{conn, BaseConnection}
 	return &ConnectionSshTunnelBuilder{
 		Connection: Connection{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/connection_ssh_tunnel_test.go
+++ b/pkg/materialize/connection_ssh_tunnel_test.go
@@ -14,7 +14,7 @@ func TestConnectionSshTunnelCreate(t *testing.T) {
 			`CREATE CONNECTION "database"."schema"."ssh_conn" TO SSH TUNNEL \(HOST 'localhost', USER 'user', PORT 123\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "ssh_conn", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "ssh_conn", SchemaName: "schema", DatabaseName: "database"}
 		b := NewConnectionSshTunnelBuilder(db, o)
 		b.SSHHost("localhost")
 		b.SSHPort(123)

--- a/pkg/materialize/database.go
+++ b/pkg/materialize/database.go
@@ -12,7 +12,7 @@ type DatabaseBuilder struct {
 	databaseName string
 }
 
-func NewDatabaseBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *DatabaseBuilder {
+func NewDatabaseBuilder(conn *sqlx.DB, obj MaterializeObject) *DatabaseBuilder {
 	return &DatabaseBuilder{
 		ddl:          Builder{conn, Database},
 		databaseName: obj.Name,
@@ -50,7 +50,7 @@ var databaseQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_databases.owner_id = mz_roles.id`)
 
-func DatabaseId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func DatabaseId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := databaseQuery.QueryPredicate(map[string]string{"mz_databases.name": obj.Name})
 
 	var c DatabaseParams

--- a/pkg/materialize/database_test.go
+++ b/pkg/materialize/database_test.go
@@ -12,7 +12,7 @@ func TestDatabaseCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE DATABASE "database";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "database"}
+		o := MaterializeObject{Name: "database"}
 		if err := NewDatabaseBuilder(db, o).Create(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -17,7 +17,7 @@ type MaterializedViewBuilder struct {
 	selectStmt           string
 }
 
-func NewMaterializedViewBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *MaterializedViewBuilder {
+func NewMaterializedViewBuilder(conn *sqlx.DB, obj MaterializeObject) *MaterializedViewBuilder {
 	return &MaterializedViewBuilder{
 		ddl:                  Builder{conn, MaterializedView},
 		materializedViewName: obj.Name,
@@ -93,7 +93,7 @@ var materializedViewQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_materialized_views.owner_id = mz_roles.id`)
 
-func MaterializedViewId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func MaterializedViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_materialized_views.name": obj.Name,
 		"mz_schemas.name":            obj.SchemaName,

--- a/pkg/materialize/materialized_view_test.go
+++ b/pkg/materialize/materialized_view_test.go
@@ -14,7 +14,7 @@ func TestMaterializedViewCreate(t *testing.T) {
 			`CREATE MATERIALIZED VIEW "database"."schema"."materialized_view" AS SELECT 1 FROM t1;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "materialized_view", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "materialized_view", SchemaName: "schema", DatabaseName: "database"}
 		b := NewMaterializedViewBuilder(db, o)
 		b.SelectStmt("SELECT 1 FROM t1")
 
@@ -28,7 +28,7 @@ func TestMaterializedViewDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP MATERIALIZED VIEW "database"."schema"."materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "materialized_view", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "materialized_view", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewMaterializedViewBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/object.go
+++ b/pkg/materialize/object.go
@@ -4,7 +4,7 @@ import "github.com/jmoiron/sqlx"
 
 // Any Materialize Database Object. Will contain name and optionally database and schema
 // Cluster name only applies to cluster replicas
-type ObjectSchemaStruct struct {
+type MaterializeObject struct {
 	ObjectType   string
 	Name         string
 	SchemaName   string
@@ -12,8 +12,8 @@ type ObjectSchemaStruct struct {
 	ClusterName  string
 }
 
-func GetObjectSchemaStruct(v interface{}) ObjectSchemaStruct {
-	var conn ObjectSchemaStruct
+func GetMaterializeObject(v interface{}) MaterializeObject {
+	var conn MaterializeObject
 	u := v.([]interface{})[0].(map[string]interface{})
 	if v, ok := u["name"]; ok {
 		conn.Name = v.(string)
@@ -36,7 +36,7 @@ func GetObjectSchemaStruct(v interface{}) ObjectSchemaStruct {
 	return conn
 }
 
-func (g *ObjectSchemaStruct) QualifiedName() string {
+func (g *MaterializeObject) QualifiedName() string {
 	fields := []string{}
 
 	if g.ClusterName != "" {
@@ -55,7 +55,7 @@ func (g *ObjectSchemaStruct) QualifiedName() string {
 	return QualifiedName(fields...)
 }
 
-func ObjectId(conn *sqlx.DB, object ObjectSchemaStruct) (string, error) {
+func ObjectId(conn *sqlx.DB, object MaterializeObject) (string, error) {
 	var i string
 	var e error
 

--- a/pkg/materialize/object_test.go
+++ b/pkg/materialize/object_test.go
@@ -12,22 +12,22 @@ import (
 func TestObjectName(t *testing.T) {
 	r := require.New(t)
 
-	on := ObjectSchemaStruct{Name: "name"}
+	on := MaterializeObject{Name: "name"}
 	r.Equal(on.QualifiedName(), `"name"`)
 
-	ond := ObjectSchemaStruct{Name: "name", DatabaseName: "database"}
+	ond := MaterializeObject{Name: "name", DatabaseName: "database"}
 	r.Equal(ond.QualifiedName(), `"database"."name"`)
 
-	onsd := ObjectSchemaStruct{Name: "name", SchemaName: "schema", DatabaseName: "database"}
+	onsd := MaterializeObject{Name: "name", SchemaName: "schema", DatabaseName: "database"}
 	r.Equal(onsd.QualifiedName(), `"database"."schema"."name"`)
 
-	onc := ObjectSchemaStruct{Name: "name", ClusterName: "cluster"}
+	onc := MaterializeObject{Name: "name", ClusterName: "cluster"}
 	r.Equal(onc.QualifiedName(), `"cluster"."name"`)
 }
 
 func TestObjectId(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		o := ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"}
+		o := MaterializeObject{ObjectType: "DATABASE", Name: "materialize"}
 
 		// Query Id
 		ip := `WHERE mz_databases.name = 'materialize'`

--- a/pkg/materialize/ownership.go
+++ b/pkg/materialize/ownership.go
@@ -8,17 +8,17 @@ import (
 
 type OwnershipBuilder struct {
 	ddl    Builder
-	object ObjectSchemaStruct
+	object MaterializeObject
 }
 
-func NewOwnershipBuilder(conn *sqlx.DB, object ObjectSchemaStruct) *OwnershipBuilder {
+func NewOwnershipBuilder(conn *sqlx.DB, object MaterializeObject) *OwnershipBuilder {
 	return &OwnershipBuilder{
 		ddl:    Builder{conn, Ownership},
 		object: object,
 	}
 }
 
-func (b *OwnershipBuilder) Object(o ObjectSchemaStruct) *OwnershipBuilder {
+func (b *OwnershipBuilder) Object(o MaterializeObject) *OwnershipBuilder {
 	b.object = o
 	return b
 }

--- a/pkg/materialize/ownership.go
+++ b/pkg/materialize/ownership.go
@@ -7,16 +7,14 @@ import (
 )
 
 type OwnershipBuilder struct {
-	ddl           Builder
-	ownershipType EntityType
-	object        ObjectSchemaStruct
+	ddl    Builder
+	object ObjectSchemaStruct
 }
 
-func NewOwnershipBuilder(conn *sqlx.DB, ownershipType EntityType, object ObjectSchemaStruct) *OwnershipBuilder {
+func NewOwnershipBuilder(conn *sqlx.DB, object ObjectSchemaStruct) *OwnershipBuilder {
 	return &OwnershipBuilder{
-		ddl:           Builder{conn, Ownership},
-		ownershipType: ownershipType,
-		object:        object,
+		ddl:    Builder{conn, Ownership},
+		object: object,
 	}
 }
 
@@ -26,6 +24,6 @@ func (b *OwnershipBuilder) Object(o ObjectSchemaStruct) *OwnershipBuilder {
 }
 
 func (b *OwnershipBuilder) Alter(roleName string) error {
-	q := fmt.Sprintf(`ALTER %s %s OWNER TO "%s";`, b.ownershipType, b.object.QualifiedName(), roleName)
+	q := fmt.Sprintf(`ALTER %s %s OWNER TO "%s";`, b.object.ObjectType, b.object.QualifiedName(), roleName)
 	return b.ddl.exec(q)
 }

--- a/pkg/materialize/ownership_test.go
+++ b/pkg/materialize/ownership_test.go
@@ -13,7 +13,7 @@ func TestOwnershipAlter(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER TABLE "database"."schema"."table" OWNER TO "my_role";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{
+		o := MaterializeObject{
 			ObjectType:   "TABLE",
 			DatabaseName: "database",
 			SchemaName:   "schema",

--- a/pkg/materialize/ownership_test.go
+++ b/pkg/materialize/ownership_test.go
@@ -14,11 +14,12 @@ func TestOwnershipAlter(t *testing.T) {
 		mock.ExpectExec(`ALTER TABLE "database"."schema"."table" OWNER TO "my_role";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := ObjectSchemaStruct{
+			ObjectType:   "TABLE",
 			DatabaseName: "database",
 			SchemaName:   "schema",
 			Name:         "table",
 		}
-		b := NewOwnershipBuilder(db, "TABLE", o)
+		b := NewOwnershipBuilder(db, o)
 
 		if err := b.Alter("my_role"); err != nil {
 			t.Fatal(err)

--- a/pkg/materialize/privilege.go
+++ b/pkg/materialize/privilege.go
@@ -112,15 +112,15 @@ type PrivilegeBuilder struct {
 	ddl       Builder
 	role      MaterializeRole
 	privilege string
-	object    ObjectSchemaStruct
+	object    MaterializeObject
 }
 
-func NewPrivilegeBuilder(conn *sqlx.DB, role, privilege string, object ObjectSchemaStruct) *PrivilegeBuilder {
+func NewPrivilegeBuilder(conn *sqlx.DB, role, privilege string, obj MaterializeObject) *PrivilegeBuilder {
 	return &PrivilegeBuilder{
 		ddl:       Builder{conn, Privilege},
 		role:      MaterializeRole{name: role},
 		privilege: privilege,
-		object:    object,
+		object:    obj,
 	}
 }
 

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -47,7 +47,7 @@ func TestPrivilegeGrant(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`GRANT CREATE ON DATABASE "materialize" TO "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewPrivilegeBuilder(db, "joe", "CREATE", ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"})
+		b := NewPrivilegeBuilder(db, "joe", "CREATE", MaterializeObject{ObjectType: "DATABASE", Name: "materialize"})
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
 		}
@@ -58,7 +58,7 @@ func TestPrivilegeRevoke(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE CREATE ON DATABASE "materialize" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewPrivilegeBuilder(db, "joe", "CREATE", ObjectSchemaStruct{ObjectType: "DATABASE", Name: "materialize"})
+		b := NewPrivilegeBuilder(db, "joe", "CREATE", MaterializeObject{ObjectType: "DATABASE", Name: "materialize"})
 		if err := b.Revoke(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -14,7 +14,7 @@ type SchemaBuilder struct {
 	databaseName string
 }
 
-func NewSchemaBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SchemaBuilder {
+func NewSchemaBuilder(conn *sqlx.DB, obj MaterializeObject) *SchemaBuilder {
 	return &SchemaBuilder{
 		ddl:          Builder{conn, Schema},
 		schemaName:   obj.Name,
@@ -58,7 +58,7 @@ var schemaQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_schemas.owner_id = mz_roles.id`)
 
-func SchemaId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func SchemaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_schemas.name":   obj.Name,
 		"mz_databases.name": obj.DatabaseName,

--- a/pkg/materialize/schema_test.go
+++ b/pkg/materialize/schema_test.go
@@ -14,7 +14,7 @@ func TestSchemaCreate(t *testing.T) {
 			`CREATE SCHEMA "database"."schema";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "schema", DatabaseName: "database"}
 		if err := NewSchemaBuilder(db, o).Create(); err != nil {
 			t.Fatal(err)
 		}
@@ -27,7 +27,7 @@ func TestSchemaDrop(t *testing.T) {
 			`DROP SCHEMA "database"."schema";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "schema", DatabaseName: "database"}
 		if err := NewSchemaBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/secret.go
+++ b/pkg/materialize/secret.go
@@ -16,7 +16,7 @@ type SecretBuilder struct {
 	value        string
 }
 
-func NewSecretBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SecretBuilder {
+func NewSecretBuilder(conn *sqlx.DB, obj MaterializeObject) *SecretBuilder {
 	return &SecretBuilder{
 		ddl:          Builder{conn, Secret},
 		secretName:   obj.Name,
@@ -80,7 +80,7 @@ var secretQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_secrets.owner_id = mz_roles.id`)
 
-func SecretId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func SecretId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_secrets.name":   obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/secret_test.go
+++ b/pkg/materialize/secret_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var secret = ObjectSchemaStruct{Name: "secret", SchemaName: "schema", DatabaseName: "database"}
+var secret = MaterializeObject{Name: "secret", SchemaName: "schema", DatabaseName: "database"}
 
 func TestSecretCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {

--- a/pkg/materialize/sink.go
+++ b/pkg/materialize/sink.go
@@ -13,7 +13,7 @@ type Sink struct {
 	DatabaseName string
 }
 
-func NewSink(conn *sqlx.DB, obj ObjectSchemaStruct) *Sink {
+func NewSink(conn *sqlx.DB, obj MaterializeObject) *Sink {
 	return &Sink{
 		ddl:          Builder{conn, BaseSink},
 		SinkName:     obj.Name,
@@ -77,7 +77,7 @@ var sinkQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_sinks.owner_id = mz_roles.id`)
 
-func SinkId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func SinkId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_sinks.name":     obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -36,7 +36,7 @@ type SinkKafkaBuilder struct {
 	snapshot        bool
 }
 
-func NewSinkKafkaBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SinkKafkaBuilder {
+func NewSinkKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *SinkKafkaBuilder {
 	b := Builder{conn, BaseSink}
 	return &SinkKafkaBuilder{
 		Sink: Sink{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -14,7 +14,7 @@ func TestSinkKafkaCreate(t *testing.T) {
 			`CREATE SINK "database"."schema"."sink" FROM "database"."schema"."table" INTO KAFKA CONNECTION "database"."schema"."kafka_connection" KEY \(key_1, key_2\) \(TOPIC 'test_avro_topic'\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."public"."csr_connection" ENVELOPE UPSERT WITH \( SIZE = 'xsmall' SNAPSHOT = false\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "sink", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "sink", SchemaName: "schema", DatabaseName: "database"}
 		b := NewSinkKafkaBuilder(db, o)
 		b.Size("xsmall")
 		b.From(IdentifierSchemaStruct{Name: "table", SchemaName: "schema", DatabaseName: "database"})

--- a/pkg/materialize/source.go
+++ b/pkg/materialize/source.go
@@ -69,7 +69,7 @@ type Source struct {
 	DatabaseName string
 }
 
-func NewSource(conn *sqlx.DB, obj ObjectSchemaStruct) *Source {
+func NewSource(conn *sqlx.DB, obj MaterializeObject) *Source {
 	return &Source{
 		ddl:          Builder{conn, BaseSource},
 		SourceName:   obj.Name,
@@ -136,7 +136,7 @@ var sourceQuery = NewBaseQuery(`
 		JOIN mz_roles
 			ON mz_sources.owner_id = mz_roles.id`)
 
-func SourceId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func SourceId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_sources.name":   obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -52,7 +52,7 @@ type SourceKafkaBuilder struct {
 	exposeProgress   string
 }
 
-func NewSourceKafkaBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SourceKafkaBuilder {
+func NewSourceKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *SourceKafkaBuilder {
 	b := Builder{conn, BaseSink}
 	return &SourceKafkaBuilder{
 		Source: Source{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/source_kafka_test.go
+++ b/pkg/materialize/source_kafka_test.go
@@ -14,7 +14,7 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 			`CREATE SOURCE "database"."schema"."source" FROM KAFKA CONNECTION "database"."schema"."kafka_connection" \(TOPIC 'events'\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_connection" INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP ENVELOPE UPSERT EXPOSE PROGRESS AS progress WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "source", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "source", SchemaName: "schema", DatabaseName: "database"}
 		b := NewSourceKafkaBuilder(db, o)
 		b.Size("xsmall")
 		b.KafkaConnection(IdentifierSchemaStruct{Name: "kafka_connection", DatabaseName: "database", SchemaName: "schema"})

--- a/pkg/materialize/source_load_generator.go
+++ b/pkg/materialize/source_load_generator.go
@@ -110,7 +110,7 @@ type SourceLoadgenBuilder struct {
 	tpchOptions       TPCHOptions
 }
 
-func NewSourceLoadgenBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SourceLoadgenBuilder {
+func NewSourceLoadgenBuilder(conn *sqlx.DB, obj MaterializeObject) *SourceLoadgenBuilder {
 	b := Builder{conn, BaseSource}
 	return &SourceLoadgenBuilder{
 		Source: Source{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/source_load_generator_test.go
+++ b/pkg/materialize/source_load_generator_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var sourceLoadgen = ObjectSchemaStruct{Name: "source", SchemaName: "schema", DatabaseName: "database"}
+var sourceLoadgen = MaterializeObject{Name: "source", SchemaName: "schema", DatabaseName: "database"}
 
 func TestSourceLoadgenCounterCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {

--- a/pkg/materialize/source_postgres.go
+++ b/pkg/materialize/source_postgres.go
@@ -19,7 +19,7 @@ type SourcePostgresBuilder struct {
 	exposeProgress     string
 }
 
-func NewSourcePostgresBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SourcePostgresBuilder {
+func NewSourcePostgresBuilder(conn *sqlx.DB, obj MaterializeObject) *SourcePostgresBuilder {
 	b := Builder{conn, BaseSource}
 	return &SourcePostgresBuilder{
 		Source: Source{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/source_postgres_test.go
+++ b/pkg/materialize/source_postgres_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var sourcePostgres = ObjectSchemaStruct{Name: "source", SchemaName: "schema", DatabaseName: "database"}
+var sourcePostgres = MaterializeObject{Name: "source", SchemaName: "schema", DatabaseName: "database"}
 var tableInput = []TableStruct{
 	{Name: "table_1"},
 	{Name: "table_2", Alias: "table_alias"},

--- a/pkg/materialize/source_webhook.go
+++ b/pkg/materialize/source_webhook.go
@@ -28,7 +28,7 @@ type SourceWebhookBuilder struct {
 	checkExpression string
 }
 
-func NewSourceWebhookBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *SourceWebhookBuilder {
+func NewSourceWebhookBuilder(conn *sqlx.DB, obj MaterializeObject) *SourceWebhookBuilder {
 	b := Builder{conn, BaseSource}
 	return &SourceWebhookBuilder{
 		Source: Source{b, obj.Name, obj.SchemaName, obj.DatabaseName},

--- a/pkg/materialize/source_webhook_test.go
+++ b/pkg/materialize/source_webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-var sourceWebhook = ObjectSchemaStruct{Name: "webhook_source", SchemaName: "schema", DatabaseName: "database"}
+var sourceWebhook = MaterializeObject{Name: "webhook_source", SchemaName: "schema", DatabaseName: "database"}
 var checkOptions = []CheckOptionsStruct{
 	{
 		Field: FieldStruct{

--- a/pkg/materialize/table.go
+++ b/pkg/materialize/table.go
@@ -35,7 +35,7 @@ type TableBuilder struct {
 	column       []TableColumn
 }
 
-func NewTableBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *TableBuilder {
+func NewTableBuilder(conn *sqlx.DB, obj MaterializeObject) *TableBuilder {
 	return &TableBuilder{
 		ddl:          Builder{conn, Table},
 		tableName:    obj.Name,
@@ -110,7 +110,7 @@ var tableQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_tables.owner_id = mz_roles.id`)
 
-func TableId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func TableId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_tables.name":    obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/table_test.go
+++ b/pkg/materialize/table_test.go
@@ -14,7 +14,7 @@ func TestTableCreate(t *testing.T) {
 			`CREATE TABLE "database"."schema"."table" \(column_1 int, column_2 text NOT NULL\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "table", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "table", SchemaName: "schema", DatabaseName: "database"}
 		b := NewTableBuilder(db, o)
 		b.Column([]TableColumn{
 			{
@@ -40,7 +40,7 @@ func TestTableRename(t *testing.T) {
 			`ALTER TABLE "database"."schema"."table" RENAME TO "new_table";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "table", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "table", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewTableBuilder(db, o).Rename("new_table"); err != nil {
 			t.Fatal(err)
 		}
@@ -53,7 +53,7 @@ func TestTableDrop(t *testing.T) {
 			`DROP TABLE "database"."schema"."table";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "table", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "table", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewTableBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/type.go
+++ b/pkg/materialize/type.go
@@ -49,7 +49,7 @@ type Type struct {
 	mapProperties  []MapProperties
 }
 
-func NewTypeBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *Type {
+func NewTypeBuilder(conn *sqlx.DB, obj MaterializeObject) *Type {
 	return &Type{
 		ddl:          Builder{conn, BaseType},
 		typeName:     obj.Name,
@@ -133,7 +133,7 @@ var typeQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_types.owner_id = mz_roles.id`)
 
-func TypeId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func TypeId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_types.name":     obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/type_test.go
+++ b/pkg/materialize/type_test.go
@@ -14,7 +14,7 @@ func TestTypeCreateList(t *testing.T) {
 			`CREATE TYPE "database"."schema"."type" AS LIST \(ELEMENT TYPE = int4\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "type", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "type", SchemaName: "schema", DatabaseName: "database"}
 		b := NewTypeBuilder(db, o)
 		b.ListProperties([]ListProperties{
 			{
@@ -34,7 +34,7 @@ func TestTypeCreateMap(t *testing.T) {
 			`CREATE TYPE "database"."schema"."type" AS MAP \(KEY TYPE text, VALUE TYPE = int\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "type", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "type", SchemaName: "schema", DatabaseName: "database"}
 		b := NewTypeBuilder(db, o)
 		b.MapProperties([]MapProperties{
 			{
@@ -55,7 +55,7 @@ func TestTypeDrop(t *testing.T) {
 			`DROP TYPE "database"."schema"."type";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "type", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "type", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewTypeBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/materialize/view.go
+++ b/pkg/materialize/view.go
@@ -16,7 +16,7 @@ type ViewBuilder struct {
 	selectStmt   string
 }
 
-func NewViewBuilder(conn *sqlx.DB, obj ObjectSchemaStruct) *ViewBuilder {
+func NewViewBuilder(conn *sqlx.DB, obj MaterializeObject) *ViewBuilder {
 	return &ViewBuilder{
 		ddl:          Builder{conn, View},
 		viewName:     obj.Name,
@@ -75,7 +75,7 @@ var viewQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_views.owner_id = mz_roles.id`)
 
-func ViewId(conn *sqlx.DB, obj ObjectSchemaStruct) (string, error) {
+func ViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{
 		"mz_views.name":     obj.Name,
 		"mz_schemas.name":   obj.SchemaName,

--- a/pkg/materialize/view_test.go
+++ b/pkg/materialize/view_test.go
@@ -14,7 +14,7 @@ func TestViewCreate(t *testing.T) {
 			`CREATE VIEW "database"."schema"."view" AS SELECT 1 FROM t1;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "view", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "view", SchemaName: "schema", DatabaseName: "database"}
 		b := NewViewBuilder(db, o)
 		b.SelectStmt("SELECT 1 FROM t1")
 
@@ -30,7 +30,7 @@ func TestViewRename(t *testing.T) {
 			`ALTER VIEW "database"."schema"."view" RENAME TO "new_view";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "view", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "view", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewViewBuilder(db, o).Rename("new_view"); err != nil {
 			t.Fatal(err)
 		}
@@ -43,7 +43,7 @@ func TestViewDrop(t *testing.T) {
 			`DROP VIEW "database"."schema"."view";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		o := ObjectSchemaStruct{Name: "view", SchemaName: "schema", DatabaseName: "database"}
+		o := MaterializeObject{Name: "view", SchemaName: "schema", DatabaseName: "database"}
 		if err := NewViewBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/provider/acceptance_cluster_grant_test.go
+++ b/pkg/provider/acceptance_cluster_grant_test.go
@@ -22,7 +22,7 @@ func TestAccGrantCluster_basic(t *testing.T) {
 				Config: testAccGrantClusterResource(roleName, clusterName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "CLUSTER",
 							Name:       clusterName,
 						}, "materialize_cluster_grant.cluster_grant", roleName, privilege),
@@ -40,7 +40,7 @@ func TestAccGrantCluster_disappears(t *testing.T) {
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType: "CLUSTER",
 		Name:       clusterName,
 	}

--- a/pkg/provider/acceptance_cluster_replica_test.go
+++ b/pkg/provider/acceptance_cluster_replica_test.go
@@ -56,7 +56,7 @@ func TestAccClusterReplica_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterReplicaExists("materialize_cluster_replica.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:  "CLUSTER REPLICA",
 							Name:        replicaName,
 							ClusterName: clusterName,

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -98,9 +98,9 @@ func TestAccCluster_disappears(t *testing.T) {
 				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "2-2", "1", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
-					testAccCheckObjectDisappears(materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}),
+					testAccCheckObjectDisappears(materialize.MaterializeObject{ObjectType: "CLUSTER", Name: clusterName}),
 					testAccCheckClusterExists("materialize_cluster.test_managed_cluster"),
-					testAccCheckObjectDisappears(materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName + "_managed"}),
+					testAccCheckObjectDisappears(materialize.MaterializeObject{ObjectType: "CLUSTER", Name: clusterName + "_managed"}),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
+++ b/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
@@ -89,7 +89,7 @@ func TestAccConnConfluentSchemaRegistry_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnConfluentSchemaRegistryExists("materialize_connection_confluent_schema_registry.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "CONNECTION",
 							Name:       connectionName,
 						},

--- a/pkg/provider/acceptance_connection_grant_test.go
+++ b/pkg/provider/acceptance_connection_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantConnection_basic(t *testing.T) {
 				Config: testAccGrantConnectionResource(roleName, connectionName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "CONNECTION",
 							Name:         connectionName,
 							SchemaName:   schemaName,
@@ -49,7 +49,7 @@ func TestAccGrantConnection_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "CONNECTION",
 		Name:         connectionName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -90,7 +90,7 @@ func TestAccConnKafka_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnKafkaExists("materialize_connection_kafka.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "CONNECTION",
 							Name:       connectionName,
 						},

--- a/pkg/provider/acceptance_connection_postgres_test.go
+++ b/pkg/provider/acceptance_connection_postgres_test.go
@@ -98,7 +98,7 @@ func TestAccConnPostgres_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnPostgresExists("materialize_connection_postgres.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "CONNECTION",
 							Name:       connectionName,
 						},

--- a/pkg/provider/acceptance_connection_ssh_tunnel_test.go
+++ b/pkg/provider/acceptance_connection_ssh_tunnel_test.go
@@ -91,7 +91,7 @@ func TestAccConnSshTunnel_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnSshTunnelExists("materialize_connection_ssh_tunnel.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "CONNECTION",
 							Name:       connectionName,
 						},

--- a/pkg/provider/acceptance_database_grant_test.go
+++ b/pkg/provider/acceptance_database_grant_test.go
@@ -26,7 +26,7 @@ func TestAccGrantDatabase_basic(t *testing.T) {
 						Config: testAccGrantDatabaseResource(roleName, databaseName, privilege),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckGrantExists(
-								materialize.ObjectSchemaStruct{
+								materialize.MaterializeObject{
 									ObjectType: "DATABASE",
 									Name:       databaseName,
 								}, "materialize_database_grant.database_grant", roleName, privilege),
@@ -46,7 +46,7 @@ func TestAccGrantDatabase_disappears(t *testing.T) {
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType: "DATABASE",
 		Name:       databaseName,
 	}

--- a/pkg/provider/acceptance_database_test.go
+++ b/pkg/provider/acceptance_database_test.go
@@ -61,7 +61,7 @@ func TestAccDatabase_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseExists("materialize_database.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "DATABASE",
 							Name:       databaseName,
 						},

--- a/pkg/provider/acceptance_materialized_view_grant_test.go
+++ b/pkg/provider/acceptance_materialized_view_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantMaterializedView_basic(t *testing.T) {
 				Config: testAccGrantMaterializedViewResource(roleName, materializedViewName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "MATERIALIZED VIEW",
 							Name:         materializedViewName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantMaterializedView_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "MATERIALIZED VIEW",
 		Name:         materializedViewName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -92,7 +92,7 @@ func TestAccMaterializedView_disappears(t *testing.T) {
 					testAccCheckMaterializedViewExists("materialize_materialized_view.test"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "name", viewName),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "MATERIALIZED VIEW",
 							Name:       viewName,
 						},

--- a/pkg/provider/acceptance_role_test.go
+++ b/pkg/provider/acceptance_role_test.go
@@ -48,7 +48,7 @@ func TestAccRole_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists("materialize_role.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "ROLE",
 							Name:       roleName,
 						},

--- a/pkg/provider/acceptance_schema_grant_test.go
+++ b/pkg/provider/acceptance_schema_grant_test.go
@@ -22,7 +22,7 @@ func TestAccGrantSchema_basic(t *testing.T) {
 			{
 				Config: testAccGrantSchemaResource(roleName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGrantExists(materialize.ObjectSchemaStruct{
+					testAccCheckGrantExists(materialize.MaterializeObject{
 						ObjectType:   "SCHEMA",
 						Name:         schemaName,
 						DatabaseName: databaseName,
@@ -43,7 +43,7 @@ func TestAccGrantSchema_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "SCHEMA",
 		Name:         schemaName,
 		DatabaseName: databaseName,

--- a/pkg/provider/acceptance_schema_test.go
+++ b/pkg/provider/acceptance_schema_test.go
@@ -60,7 +60,7 @@ func TestAccSchema_disappears(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_schema.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_schema.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."%s"`, schemaName)),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SCHEMA",
 							Name:       schemaName,
 						},

--- a/pkg/provider/acceptance_secret_grant_test.go
+++ b/pkg/provider/acceptance_secret_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantSecret_basic(t *testing.T) {
 				Config: testAccGrantSecretResource(roleName, secretName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "SECRET",
 							Name:         secretName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantSecret_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "SECRET",
 		Name:         secretName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_secret_test.go
+++ b/pkg/provider/acceptance_secret_test.go
@@ -91,7 +91,7 @@ func TestAccSecret_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists("materialize_secret.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SECRET",
 							Name:       secretName,
 						},

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -100,7 +100,7 @@ func TestAccSinkKafka_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkKafkaExists("materialize_sink_kafka.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SINK",
 							Name:       sinkName,
 						},

--- a/pkg/provider/acceptance_source_grant_test.go
+++ b/pkg/provider/acceptance_source_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantSource_basic(t *testing.T) {
 				Config: testAccGrantSourceResource(roleName, sourceName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "SOURCE",
 							Name:         sourceName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantSource_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "SOURCE",
 		Name:         sourceName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -103,7 +103,7 @@ func TestAccSourceKafka_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceKafkaExists("materialize_source_kafka.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SOURCE",
 							Name:       sourceName,
 						},

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -119,7 +119,7 @@ func TestAccSourcePostgres_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourcePostgresExists("materialize_source_postgres.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SOURCE",
 							Name:       sourceName,
 						},

--- a/pkg/provider/acceptance_source_webhook_test.go
+++ b/pkg/provider/acceptance_source_webhook_test.go
@@ -63,7 +63,7 @@ func TestAccSourceWebhook_disappears(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceWebhookExists("materialize_source_webhook.test"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "SOURCE",
 							Name:       sourceName,
 						},

--- a/pkg/provider/acceptance_table_grant_test.go
+++ b/pkg/provider/acceptance_table_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantTable_basic(t *testing.T) {
 				Config: testAccGrantTableResource(roleName, tableName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "TABLE",
 							Name:         tableName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantTable_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "TABLE",
 		Name:         tableName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_table_test.go
+++ b/pkg/provider/acceptance_table_test.go
@@ -98,7 +98,7 @@ func TestAccTable_disappears(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, tableName)),
 					resource.TestCheckResourceAttr("materialize_table.test", "column.#", "3"),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "TABLE",
 							Name:       tableName,
 						},

--- a/pkg/provider/acceptance_type_grant_test.go
+++ b/pkg/provider/acceptance_type_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantType_basic(t *testing.T) {
 				Config: testAccGrantTypeResource(roleName, typeName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "TYPE",
 							Name:         typeName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantType_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "TYPE",
 		Name:         typeName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_type_test.go
+++ b/pkg/provider/acceptance_type_test.go
@@ -94,7 +94,7 @@ func TestAccType_disappears(t *testing.T) {
 					testAccCheckTypeExists("materialize_type.test"),
 					resource.TestCheckResourceAttr("materialize_type.test", "name", typeName),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "TYPE",
 							Name:       typeName,
 						},

--- a/pkg/provider/acceptance_view_grant_test.go
+++ b/pkg/provider/acceptance_view_grant_test.go
@@ -24,7 +24,7 @@ func TestAccGrantView_basic(t *testing.T) {
 				Config: testAccGrantViewResource(roleName, viewName, schemaName, databaseName, privilege),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType:   "VIEW",
 							Name:         viewName,
 							SchemaName:   schemaName,
@@ -48,7 +48,7 @@ func TestAccGrantView_disappears(t *testing.T) {
 	schemaName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	databaseName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
-	o := materialize.ObjectSchemaStruct{
+	o := materialize.MaterializeObject{
 		ObjectType:   "VIEW",
 		Name:         viewName,
 		SchemaName:   schemaName,

--- a/pkg/provider/acceptance_view_test.go
+++ b/pkg/provider/acceptance_view_test.go
@@ -93,7 +93,7 @@ func TestAccView_disappears(t *testing.T) {
 					testAccCheckViewExists("materialize_view.test"),
 					resource.TestCheckResourceAttr("materialize_view.test", "name", viewName),
 					testAccCheckObjectDisappears(
-						materialize.ObjectSchemaStruct{
+						materialize.MaterializeObject{
 							ObjectType: "VIEW",
 							Name:       viewName,
 						},

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -43,7 +43,7 @@ func testAccPreCheck(t *testing.T) {
 
 }
 
-func testAccCheckObjectDisappears(object materialize.ObjectSchemaStruct) resource.TestCheckFunc {
+func testAccCheckObjectDisappears(object materialize.MaterializeObject) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		db := testAccProvider.Meta().(*sqlx.DB)
 		_, err := db.Exec(fmt.Sprintf(`DROP %[1]s %[2]s;`, object.ObjectType, object.QualifiedName()))
@@ -51,7 +51,7 @@ func testAccCheckObjectDisappears(object materialize.ObjectSchemaStruct) resourc
 	}
 }
 
-func testAccCheckGrantRevoked(object materialize.ObjectSchemaStruct, roleName, privilege string) resource.TestCheckFunc {
+func testAccCheckGrantRevoked(object materialize.MaterializeObject, roleName, privilege string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		db := testAccProvider.Meta().(*sqlx.DB)
 		_, err := db.Exec(fmt.Sprintf(
@@ -62,7 +62,7 @@ func testAccCheckGrantRevoked(object materialize.ObjectSchemaStruct, roleName, p
 	}
 }
 
-func testAccCheckGrantExists(object materialize.ObjectSchemaStruct, grantName, roleName, privilege string) resource.TestCheckFunc {
+func testAccCheckGrantExists(object materialize.MaterializeObject, grantName, roleName, privilege string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		db := testAccProvider.Meta().(*sqlx.DB)
 		_, ok := s.RootModule().Resources[grantName]

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -94,7 +94,7 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: clusterName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}
 	b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 
 	// managed cluster options
@@ -135,7 +135,7 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CLUSTER", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -157,24 +157,20 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
+	o := materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}
+
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: clusterName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CLUSTER", o)
-
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	// managed cluster options
+	b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 	if _, ok := d.GetOk("size"); ok {
-		o := materialize.ObjectSchemaStruct{Name: clusterName}
-
 		if d.HasChange("size") {
 			_, newSize := d.GetChange("size")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.Resize(newSize.(string)); err != nil {
 				return diag.FromErr(err)
 			}
@@ -183,7 +179,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("disk") {
 			_, newDisk := d.GetChange("disk")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.SetDisk(newDisk.(bool)); err != nil {
 				return diag.FromErr(err)
 			}
@@ -191,7 +186,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("replication_factor") {
 			_, n := d.GetChange("replication_factor")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.SetReplicationFactor(n.(int)); err != nil {
 				return diag.FromErr(err)
 			}
@@ -208,7 +202,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("introspection_interval") {
 			_, n := d.GetChange("introspection_interval")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.SetIntrospectionInterval(n.(string)); err != nil {
 				return diag.FromErr(err)
 			}
@@ -216,7 +209,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("introspection_debugging") {
 			_, n := d.GetChange("introspection_debugging")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.SetIntrospectionDebugging(n.(bool)); err != nil {
 				return diag.FromErr(err)
 			}
@@ -224,7 +216,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("idle_arrangement_merge_effort") {
 			_, n := d.GetChange("idle_arrangement_merge_effort")
-			b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 			if err := b.SetIdleArrangementMergeEffort(n.(int)); err != nil {
 				return diag.FromErr(err)
 			}

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -94,7 +94,7 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}
+	o := materialize.MaterializeObject{ObjectType: "CLUSTER", Name: clusterName}
 	b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 
 	// managed cluster options
@@ -157,7 +157,7 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CLUSTER", Name: clusterName}
+	o := materialize.MaterializeObject{ObjectType: "CLUSTER", Name: clusterName}
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
@@ -228,7 +228,7 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 func clusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: clusterName}
+	o := materialize.MaterializeObject{Name: clusterName}
 	b := materialize.NewClusterBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -89,7 +89,7 @@ func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: replicaName, ClusterName: clusterName}
+	o := materialize.MaterializeObject{Name: replicaName, ClusterName: clusterName}
 	b := materialize.NewClusterReplicaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("size"); ok {
@@ -135,7 +135,7 @@ func clusterReplicaDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: replicaName, ClusterName: clusterName}
+	o := materialize.MaterializeObject{Name: replicaName, ClusterName: clusterName}
 	b := materialize.NewClusterReplicaBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -53,11 +53,11 @@ func connectionUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewConnection(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
@@ -81,7 +81,7 @@ func connectionDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnection(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -53,24 +53,21 @@ func connectionUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewConnection(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewConnection(meta.(*sqlx.DB), o)
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
-		if err := b.Rename(newName.(string)); err != nil {
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -54,20 +54,21 @@ func connectionUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 	databaseName := d.Get("database_name").(string)
 
 	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-	b := materialize.NewConnection(meta.(*sqlx.DB), o)
+
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewConnection(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -109,7 +109,7 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("service_name"); ok {
@@ -152,11 +152,11 @@ func connectionAwsPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -153,19 +153,20 @@ func connectionAwsPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 	databaseName := d.Get("database_name").(string)
 
 	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-	b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
+
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -109,7 +109,7 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("service_name"); ok {
@@ -128,7 +128,7 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -152,24 +152,20 @@ func connectionAwsPrivatelinkUpdate(ctx context.Context, d *schema.ResourceData,
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewConnectionAwsPrivatelinkBuilder(meta.(*sqlx.DB), o)
-
-		if err := b.Rename(newName.(string)); err != nil {
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_aws_privatelink_test.go
+++ b/pkg/resources/resource_connection_aws_privatelink_test.go
@@ -57,7 +57,7 @@ func TestResourceConnectionAwsPrivatelinkUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_aws_privatelink_test.go
+++ b/pkg/resources/resource_connection_aws_privatelink_test.go
@@ -57,7 +57,7 @@ func TestResourceConnectionAwsPrivatelinkUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_confluent_schema_registry.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry.go
@@ -54,7 +54,7 @@ func connectionConfluentSchemaRegistryCreate(ctx context.Context, d *schema.Reso
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionConfluentSchemaRegistryBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("url"); ok {
@@ -107,7 +107,7 @@ func connectionConfluentSchemaRegistryCreate(ctx context.Context, d *schema.Reso
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_connection_confluent_schema_registry.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry.go
@@ -54,7 +54,7 @@ func connectionConfluentSchemaRegistryCreate(ctx context.Context, d *schema.Reso
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionConfluentSchemaRegistryBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("url"); ok {

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -90,7 +90,7 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("kafka_broker"); ok {

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -90,7 +90,7 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("kafka_broker"); ok {
@@ -147,7 +147,7 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_connection_postgres.go
+++ b/pkg/resources/resource_connection_postgres.go
@@ -74,7 +74,7 @@ func connectionPostgresCreate(ctx context.Context, d *schema.ResourceData, meta 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionPostgresBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("connection_type"); ok {

--- a/pkg/resources/resource_connection_postgres.go
+++ b/pkg/resources/resource_connection_postgres.go
@@ -74,7 +74,7 @@ func connectionPostgresCreate(ctx context.Context, d *schema.ResourceData, meta 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionPostgresBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("connection_type"); ok {
@@ -143,7 +143,7 @@ func connectionPostgresCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -115,7 +115,7 @@ func connectionSshTunnelCreate(ctx context.Context, d *schema.ResourceData, meta
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
 
 	b.SSHHost(d.Get("host").(string))
@@ -129,7 +129,7 @@ func connectionSshTunnelCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -153,24 +153,20 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
+	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
-
-		if err := b.Rename(newName.(string)); err != nil {
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "CONNECTION", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -154,19 +154,20 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 	databaseName := d.Get("database_name").(string)
 
 	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
-	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
+
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -115,7 +115,7 @@ func connectionSshTunnelCreate(ctx context.Context, d *schema.ResourceData, meta
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
 
 	b.SSHHost(d.Get("host").(string))
@@ -153,11 +153,11 @@ func connectionSshTunnelUpdate(ctx context.Context, d *schema.ResourceData, meta
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: connectionName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewConnectionSshTunnelBuilder(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)

--- a/pkg/resources/resource_connection_ssh_tunnel_test.go
+++ b/pkg/resources/resource_connection_ssh_tunnel_test.go
@@ -58,7 +58,7 @@ func TestResourceConnectionSshTunnelUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_ssh_tunnel_test.go
+++ b/pkg/resources/resource_connection_ssh_tunnel_test.go
@@ -58,7 +58,7 @@ func TestResourceConnectionSshTunnelUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_test.go
+++ b/pkg/resources/resource_connection_test.go
@@ -27,7 +27,7 @@ func TestResourceConnectionUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		p := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_test.go
+++ b/pkg/resources/resource_connection_test.go
@@ -27,7 +27,7 @@ func TestResourceConnectionUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."" RENAME TO "conn";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		p := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -61,7 +61,7 @@ func databaseRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "DATABASE", Name: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "DATABASE", Name: databaseName}
 	b := materialize.NewDatabaseBuilder(meta.(*sqlx.DB), o)
 
 	// create resource
@@ -93,7 +93,7 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 func databaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "DATABASE", Name: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "DATABASE", Name: databaseName}
 	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("ownership_role") {
@@ -109,7 +109,7 @@ func databaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{
 func databaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: databaseName}
+	o := materialize.MaterializeObject{Name: databaseName}
 	b := materialize.NewDatabaseBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -61,7 +61,7 @@ func databaseRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseName := d.Get("name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "DATABASE", Name: databaseName}
 	b := materialize.NewDatabaseBuilder(meta.(*sqlx.DB), o)
 
 	// create resource
@@ -71,7 +71,7 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "DATABASE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -93,12 +93,11 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 func databaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseName := d.Get("name").(string)
 
+	o := materialize.ObjectSchemaStruct{ObjectType: "DATABASE", Name: databaseName}
+	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
+
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "DATABASE", o)
-
 		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_cluster.go
+++ b/pkg/resources/resource_grant_cluster.go
@@ -42,7 +42,7 @@ func grantClusterCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	privilege := d.Get("privilege").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType: "CLUSTER",
 		Name:       clusterName,
 	}
@@ -80,7 +80,7 @@ func grantClusterDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType: "CLUSTER",
 			Name:       clusterName,
 		},

--- a/pkg/resources/resource_grant_connection.go
+++ b/pkg/resources/resource_grant_connection.go
@@ -56,7 +56,7 @@ func grantConnectionCreate(ctx context.Context, d *schema.ResourceData, meta int
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "CONNECTION",
 		Name:         connectionName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantConnectionDelete(ctx context.Context, d *schema.ResourceData, meta int
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "CONNECTION",
 			Name:         connectionName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_connection_default_privilege.go
+++ b/pkg/resources/resource_grant_connection_default_privilege.go
@@ -70,14 +70,14 @@ func grantConnectionDefaultPrivilegeCreate(ctx context.Context, d *schema.Resour
 
 	var dId, sId string
 	if database != "" {
-		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if schema != "" {
-		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: schema, DatabaseName: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_database.go
+++ b/pkg/resources/resource_grant_database.go
@@ -42,7 +42,7 @@ func grantDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	privilege := d.Get("privilege").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType: "DATABASE",
 		Name:       databaseName,
 	}
@@ -80,7 +80,7 @@ func grantDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType: "DATABASE",
 			Name:       databaseName,
 		},

--- a/pkg/resources/resource_grant_materialized_view.go
+++ b/pkg/resources/resource_grant_materialized_view.go
@@ -56,7 +56,7 @@ func grantMaterializedViewCreate(ctx context.Context, d *schema.ResourceData, me
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "MATERIALIZED VIEW",
 		Name:         mviewName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantMaterializedViewDelete(ctx context.Context, d *schema.ResourceData, me
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "MATERIALIZED VIEW",
 			Name:         mviewName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_schema.go
+++ b/pkg/resources/resource_grant_schema.go
@@ -49,7 +49,7 @@ func grantSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "SCHEMA",
 		Name:         schemaName,
 		DatabaseName: databaseName,
@@ -89,7 +89,7 @@ func grantSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "SCHEMA",
 			Name:         schemaName,
 			DatabaseName: databaseName,

--- a/pkg/resources/resource_grant_schema_default_privilege.go
+++ b/pkg/resources/resource_grant_schema_default_privilege.go
@@ -64,7 +64,7 @@ func grantSchemaDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 	var dId string
 	if database != "" {
-		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_secret.go
+++ b/pkg/resources/resource_grant_secret.go
@@ -56,7 +56,7 @@ func grantSecretCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "SECRET",
 		Name:         secretName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantSecretDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "SECRET",
 			Name:         secretName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_secret_default_privilege.go
+++ b/pkg/resources/resource_grant_secret_default_privilege.go
@@ -70,14 +70,14 @@ func grantSecretDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDa
 
 	var dId, sId string
 	if database != "" {
-		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if schema != "" {
-		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: schema, DatabaseName: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_source.go
+++ b/pkg/resources/resource_grant_source.go
@@ -56,7 +56,7 @@ func grantSourceCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "SOURCE",
 		Name:         sourceName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantSourceDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "SOURCE",
 			Name:         sourceName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_table.go
+++ b/pkg/resources/resource_grant_table.go
@@ -56,7 +56,7 @@ func grantTableCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "TABLE",
 		Name:         tableName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantTableDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "TABLE",
 			Name:         tableName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_table_default_privilege.go
+++ b/pkg/resources/resource_grant_table_default_privilege.go
@@ -70,14 +70,14 @@ func grantTableDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceDat
 
 	var dId, sId string
 	if database != "" {
-		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if schema != "" {
-		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: schema, DatabaseName: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_type.go
+++ b/pkg/resources/resource_grant_type.go
@@ -56,7 +56,7 @@ func grantTypeCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "TYPE",
 		Name:         typeName,
 		SchemaName:   schemaName,
@@ -98,7 +98,7 @@ func grantTypeDelete(ctx context.Context, d *schema.ResourceData, meta interface
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "TYPE",
 			Name:         typeName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_grant_type_default_privilege.go
+++ b/pkg/resources/resource_grant_type_default_privilege.go
@@ -70,14 +70,14 @@ func grantTypeDefaultPrivilegeCreate(ctx context.Context, d *schema.ResourceData
 
 	var dId, sId string
 	if database != "" {
-		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: database})
+		dId, err = materialize.DatabaseId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if schema != "" {
-		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.ObjectSchemaStruct{Name: schema, DatabaseName: database})
+		sId, err = materialize.SchemaId(meta.(*sqlx.DB), materialize.MaterializeObject{Name: schema, DatabaseName: database})
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -98,7 +98,7 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok && v.(string) != "" {
@@ -116,7 +116,7 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "MATERIALIZED VIEW", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -140,24 +140,21 @@ func materializedViewUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	if d.HasChange("name") {
-		oldMaterializedViewName, newMaterializedViewName := d.GetChange("name")
+	o := materialize.ObjectSchemaStruct{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldMaterializedViewName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
-		if err := b.Rename(newMaterializedViewName.(string)); err != nil {
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "MATERIALIZED VIEW", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+	if d.HasChange("name") {
+		_, newMaterializedViewName := d.GetChange("name")
+		if err := b.Rename(newMaterializedViewName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -98,7 +98,7 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok && v.(string) != "" {
@@ -140,11 +140,11 @@ func materializedViewUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "MATERIALIZED VIEW", Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newMaterializedViewName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "MATERIALIZED VIEW", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "MATERIALIZED VIEW", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
 		if err := b.Rename(newMaterializedViewName.(string)); err != nil {
 			return diag.FromErr(err)
@@ -168,7 +168,7 @@ func materializedViewDelete(ctx context.Context, d *schema.ResourceData, meta an
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: materializedViewName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewMaterializedViewBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_materialized_view_test.go
+++ b/pkg/resources/resource_materialized_view_test.go
@@ -54,7 +54,7 @@ func TestResourceMaterializedViewUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER MATERIALIZED VIEW "database"."schema"."old_materialized_view" RENAME TO "materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER MATERIALIZED VIEW "database"."schema"."" RENAME TO "materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_materialized_views.id = 'u1'`

--- a/pkg/resources/resource_materialized_view_test.go
+++ b/pkg/resources/resource_materialized_view_test.go
@@ -54,7 +54,7 @@ func TestResourceMaterializedViewUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER MATERIALIZED VIEW "database"."schema"."" RENAME TO "materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER MATERIALIZED VIEW "database"."schema"."old_materialized_view" RENAME TO "materialized_view";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_materialized_views.id = 'u1'`

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -72,7 +72,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSchemaBuilder(meta.(*sqlx.DB), o)
 
 	// create resource
@@ -82,7 +82,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SCHEMA", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -105,12 +105,11 @@ func schemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
+	o := materialize.ObjectSchemaStruct{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
+	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
+
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SCHEMA", o)
-
 		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -72,7 +72,7 @@ func schemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSchemaBuilder(meta.(*sqlx.DB), o)
 
 	// create resource
@@ -105,7 +105,7 @@ func schemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SCHEMA", Name: schemaName, DatabaseName: databaseName}
 	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("ownership_role") {
@@ -122,7 +122,7 @@ func schemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSchemaBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -85,7 +85,7 @@ func secretCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("value"); ok {
@@ -99,7 +99,7 @@ func secretCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SECRET", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -123,22 +123,10 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	// Name changes should occur first
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
-
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
-
-		if err := b.Rename(newName.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("value") {
-		o := materialize.ObjectSchemaStruct{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
-
 		_, newValue := d.GetChange("value")
 		if err := b.UpdateValue(newValue.(string)); err != nil {
 			return diag.FromErr(err)
@@ -147,11 +135,16 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
-
-		o := materialize.ObjectSchemaStruct{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SECRET", o)
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -126,6 +126,15 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("value") {
 		_, newValue := d.GetChange("value")
 		if err := b.UpdateValue(newValue.(string)); err != nil {
@@ -138,13 +147,6 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -85,7 +85,7 @@ func secretCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("value"); ok {
@@ -123,12 +123,12 @@ func secretUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SECRET", Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "SECRET", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "SECRET", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
@@ -159,7 +159,7 @@ func secretDelete(ctx context.Context, d *schema.ResourceData, meta interface{})
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: secretName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSecretBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_secret_test.go
+++ b/pkg/resources/resource_secret_test.go
@@ -55,8 +55,8 @@ func TestResourceSecretUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER SECRET "database"."schema"."" RENAME TO "secret";`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SECRET "database"."schema"."old_secret" AS 'value';`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SECRET "database"."schema"."old_secret" RENAME TO "secret";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_secrets.id = 'u1'`

--- a/pkg/resources/resource_secret_test.go
+++ b/pkg/resources/resource_secret_test.go
@@ -55,8 +55,8 @@ func TestResourceSecretUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER SECRET "database"."schema"."" RENAME TO "secret";`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SECRET "database"."schema"."old_secret" AS 'value';`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SECRET "database"."schema"."old_secret" RENAME TO "secret";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_secrets.id = 'u1'`

--- a/pkg/resources/resource_sink.go
+++ b/pkg/resources/resource_sink.go
@@ -64,6 +64,15 @@ func sinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSink(meta.(*sqlx.DB), o)
 
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewSink(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("size") {
 		_, newSize := d.GetChange("size")
 		if err := b.Resize(newSize.(string)); err != nil {
@@ -76,13 +85,6 @@ func sinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_sink.go
+++ b/pkg/resources/resource_sink.go
@@ -61,12 +61,12 @@ func sinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSink(meta.(*sqlx.DB), o)
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "SINK", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewSink(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
@@ -97,7 +97,7 @@ func sinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSink(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -91,7 +91,7 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSinkKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -91,7 +91,7 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SINK", Name: sinkName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSinkKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {
@@ -142,7 +142,7 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SINK", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_sink_test.go
+++ b/pkg/resources/resource_sink_test.go
@@ -23,7 +23,7 @@ func TestResourceSinkUpdate(t *testing.T) {
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER SINK "database"."schema"."old_sink" SET \(SIZE = 'small'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SINK "database"."schema"."" RENAME TO "sink";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SINK "database"."schema"."old_sink" RENAME TO "sink";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_sinks.id = 'u1'`

--- a/pkg/resources/resource_sink_test.go
+++ b/pkg/resources/resource_sink_test.go
@@ -22,8 +22,8 @@ func TestResourceSinkUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER SINK "database"."schema"."" RENAME TO "sink";`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SINK "database"."schema"."old_sink" SET \(SIZE = 'small'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SINK "database"."schema"."old_sink" RENAME TO "sink";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_sinks.id = 'u1'`

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -94,6 +94,15 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewSource(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("size") {
 		_, newSize := d.GetChange("size")
 		if err := b.Resize(newSize.(string)); err != nil {
@@ -106,13 +115,6 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -91,7 +91,7 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
 	if d.HasChange("size") {
@@ -101,23 +101,18 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		}
 	}
 
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewSource(meta.(*sqlx.DB), o)
-
-		if err := b.Rename(newName.(string)); err != nil {
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
-
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -91,12 +91,12 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewSource(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
@@ -127,7 +127,7 @@ func sourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -166,7 +166,7 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {
@@ -266,7 +266,7 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -166,7 +166,7 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceKafkaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -154,7 +154,7 @@ func sourceLoadgenCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceLoadgenBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {

--- a/pkg/resources/resource_source_load_generator.go
+++ b/pkg/resources/resource_source_load_generator.go
@@ -154,7 +154,7 @@ func sourceLoadgenCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceLoadgenBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {
@@ -196,7 +196,7 @@ func sourceLoadgenCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -165,6 +165,15 @@ func sourcePostgresUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewSource(meta.(*sqlx.DB), o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("size") {
 		_, newSize := d.GetChange("size")
 		if err := b.Resize(newSize.(string)); err != nil {
@@ -201,13 +210,6 @@ func sourcePostgresUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 			if err := b.DropSubsource(dropTables); err != nil {
 				return diag.FromErr(err)
 			}
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-		if err := b.Rename(newName.(string)); err != nil {
-			return diag.FromErr(err)
 		}
 	}
 

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -93,7 +93,7 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourcePostgresBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("cluster_name"); ok {
@@ -162,12 +162,12 @@ func sourcePostgresUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSource(meta.(*sqlx.DB), o)
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewSource(meta.(*sqlx.DB), o)
 		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -67,9 +67,9 @@ func TestResourceSourcePostgresUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."" RENAME TO "source"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" SET \(SIZE = 'small'\)`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" ADD SUBSOURCE "name1" AS "alias", "name2"`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" RENAME TO "source"`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_sources.id = 'u1'`

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -62,13 +62,14 @@ func TestResourceSourcePostgresUpdate(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgres)
 
 	d.SetId("u1")
+	d.Set("name", "old_source")
 	d.Set("size", "large")
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."source" SET \(SIZE = 'small'\)`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."" RENAME TO "source"`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."source" ADD SUBSOURCE "name1" AS "alias", "name2"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" SET \(SIZE = 'small'\)`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" ADD SUBSOURCE "name1" AS "alias", "name2"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" RENAME TO "source"`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_sources.id = 'u1'`

--- a/pkg/resources/resource_source_test.go
+++ b/pkg/resources/resource_source_test.go
@@ -23,7 +23,7 @@ func TestResourceSourceUpdate(t *testing.T) {
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" SET \(SIZE = 'small'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."" RENAME TO "source";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" RENAME TO "source";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_sources.id = 'u1'`

--- a/pkg/resources/resource_source_test.go
+++ b/pkg/resources/resource_source_test.go
@@ -22,9 +22,8 @@ func TestResourceSourceUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER SOURCE "database"."schema"."" RENAME TO "source";`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" SET \(SIZE = 'small'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER SOURCE "database"."schema"."old_source" RENAME TO "source";`).WillReturnResult(sqlmock.NewResult(1, 1))
-
 		// Query Params
 		pp := `WHERE mz_sources.id = 'u1'`
 		testhelpers.MockSourceScan(mock, pp)

--- a/pkg/resources/resource_source_webhook.go
+++ b/pkg/resources/resource_source_webhook.go
@@ -115,7 +115,7 @@ func sourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	clusterName := d.Get("cluster_name").(string)
 	bodyFormat := d.Get("body_format").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceWebhookBuilder(meta.(*sqlx.DB), o)
 
 	b.ClusterName(clusterName).
@@ -154,7 +154,7 @@ func sourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "SOURCE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)

--- a/pkg/resources/resource_source_webhook.go
+++ b/pkg/resources/resource_source_webhook.go
@@ -115,7 +115,7 @@ func sourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	clusterName := d.Get("cluster_name").(string)
 	bodyFormat := d.Get("body_format").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "SOURCE", Name: sourceName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewSourceWebhookBuilder(meta.(*sqlx.DB), o)
 
 	b.ClusterName(clusterName).

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -168,21 +168,22 @@ func tableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	databaseName := d.Get("database_name").(string)
 
 	o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
-	b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
+
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
+
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newName := d.GetChange("name")
-
-		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -127,7 +127,7 @@ func tableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("column"); ok {
@@ -142,7 +142,7 @@ func tableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TABLE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -167,24 +167,22 @@ func tableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
+	o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
 
-		o := materialize.ObjectSchemaStruct{Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
+	if d.HasChange("ownership_role") {
+		_, newRole := d.GetChange("ownership_role")
+		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
-		if err := b.Rename(newName.(string)); err != nil {
+		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if d.HasChange("ownership_role") {
-		_, newRole := d.GetChange("ownership_role")
+	if d.HasChange("name") {
+		_, newName := d.GetChange("name")
 
-		o := materialize.ObjectSchemaStruct{Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TABLE", o)
-
-		if err := b.Alter(newRole.(string)); err != nil {
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -127,7 +127,7 @@ func tableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("column"); ok {
@@ -167,11 +167,11 @@ func tableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "TABLE", Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "TABLE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "TABLE", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Rename(newName.(string)); err != nil {
@@ -196,7 +196,7 @@ func tableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: tableName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTableBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -131,7 +131,7 @@ func typeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTypeBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("list_properties"); ok {
@@ -151,7 +151,7 @@ func typeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
-		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TYPE", o)
+		ownership := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
@@ -175,12 +175,11 @@ func typeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.ObjectSchemaStruct{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
-
-		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), "TYPE", o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
 			return diag.FromErr(err)

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -131,7 +131,7 @@ func typeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTypeBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("list_properties"); ok {
@@ -175,7 +175,7 @@ func typeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "TYPE", Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 	if d.HasChange("ownership_role") {
@@ -194,7 +194,7 @@ func typeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: typeName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewTypeBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -125,20 +125,21 @@ func viewUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	o := materialize.ObjectSchemaStruct{ObjectType: "VIEW", Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
 
+	if d.HasChange("name") {
+		oldName, newViewName := d.GetChange("name")
+		o := materialize.ObjectSchemaStruct{ObjectType: "VIEW", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewViewBuilder(meta.(*sqlx.DB), o)
+
+		if err := b.Rename(newViewName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("ownership_role") {
 		_, newRole := d.GetChange("ownership_role")
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("name") {
-		_, newViewName := d.GetChange("name")
-		b := materialize.NewViewBuilder(meta.(*sqlx.DB), o)
-
-		if err := b.Rename(newViewName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -85,7 +85,7 @@ func viewCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "VIEW", Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "VIEW", Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewViewBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("statement"); ok && v.(string) != "" {
@@ -123,11 +123,11 @@ func viewUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{ObjectType: "VIEW", Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{ObjectType: "VIEW", Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
 
 	if d.HasChange("name") {
 		oldName, newViewName := d.GetChange("name")
-		o := materialize.ObjectSchemaStruct{ObjectType: "VIEW", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		o := materialize.MaterializeObject{ObjectType: "VIEW", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
 		b := materialize.NewViewBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Rename(newViewName.(string)); err != nil {
@@ -152,7 +152,7 @@ func viewDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	o := materialize.ObjectSchemaStruct{Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
+	o := materialize.MaterializeObject{Name: viewName, SchemaName: schemaName, DatabaseName: databaseName}
 	b := materialize.NewViewBuilder(meta.(*sqlx.DB), o)
 
 	if err := b.Drop(); err != nil {

--- a/pkg/resources/resource_view_grant.go
+++ b/pkg/resources/resource_view_grant.go
@@ -55,7 +55,7 @@ func grantViewCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	schemaName := d.Get("schema_name").(string)
 	databaseName := d.Get("database_name").(string)
 
-	obj := materialize.ObjectSchemaStruct{
+	obj := materialize.MaterializeObject{
 		ObjectType:   "VIEW",
 		Name:         viewName,
 		SchemaName:   schemaName,
@@ -97,7 +97,7 @@ func grantViewDelete(ctx context.Context, d *schema.ResourceData, meta interface
 		meta.(*sqlx.DB),
 		roleName,
 		privilege,
-		materialize.ObjectSchemaStruct{
+		materialize.MaterializeObject{
 			ObjectType:   "VIEW",
 			Name:         viewName,
 			SchemaName:   schemaName,

--- a/pkg/resources/resource_view_test.go
+++ b/pkg/resources/resource_view_test.go
@@ -52,7 +52,7 @@ func TestResourceViewUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER VIEW "database"."schema"."old_view" RENAME TO "view";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER VIEW "database"."schema"."" RENAME TO "view";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_views.id = 'u1'`

--- a/pkg/resources/resource_view_test.go
+++ b/pkg/resources/resource_view_test.go
@@ -52,7 +52,7 @@ func TestResourceViewUpdate(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`ALTER VIEW "database"."schema"."" RENAME TO "view";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER VIEW "database"."schema"."old_view" RENAME TO "view";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_views.id = 'u1'`


### PR DESCRIPTION
Rename `ObjectSchemaStruct` to `MaterializeObject` and be more consistent with initializing the `MaterializeObject` and builder which shows up most often in the update context functions were was inconsistently being redeclared.