### PR TITLE
Postgres `schema` Attribute

### DIFF
--- a/integration/source.tf
+++ b/integration/source.tf
@@ -42,6 +42,18 @@ resource "materialize_source_postgres" "example_source_postgres" {
   text_columns = ["table1.id"]
 }
 
+resource "materialize_source_postgres" "example_source_postgres_schema" {
+  name = "source_postgres_schema"
+  size = "2"
+  postgres_connection {
+    name          = materialize_connection_postgres.postgres_connection.name
+    schema_name   = materialize_connection_postgres.postgres_connection.schema_name
+    database_name = materialize_connection_postgres.postgres_connection.database_name
+  }
+  publication = "mz_source"
+  schema = ["PUBLIC"]
+}
+
 resource "materialize_source_kafka" "example_source_kafka_format_text" {
   name = "source_kafka_text"
   size = "2"

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -119,7 +119,8 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if v, ok := d.GetOk("schema"); ok {
-		b.Schema(v.([]string))
+		schemas := materialize.GetSliceValueString(v.([]interface{}))
+		b.Schema(schemas)
 	}
 
 	if v, ok := d.GetOk("expose_progress"); ok {

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var inSourcePostgres = map[string]interface{}{
+var inSourcePostgresTable = map[string]interface{}{
 	"name":                "source",
 	"schema_name":         "schema",
 	"database_name":       "database",
@@ -26,11 +26,12 @@ var inSourcePostgres = map[string]interface{}{
 		map[string]interface{}{"name": "name1", "alias": "alias"},
 		map[string]interface{}{"name": "name2"},
 	},
+	"schema": []interface{}{"schema1", "schema2"},
 }
 
-func TestResourceSourcePostgresCreate(t *testing.T) {
+func TestResourceSourcePostgresCreateTable(t *testing.T) {
 	r := require.New(t)
-	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgres)
+	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgresTable)
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
@@ -57,9 +58,50 @@ func TestResourceSourcePostgresCreate(t *testing.T) {
 	})
 }
 
+var inSourcePostgresSchema = map[string]interface{}{
+	"name":                "source",
+	"schema_name":         "schema",
+	"database_name":       "database",
+	"cluster_name":        "cluster",
+	"size":                "small",
+	"postgres_connection": []interface{}{map[string]interface{}{"name": "pg_connection"}},
+	"publication":         "mz_source",
+	"text_columns":        []interface{}{"table.unsupported_type_1"},
+	"schema":              []interface{}{"schema1", "schema2"},
+}
+
+func TestResourceSourcePostgresCreateSchema(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgresSchema)
+	r.NotNil(d)
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."source" IN CLUSTER "cluster" FROM POSTGRES CONNECTION "database"."schema"."pg_connection" \(PUBLICATION 'mz_source', TEXT COLUMNS \(table.unsupported_type_1\)\) FOR SCHEMAS \(schema1, schema2\) WITH \(SIZE = 'small'\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Id
+		ip := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_sources.name = 'source'`
+		testhelpers.MockSourceScan(mock, ip)
+
+		// Query Params
+		pp := `WHERE mz_sources.id = 'u1'`
+		testhelpers.MockSourceScan(mock, pp)
+
+		// Query Subsources
+		ps := `WHERE mz_object_dependencies.object_id = 'u1' AND mz_objects.type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
+		if err := sourcePostgresCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestResourceSourcePostgresUpdate(t *testing.T) {
 	r := require.New(t)
-	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgres)
+	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgresTable)
 
 	d.SetId("u1")
 	d.Set("name", "old_source")

--- a/pkg/resources/resource_source_test.go
+++ b/pkg/resources/resource_source_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestResourceSourceUpdate(t *testing.T) {
 	r := require.New(t)
-	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgres)
+	d := schema.TestResourceDataRaw(t, SourcePostgres().Schema, inSourcePostgresTable)
 
 	// Set current state
 	d.SetId("u1")


### PR DESCRIPTION
Using the `schema` attribute within the postgres source was leading to errors. Including fix and including unit and integration tests specific for schema attribute.