### PR TITLE
Require `FOR ALL TABLES` Multi Output Sources

### DIFF
--- a/integration/source.tf
+++ b/integration/source.tf
@@ -22,6 +22,18 @@ resource "materialize_source_load_generator" "load_generator_cluster" {
   }
 }
 
+resource "materialize_source_load_generator" "load_generator_auction" {
+  name                = "load_gen_auction"
+  schema_name         = materialize_schema.schema.name
+  database_name       = materialize_database.database.name
+  cluster_name        = materialize_cluster.cluster_source.name
+  load_generator_type = "AUCTION"
+
+  auction_options {
+    tick_interval = "500ms"
+  }
+}
+
 resource "materialize_source_postgres" "example_source_postgres" {
   name = "source_postgres"
   size = "2"

--- a/pkg/materialize/source_load_generator.go
+++ b/pkg/materialize/source_load_generator.go
@@ -172,6 +172,11 @@ func (b *SourceLoadgenBuilder) Create() error {
 		q.WriteString(fmt.Sprintf(` (%s)`, p))
 	}
 
+	// Include for multi-output sources
+	if b.loadGeneratorType == "AUCTION" || b.loadGeneratorType == "MARKETING" {
+		q.WriteString(` FOR ALL TABLES`)
+	}
+
 	// Size
 	if b.size != "" {
 		q.WriteString(fmt.Sprintf(` WITH (SIZE = %s)`, QuoteString(b.size)))

--- a/pkg/materialize/source_load_generator_test.go
+++ b/pkg/materialize/source_load_generator_test.go
@@ -33,7 +33,7 @@ func TestSourceLoadgenCounterCreate(t *testing.T) {
 func TestSourceLoadgenAuctionCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR AUCTION \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) WITH \(SIZE = 'xsmall'\);`,
+			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR AUCTION \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) FOR ALL TABLES WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceLoadgenBuilder(db, sourceLoadgen)
@@ -53,7 +53,7 @@ func TestSourceLoadgenAuctionCreate(t *testing.T) {
 func TestSourceLoadgenMarketingCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR MARKETING \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) WITH \(SIZE = 'xsmall'\);`,
+			`CREATE SOURCE "database"."schema"."source" FROM LOAD GENERATOR MARKETING \(TICK INTERVAL '1s', SCALE FACTOR 0.01\) FOR ALL TABLES WITH \(SIZE = 'xsmall'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewSourceLoadgenBuilder(db, sourceLoadgen)


### PR DESCRIPTION
Include `FOR ALL TABLES` as a non configurable part of the SQL syntax for multi output load generator sources (auction and marketing)