### PR TITLE
GHA Docs Forks

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,6 @@
 name: documentation
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - pkg/**
       - examples/**


### PR DESCRIPTION
When users submit PRs on forks, the documentation check will fail. This is because of how the [git-auto-commit-action works with public repos](https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories). Seems like the correct (hopefully simple) solution is to changing the trigger