### PR TITLE
docs(source): update postgres source example

### DIFF
--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -24,15 +24,16 @@ resource "materialize_source_postgres" "example_source_postgres" {
     # schema_name = "public"
   }
   publication = "mz_source"
-  table = {
-    "schema1.table_1" = "s1_table_1"
-    "schema2_table_1" = "s2_table_1"
+
+  table {
+    name  = "table_1"
+    alias = "s1_table_1"
   }
 }
 
 # CREATE SOURCE schema.source_postgres
 #   FROM POSTGRES CONNECTION "database"."schema"."pg_connection" (PUBLICATION 'mz_source')
-#   FOR TABLES (schema1.table_1 AS s1_table_1, schema2_table_1 AS s2_table_1)
+#   FOR TABLES (schema1.table_1 AS s1_table_1)
 #   WITH (SIZE = '3xsmall');
 ```
 


### PR DESCRIPTION
Minor update to reflect `table` being a `block` not an `object` for `materialize_source_postgres`

```
➜ tf plan
╷
│ Error: Unsupported argument
│
│   on main.tf line 13, in resource "materialize_source_postgres" "this":
│   13:   table = {
│
│ An argument named "table" is not expected here. Did you mean to define a block of type "table"?
```

Current docs: [materialize_source_postgres | Terraform](https://registry.terraform.io/providers/MaterializeInc/materialize/latest/docs/resources/source_postgres)

Currently trying out the other Terraform resources, so can update anything else I spot 🙂 
