### PR TITLE
Attribute `COMMENT`

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -27,6 +27,7 @@ resource "materialize_cluster" "example_cluster" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `disk` (Boolean) **Private Preview**. Whether or not the replica is a _disk-backed replica_.
 - `idle_arrangement_merge_effort` (Number) The amount of effort to exert compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.
 - `introspection_debugging` (Boolean) Whether to introspect the gathering of the introspection data.

--- a/docs/resources/cluster_replica.md
+++ b/docs/resources/cluster_replica.md
@@ -32,6 +32,7 @@ resource "materialize_cluster_replica" "example_cluster_replica" {
 ### Optional
 
 - `availability_zone` (String) The specific availability zone of the replica.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `disk` (Boolean) **Private Preview**. Whether or not the replica is a _disk-backed replica_.
 - `idle_arrangement_merge_effort` (Number) The amount of effort to exert compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.
 - `introspection_debugging` (Boolean) Whether to introspect the gathering of the introspection data.

--- a/docs/resources/connection_aws_privatelink.md
+++ b/docs/resources/connection_aws_privatelink.md
@@ -40,6 +40,7 @@ resource "materialize_connection_aws_privatelink" "example_privatelink_connectio
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the connection schema. Defaults to `public`.

--- a/docs/resources/connection_confluent_schema_registry.md
+++ b/docs/resources/connection_confluent_schema_registry.md
@@ -45,6 +45,7 @@ resource "materialize_connection_confluent_schema_registry" "example_confluent_s
 ### Optional
 
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the Confluent Schema Registry. (see [below for nested schema](#nestedblock--aws_privatelink))
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `password` (Block List, Max: 1) The password for the Confluent Schema Registry. (see [below for nested schema](#nestedblock--password))

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -81,6 +81,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `progress_topic` (String) The name of a topic that Kafka sinks can use to track internal consistency metadata.

--- a/docs/resources/connection_postgres.md
+++ b/docs/resources/connection_postgres.md
@@ -85,6 +85,7 @@ resource "materialize_connection_postgres" "example_postgres_connection" {
 ### Optional
 
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the Postgres database. (see [below for nested schema](#nestedblock--aws_privatelink))
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `password` (Block List, Max: 1) The Postgres database password. (see [below for nested schema](#nestedblock--password))

--- a/docs/resources/connection_ssh_tunnel.md
+++ b/docs/resources/connection_ssh_tunnel.md
@@ -41,6 +41,7 @@ resource "materialize_connection_ssh_tunnel" "example_ssh_connection" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the connection schema. Defaults to `public`.

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -27,6 +27,7 @@ resource "materialize_database" "example_database" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `ownership_role` (String) The owernship role of the object.
 
 ### Read-Only

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -42,6 +42,7 @@ resource "materialize_index" "loadgen_index" {
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this index. If not specified, defaults to the active cluster.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `default` (Boolean) Creates a default index using all inferred columns are used.
 - `method` (String) The name of the index method to use.
 - `name` (String) The identifier for the index.
@@ -50,7 +51,7 @@ resource "materialize_index" "loadgen_index" {
 
 - `database_name` (String) The identifier for the index database.
 - `id` (String) The ID of this resource.
-- `qualified_sql_name` (String) The fully qualified name of the view.
+- `qualified_sql_name` (String) The fully qualified name of the index.
 - `schema_name` (String) The identifier for the index schema.
 
 <a id="nestedblock--col_expr"></a>

--- a/docs/resources/materialized_view.md
+++ b/docs/resources/materialized_view.md
@@ -48,6 +48,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain the materialized view. If not specified, defaults to the default cluster.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the materialized view database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the materialized view schema. Defaults to `public`.

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -25,6 +25,10 @@ resource "materialize_role" "example_role" {
 
 - `name` (String) The identifier for the role.
 
+### Optional
+
+- `comment` (String) **Private Preview** Comment on an object in the database.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -28,6 +28,7 @@ resource "materialize_schema" "example_schema" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the schema database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -28,6 +28,7 @@ resource "materialize_secret" "example_secret" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the secret database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the secret schema. Defaults to `public`.

--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -59,6 +59,7 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this sink. If not specified, the `size` option must be specified.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the sink database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))

--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -55,6 +55,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `envelope` (Block List, Max: 1) How Materialize should interpret records (e.g. append-only, upsert).. (see [below for nested schema](#nestedblock--envelope))
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.

--- a/docs/resources/source_load_generator.md
+++ b/docs/resources/source_load_generator.md
@@ -44,6 +44,7 @@ resource "materialize_source_load_generator" "example_source_load_generator" {
 
 - `auction_options` (Block List) Auction Options. (see [below for nested schema](#nestedblock--auction_options))
 - `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `counter_options` (Block List) Counter Options. (see [below for nested schema](#nestedblock--counter_options))
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `marketing_options` (Block List) Marketing Options. (see [below for nested schema](#nestedblock--marketing_options))

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -55,6 +55,7 @@ resource "materialize_source_postgres" "example_source_postgres" {
 ### Optional
 
 - `cluster_name` (String) The cluster to maintain this source. If not specified, the `size` option must be specified.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (String) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`.
 - `ownership_role` (String) The owernship role of the object.

--- a/docs/resources/source_webhook.md
+++ b/docs/resources/source_webhook.md
@@ -34,6 +34,7 @@ resource "materialize_source_webhook" "example_webhook" {
 - `check_expression` (String) The check expression for the webhook.
 - `check_options` (Block List) The check options for the webhook. (see [below for nested schema](#nestedblock--check_options))
 - `cluster_name` (String) The cluster to maintain this source.
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `include_headers` (Boolean) Include headers in the webhook.
 - `ownership_role` (String) The owernship role of the object.

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -45,6 +45,7 @@ resource "materialize_table" "simple_table" {
 ### Optional
 
 - `column` (Block List) Column of the table. (see [below for nested schema](#nestedblock--column))
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the table database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the table schema. Defaults to `public`.
@@ -64,6 +65,7 @@ Required:
 
 Optional:
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `nullable` (Boolean) Do not allow the column to contain NULL values. Columns without this constraint can contain NULL values.
 
 ## Import

--- a/docs/resources/type.md
+++ b/docs/resources/type.md
@@ -44,6 +44,7 @@ resource "materialize_type" "map_type" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the type database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `list_properties` (Block List, Max: 1) List properties. (see [below for nested schema](#nestedblock--list_properties))
 - `map_properties` (Block List, Max: 1) Map properties. (see [below for nested schema](#nestedblock--map_properties))

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -47,6 +47,7 @@ resource "materialize_view" "simple_view" {
 
 ### Optional
 
+- `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the view database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the view schema. Defaults to `public`.

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -1,5 +1,6 @@
 resource "materialize_cluster" "cluster" {
-  name = "cluster"
+  name    = "cluster"
+  comment = "cluster comment"
 }
 
 resource "materialize_cluster" "cluster_source" {

--- a/integration/cluster_replica.tf
+++ b/integration/cluster_replica.tf
@@ -2,6 +2,7 @@ resource "materialize_cluster_replica" "cluster_replica_1" {
   name         = "r1"
   cluster_name = materialize_cluster.cluster.name
   size         = "8"
+  comment      = "cluster replica comment"
 }
 
 resource "materialize_cluster_replica" "cluster_replica_2" {

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -1,21 +1,27 @@
 resource "materialize_connection_kafka" "kafka_connection" {
-  name = "kafka_connection"
+  name    = "kafka_connection"
+  comment = "connection kafka comment"
+
   kafka_broker {
     broker = "redpanda:9092"
   }
 }
 
 resource "materialize_connection_confluent_schema_registry" "schema_registry" {
-  name = "schema_registry_connection"
-  url  = "http://redpanda:8081"
+  name    = "schema_registry_connection"
+  comment = "connection schema registry comment"
+
+  url = "http://redpanda:8081"
 }
 
 resource "materialize_connection_ssh_tunnel" "ssh_connection" {
   name        = "ssh_connection"
   schema_name = "public"
-  host        = "ssh_host"
-  user        = "ssh_user"
-  port        = 22
+  comment     = "connection ssh tunnel comment"
+
+  host = "ssh_host"
+  user = "ssh_user"
+  port = 22
 }
 
 resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
@@ -40,7 +46,9 @@ resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
 }
 
 resource "materialize_connection_postgres" "postgres_connection" {
-  name = "postgres_connection"
+  name    = "postgres_connection"
+  comment = "connection postgres comment"
+
   host = "postgres"
   port = 5432
   user {

--- a/integration/database.tf
+++ b/integration/database.tf
@@ -1,5 +1,6 @@
 resource "materialize_database" "database" {
-  name = "example_database"
+  name    = "example_database"
+  comment = "database comment"
 }
 
 resource "materialize_database_grant" "database_grant_usage" {

--- a/integration/index.tf
+++ b/integration/index.tf
@@ -1,5 +1,7 @@
 resource "materialize_index" "loadgen_index" {
-  name         = "loadgen_index"
+  name    = "loadgen_index"
+  comment = "index comment"
+
   cluster_name = materialize_cluster.cluster.name
 
   obj_name {

--- a/integration/materialized_view.tf
+++ b/integration/materialized_view.tf
@@ -2,6 +2,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
   name          = "simple_materialized_view"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
+  comment       = "materialize view comment"
   cluster_name  = "default"
 
   statement = <<SQL

--- a/integration/role.tf
+++ b/integration/role.tf
@@ -1,13 +1,16 @@
 resource "materialize_role" "role_1" {
-  name = "role-1"
+  name    = "role-1"
+  comment = "role 1 comment"
 }
 
 resource "materialize_role" "role_2" {
-  name = "role-2"
+  name    = "role-2"
+  comment = "role 2 comment"
 }
 
 resource "materialize_role" "grantee" {
-  name = "grantee"
+  name    = "grantee"
+  comment = "role grantee comment"
 }
 
 resource "materialize_role" "target" {

--- a/integration/schema.tf
+++ b/integration/schema.tf
@@ -1,6 +1,7 @@
 resource "materialize_schema" "schema" {
   name          = "example_schema"
   database_name = materialize_database.database.name
+  comment       = "schema comment"
 }
 
 resource "materialize_schema_grant" "schema_grant_usage" {

--- a/integration/secret.tf
+++ b/integration/secret.tf
@@ -1,6 +1,7 @@
 resource "materialize_secret" "password" {
-  name  = "password"
-  value = "c2VjcmV0Cg=="
+  name    = "password"
+  value   = "c2VjcmV0Cg=="
+  comment = "secret comment"
 }
 
 resource "materialize_secret" "postgres_password" {

--- a/integration/sink.tf
+++ b/integration/sink.tf
@@ -2,6 +2,7 @@ resource "materialize_sink_kafka" "sink_kafka" {
   name          = "sink_kafka"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
+  comment       = "sink comment"
   size          = "1"
   from {
     name          = materialize_source_load_generator.load_generator.name

--- a/integration/source.tf
+++ b/integration/source.tf
@@ -1,7 +1,9 @@
 resource "materialize_source_load_generator" "load_generator" {
-  name                = "load_gen"
-  schema_name         = materialize_schema.schema.name
-  database_name       = materialize_database.database.name
+  name          = "load_gen"
+  schema_name   = materialize_schema.schema.name
+  database_name = materialize_database.database.name
+  comment       = "source load generator comment"
+
   size                = "1"
   load_generator_type = "COUNTER"
 
@@ -35,7 +37,9 @@ resource "materialize_source_load_generator" "load_generator_auction" {
 }
 
 resource "materialize_source_postgres" "example_source_postgres" {
-  name = "source_postgres"
+  name    = "source_postgres"
+  comment = "source postgres comment"
+
   size = "2"
   postgres_connection {
     name          = materialize_connection_postgres.postgres_connection.name
@@ -67,7 +71,9 @@ resource "materialize_source_postgres" "example_source_postgres_schema" {
 }
 
 resource "materialize_source_kafka" "example_source_kafka_format_text" {
-  name = "source_kafka_text"
+  name    = "source_kafka_text"
+  comment = "source kafka comment"
+
   size = "2"
   kafka_connection {
     name          = materialize_connection_kafka.kafka_connection.name
@@ -122,7 +128,9 @@ resource "materialize_source_kafka" "example_source_kafka_format_avro" {
 }
 
 resource "materialize_source_webhook" "example_webhook_source" {
-  name            = "example_webhook_source"
+  name    = "example_webhook_source"
+  comment = "source webhook comment"
+
   cluster_name    = materialize_cluster.cluster_source.name
   body_format     = "json"
   include_headers = false

--- a/integration/table.tf
+++ b/integration/table.tf
@@ -2,14 +2,16 @@ resource "materialize_table" "simple_table" {
   name          = "simple_table"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
+  comment       = "table comment"
 
   column {
     name = "column_1"
     type = "text"
   }
   column {
-    name = "column_2"
-    type = "int"
+    name    = "column_2"
+    type    = "int"
+    comment = "column_2 comment"
   }
   column {
     name     = "column_3"

--- a/integration/view.tf
+++ b/integration/view.tf
@@ -2,6 +2,7 @@ resource "materialize_view" "simple_view" {
   name          = "simple_view"
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
+  comment       = "view comment"
 
   statement = <<SQL
 SELECT

--- a/pkg/datasources/datasource_materialized_view_test.go
+++ b/pkg/datasources/datasource_materialized_view_test.go
@@ -24,7 +24,7 @@ func TestMaterializedViewDatasource(t *testing.T) {
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		p := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
-		testhelpers.MockMaterailizeViewScan(mock, p)
+		testhelpers.MockMaterializeViewScan(mock, p)
 
 		if err := materializedViewRead(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/datasources/datasource_table_test.go
+++ b/pkg/datasources/datasource_table_test.go
@@ -23,7 +23,7 @@ func TestTableDatasource(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		p := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
+		p := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
 		testhelpers.MockTableScan(mock, p)
 
 		if err := tableRead(context.TODO(), d, db); err != nil {

--- a/pkg/datasources/datasource_table_test.go
+++ b/pkg/datasources/datasource_table_test.go
@@ -23,7 +23,7 @@ func TestTableDatasource(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		p := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
+		p := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
 		testhelpers.MockTableScan(mock, p)
 
 		if err := tableRead(context.TODO(), d, db); err != nil {

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -186,14 +186,18 @@ var clusterQuery = NewBaseQuery(`
 		mz_clusters.size,
 		mz_clusters.replication_factor,
 		mz_clusters.disk,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_clusters.privileges
 	FROM mz_clusters
 	JOIN mz_roles
 		ON mz_clusters.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_clusters.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'cluster'
+	) comments
+		ON mz_clusters.id = comments.id`)
 
 func ClusterId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := clusterQuery.QueryPredicate(map[string]string{"mz_clusters.name": obj.Name})

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -173,6 +173,7 @@ type ClusterParams struct {
 	Size              sql.NullString `db:"size"`
 	ReplicationFactor sql.NullInt64  `db:"replication_factor"`
 	Disk              sql.NullBool   `db:"disk"`
+	Comment           sql.NullString `db:"comment"`
 	OwnerName         sql.NullString `db:"owner_name"`
 	Privileges        sql.NullString `db:"privileges"`
 }
@@ -185,11 +186,14 @@ var clusterQuery = NewBaseQuery(`
 		mz_clusters.size,
 		mz_clusters.replication_factor,
 		mz_clusters.disk,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_clusters.privileges
 	FROM mz_clusters
 	JOIN mz_roles
-		ON mz_clusters.owner_id = mz_roles.id`)
+		ON mz_clusters.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_clusters.id = mz_comments.id`)
 
 func ClusterId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := clusterQuery.QueryPredicate(map[string]string{"mz_clusters.name": obj.Name})

--- a/pkg/materialize/cluster_replica.go
+++ b/pkg/materialize/cluster_replica.go
@@ -120,6 +120,7 @@ type ClusterReplicaParams struct {
 	Size             sql.NullString `db:"size"`
 	AvailabilityZone sql.NullString `db:"availability_zone"`
 	Disk             sql.NullBool   `db:"disk"`
+	Comment          sql.NullString `db:"comment"`
 }
 
 var clusterReplicaQuery = NewBaseQuery(`
@@ -129,10 +130,13 @@ var clusterReplicaQuery = NewBaseQuery(`
 		mz_clusters.name AS cluster_name,
 		mz_cluster_replicas.size,
 		mz_cluster_replicas.availability_zone,
-		mz_cluster_replicas.disk
+		mz_cluster_replicas.disk,
+		mz_comments.comment AS comment
 	FROM mz_cluster_replicas
 	JOIN mz_clusters
-		ON mz_cluster_replicas.cluster_id = mz_clusters.id`)
+		ON mz_cluster_replicas.cluster_id = mz_clusters.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_cluster_replicas.id = mz_comments.id`)
 
 func ClusterReplicaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/cluster_replica.go
+++ b/pkg/materialize/cluster_replica.go
@@ -131,12 +131,16 @@ var clusterReplicaQuery = NewBaseQuery(`
 		mz_cluster_replicas.size,
 		mz_cluster_replicas.availability_zone,
 		mz_cluster_replicas.disk,
-		mz_comments.comment AS comment
+		comments.comment AS comment
 	FROM mz_cluster_replicas
 	JOIN mz_clusters
 		ON mz_cluster_replicas.cluster_id = mz_clusters.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_cluster_replicas.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'cluster-replica'
+	) comments
+		ON mz_cluster_replicas.id = comments.id`)
 
 func ClusterReplicaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/column.go
+++ b/pkg/materialize/column.go
@@ -22,13 +22,17 @@ var tableColumnQuery = NewBaseQuery(`
 		mz_columns.name,
 		mz_columns.position,
 		mz_columns.nullable,
-		mz_comments.comment,
+		comments.comment,
 		mz_columns.type,
 		mz_columns.default
 	FROM mz_columns
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_columns.id = mz_comments.id
-		AND mz_columns.position = mz_comments.object_sub_id`).Order("mz_columns.position")
+	LEFT JOIN (
+		SELECT id, object_sub_id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'table'
+	) comments
+		ON mz_columns.id = comments.id
+		AND mz_columns.position = comments.object_sub_id`).Order("mz_columns.position")
 
 func ListTableColumns(conn *sqlx.DB, objectId string) ([]TableColumnParams, error) {
 	p := map[string]string{"mz_columns.id": objectId}

--- a/pkg/materialize/column.go
+++ b/pkg/materialize/column.go
@@ -11,6 +11,7 @@ type TableColumnParams struct {
 	Name     sql.NullString `db:"name"`
 	Position sql.NullString `db:"position"`
 	Nullable sql.NullBool   `db:"nullable"`
+	Comment  sql.NullString `db:"comment"`
 	Type     sql.NullString `db:"type"`
 	Default  sql.NullString `db:"default"`
 }
@@ -21,9 +22,13 @@ var tableColumnQuery = NewBaseQuery(`
 		mz_columns.name,
 		mz_columns.position,
 		mz_columns.nullable,
+		mz_comments.comment,
 		mz_columns.type,
 		mz_columns.default
-	FROM mz_columns`).Order("mz_columns.position")
+	FROM mz_columns
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_columns.id = mz_comments.id
+		AND mz_columns.position = mz_comments.object_sub_id`).Order("mz_columns.position")
 
 func ListTableColumns(conn *sqlx.DB, objectId string) ([]TableColumnParams, error) {
 	p := map[string]string{"mz_columns.id": objectId}

--- a/pkg/materialize/comment.go
+++ b/pkg/materialize/comment.go
@@ -1,0 +1,32 @@
+package materialize
+
+import (
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type CommentBuilder struct {
+	ddl    Builder
+	object MaterializeObject
+}
+
+func NewCommentBuilder(conn *sqlx.DB, obj MaterializeObject) *CommentBuilder {
+	return &CommentBuilder{
+		ddl:    Builder{conn, Cluster},
+		object: obj,
+	}
+}
+
+func (b *CommentBuilder) Object(comment string) error {
+	c := QuoteString(comment)
+	q := fmt.Sprintf(`COMMENT ON %s %s IS %s;`, b.object.ObjectType, b.object.QualifiedName(), c)
+	return b.ddl.exec(q)
+}
+
+func (b *CommentBuilder) Column(column, comment string) error {
+	c := QuoteString(comment)
+	col := QuoteIdentifier(column)
+	q := fmt.Sprintf(`COMMENT ON COLUMN %s.%s IS %s;`, b.object.QualifiedName(), col, c)
+	return b.ddl.exec(q)
+}

--- a/pkg/materialize/comment_test.go
+++ b/pkg/materialize/comment_test.go
@@ -1,0 +1,33 @@
+package materialize
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestCommentObject(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`COMMENT ON TABLE "database"."schema"."table" IS 'my comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{ObjectType: "TABLE", Name: "table", DatabaseName: "database", SchemaName: "schema"}
+		c := "my comment"
+		if err := NewCommentBuilder(db, o).Object(c); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestCommentColumn(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`COMMENT ON COLUMN "database"."schema"."table"."column" IS 'my comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{ObjectType: "TABLE", Name: "table", DatabaseName: "database", SchemaName: "schema"}
+		c := "my comment"
+		if err := NewCommentBuilder(db, o).Column("column", c); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/pkg/materialize/database.go
+++ b/pkg/materialize/database.go
@@ -36,6 +36,7 @@ func (b *DatabaseBuilder) Drop() error {
 type DatabaseParams struct {
 	DatabaseId   sql.NullString `db:"id"`
 	DatabaseName sql.NullString `db:"database_name"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -44,11 +45,14 @@ var databaseQuery = NewBaseQuery(`
 	SELECT
 		mz_databases.id,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_databases.privileges
 	FROM mz_databases
 	JOIN mz_roles
-		ON mz_databases.owner_id = mz_roles.id`)
+		ON mz_databases.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_databases.id = mz_comments.id`)
 
 func DatabaseId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := databaseQuery.QueryPredicate(map[string]string{"mz_databases.name": obj.Name})

--- a/pkg/materialize/database.go
+++ b/pkg/materialize/database.go
@@ -45,14 +45,18 @@ var databaseQuery = NewBaseQuery(`
 	SELECT
 		mz_databases.id,
 		mz_databases.name AS database_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_databases.privileges
 	FROM mz_databases
 	JOIN mz_roles
 		ON mz_databases.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_databases.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'database'
+	) comments
+		ON mz_databases.id = comments.id`)
 
 func DatabaseId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	q := databaseQuery.QueryPredicate(map[string]string{"mz_databases.name": obj.Name})

--- a/pkg/materialize/index_test.go
+++ b/pkg/materialize/index_test.go
@@ -14,7 +14,8 @@ func TestIndexCreate(t *testing.T) {
 			`CREATE INDEX index IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT \(column\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewIndexBuilder(db, "index", false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
+		o := MaterializeObject{Name: "index"}
+		b := NewIndexBuilder(db, o, false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
 		b.ClusterName("cluster")
 		b.Method("ARRANGEMENT")
 		b.ColExpr([]IndexColumn{
@@ -35,7 +36,8 @@ func TestIndexDefaultCreate(t *testing.T) {
 			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT \(\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewIndexBuilder(db, "", true, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
+		o := MaterializeObject{Name: "index"}
+		b := NewIndexBuilder(db, o, true, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
 		b.ClusterName("cluster")
 		b.Method("ARRANGEMENT")
 
@@ -49,8 +51,21 @@ func TestIndexDrop(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`DROP INDEX "database"."schema"."index" RESTRICT;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		b := NewIndexBuilder(db, "index", false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
+		o := MaterializeObject{Name: "index"}
+		b := NewIndexBuilder(db, o, false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
 		if err := b.Drop(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestIndexComment(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`COMMENT ON INDEX "database"."schema"."index" IS 'comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "index"}
+		b := NewIndexBuilder(db, o, false, IdentifierSchemaStruct{SchemaName: "schema", Name: "source", DatabaseName: "database"})
+		if err := b.Comment("comment"); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -82,7 +82,7 @@ var materializedViewQuery = NewBaseQuery(`
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_clusters.name AS cluster_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_materialized_views.privileges
 	FROM mz_materialized_views
@@ -94,8 +94,12 @@ var materializedViewQuery = NewBaseQuery(`
 		ON mz_materialized_views.cluster_id = mz_clusters.id
 	JOIN mz_roles
 		ON mz_materialized_views.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_materialized_views.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'materialized-view'
+	) comments
+		ON mz_materialized_views.id = comments.id`)
 
 func MaterializedViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -70,6 +70,7 @@ type MaterializedViewParams struct {
 	SchemaName           sql.NullString `db:"schema_name"`
 	DatabaseName         sql.NullString `db:"database_name"`
 	Cluster              sql.NullString `db:"cluster_name"`
+	Comment              sql.NullString `db:"comment"`
 	OwnerName            sql.NullString `db:"owner_name"`
 	Privileges           sql.NullString `db:"privileges"`
 }
@@ -81,6 +82,7 @@ var materializedViewQuery = NewBaseQuery(`
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_clusters.name AS cluster_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_materialized_views.privileges
 	FROM mz_materialized_views
@@ -91,7 +93,9 @@ var materializedViewQuery = NewBaseQuery(`
 	LEFT JOIN mz_clusters
 		ON mz_materialized_views.cluster_id = mz_clusters.id
 	JOIN mz_roles
-		ON mz_materialized_views.owner_id = mz_roles.id`)
+		ON mz_materialized_views.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_materialized_views.id = mz_comments.id`)
 
 func MaterializedViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/role.go
+++ b/pkg/materialize/role.go
@@ -14,10 +14,10 @@ type RoleBuilder struct {
 	inherit  bool
 }
 
-func NewRoleBuilder(conn *sqlx.DB, roleName string) *RoleBuilder {
+func NewRoleBuilder(conn *sqlx.DB, obj MaterializeObject) *RoleBuilder {
 	return &RoleBuilder{
 		ddl:      Builder{conn, Role},
-		roleName: roleName,
+		roleName: obj.Name,
 	}
 }
 
@@ -66,14 +66,22 @@ type RoleParams struct {
 	RoleId   sql.NullString `db:"id"`
 	RoleName sql.NullString `db:"role_name"`
 	Inherit  sql.NullBool   `db:"inherit"`
+	Comment  sql.NullString `db:"comment"`
 }
 
 var roleQuery = NewBaseQuery(`
 	SELECT
-		id,
-		name AS role_name,
-		inherit
-	FROM mz_roles`)
+		mz_roles.id,
+		mz_roles.name AS role_name,
+		mz_roles.inherit,
+		comments.comment AS comment
+	FROM mz_roles
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'role'
+	) comments
+		ON mz_roles.id = comments.id`)
 
 func RoleId(conn *sqlx.DB, roleName string) (string, error) {
 	if roleName == "PUBLIC" {

--- a/pkg/materialize/role_test.go
+++ b/pkg/materialize/role_test.go
@@ -13,7 +13,9 @@ func TestRoleCreate(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE ROLE "role" INHERIT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
-		b := NewRoleBuilder(db, "role")
+
+		o := MaterializeObject{Name: "role"}
+		b := NewRoleBuilder(db, o)
 		b.Inherit()
 
 		if err := b.Create(); err != nil {
@@ -28,7 +30,8 @@ func TestRoleAlter(t *testing.T) {
 			`ALTER ROLE "role" INHERIT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		if err := NewRoleBuilder(db, "role").Alter("INHERIT"); err != nil {
+		o := MaterializeObject{Name: "role"}
+		if err := NewRoleBuilder(db, o).Alter("INHERIT"); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -40,7 +43,8 @@ func TestRoleDrop(t *testing.T) {
 			`DROP ROLE "role";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		if err := NewRoleBuilder(db, "role").Drop(); err != nil {
+		o := MaterializeObject{Name: "role"}
+		if err := NewRoleBuilder(db, o).Drop(); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -51,7 +51,7 @@ var schemaQuery = NewBaseQuery(`
 		mz_schemas.id,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_schemas.privileges
 	FROM mz_schemas
@@ -59,8 +59,12 @@ var schemaQuery = NewBaseQuery(`
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
 		ON mz_schemas.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_schemas.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'schema'
+	) comments
+		ON mz_schemas.id = comments.id`)
 
 func SchemaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -60,7 +60,7 @@ var schemaQuery = NewBaseQuery(`
 	JOIN mz_roles
 		ON mz_schemas.owner_id = mz_roles.id
 	LEFT JOIN mz_internal.mz_comments
-		ON mz_clusters.id = mz_comments.id`)
+		ON mz_schemas.id = mz_comments.id`)
 
 func SchemaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -41,6 +41,7 @@ type SchemaParams struct {
 	SchemaId     sql.NullString `db:"id"`
 	SchemaName   sql.NullString `db:"schema_name"`
 	DatabaseName sql.NullString `db:"database_name"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -50,13 +51,16 @@ var schemaQuery = NewBaseQuery(`
 		mz_schemas.id,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_schemas.privileges
 	FROM mz_schemas
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_schemas.owner_id = mz_roles.id`)
+		ON mz_schemas.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_clusters.id = mz_comments.id`)
 
 func SchemaId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/secret.go
+++ b/pkg/materialize/secret.go
@@ -71,7 +71,7 @@ var secretQuery = NewBaseQuery(`
 		mz_secrets.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_secrets.privileges
 	FROM mz_secrets
@@ -81,8 +81,12 @@ var secretQuery = NewBaseQuery(`
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
 		ON mz_secrets.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_secrets.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'secret'
+	) comments
+		ON mz_secrets.id = comments.id`)
 
 func SecretId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/secret.go
+++ b/pkg/materialize/secret.go
@@ -60,6 +60,7 @@ type SecretParams struct {
 	SecretName   sql.NullString `db:"name"`
 	SchemaName   sql.NullString `db:"schema_name"`
 	DatabaseName sql.NullString `db:"database_name"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -70,6 +71,7 @@ var secretQuery = NewBaseQuery(`
 		mz_secrets.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_secrets.privileges
 	FROM mz_secrets
@@ -78,7 +80,9 @@ var secretQuery = NewBaseQuery(`
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_secrets.owner_id = mz_roles.id`)
+		ON mz_secrets.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_secrets.id = mz_comments.id`)
 
 func SecretId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/sink.go
+++ b/pkg/materialize/sink.go
@@ -65,7 +65,7 @@ var sinkQuery = NewBaseQuery(`
 		mz_sinks.envelope_type,
 		mz_connections.name as connection_name,
 		mz_clusters.name as cluster_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name
 	FROM mz_sinks
 	JOIN mz_schemas
@@ -78,8 +78,12 @@ var sinkQuery = NewBaseQuery(`
 		ON mz_sinks.cluster_id = mz_clusters.id
 	JOIN mz_roles
 		ON mz_sinks.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_sinks.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'sink'
+	) comments
+		ON mz_sinks.id = comments.id`)
 
 func SinkId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/sink.go
+++ b/pkg/materialize/sink.go
@@ -50,6 +50,7 @@ type SinkParams struct {
 	EnvelopeType   sql.NullString `db:"envelope_type"`
 	ConnectionName sql.NullString `db:"connection_name"`
 	ClusterName    sql.NullString `db:"cluster_name"`
+	Comment        sql.NullString `db:"comment"`
 	OwnerName      sql.NullString `db:"owner_name"`
 }
 
@@ -64,6 +65,7 @@ var sinkQuery = NewBaseQuery(`
 		mz_sinks.envelope_type,
 		mz_connections.name as connection_name,
 		mz_clusters.name as cluster_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name
 	FROM mz_sinks
 	JOIN mz_schemas
@@ -75,7 +77,9 @@ var sinkQuery = NewBaseQuery(`
 	LEFT JOIN mz_clusters
 		ON mz_sinks.cluster_id = mz_clusters.id
 	JOIN mz_roles
-		ON mz_sinks.owner_id = mz_roles.id`)
+		ON mz_sinks.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_sinks.id = mz_comments.id`)
 
 func SinkId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/table.go
+++ b/pkg/materialize/table.go
@@ -92,6 +92,7 @@ type TableParams struct {
 	TableName    sql.NullString `db:"name"`
 	SchemaName   sql.NullString `db:"schema_name"`
 	DatabaseName sql.NullString `db:"database_name"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -102,6 +103,7 @@ var tableQuery = NewBaseQuery(`
 		mz_tables.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_tables.privileges
 	FROM mz_tables
@@ -110,7 +112,12 @@ var tableQuery = NewBaseQuery(`
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_tables.owner_id = mz_roles.id`)
+		ON mz_tables.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_tables.id = mz_comments.id`).
+	CustomPredicate([]string{
+		"mz_comments.object_sub_id IS NULL",
+	})
 
 func TableId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/table.go
+++ b/pkg/materialize/table.go
@@ -12,6 +12,7 @@ type TableColumn struct {
 	ColName string
 	ColType string
 	NotNull bool
+	Comment string
 }
 
 func GetTableColumnStruct(v []interface{}) []TableColumn {
@@ -22,6 +23,7 @@ func GetTableColumnStruct(v []interface{}) []TableColumn {
 			ColName: c["name"].(string),
 			ColType: c["type"].(string),
 			NotNull: c["nullable"].(bool),
+			Comment: c["comment"].(string),
 		})
 	}
 	return columns

--- a/pkg/materialize/type.go
+++ b/pkg/materialize/type.go
@@ -124,7 +124,7 @@ var typeQuery = NewBaseQuery(`
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_types.category,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_types.privileges
 	FROM mz_types
@@ -134,8 +134,12 @@ var typeQuery = NewBaseQuery(`
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
 		ON mz_types.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_types.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'type'
+	) comments
+		ON mz_types.id = comments.id`)
 
 func TypeId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/type.go
+++ b/pkg/materialize/type.go
@@ -112,6 +112,7 @@ type TypeParams struct {
 	SchemaName   sql.NullString `db:"schema_name"`
 	DatabaseName sql.NullString `db:"database_name"`
 	Category     sql.NullString `db:"category"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -123,6 +124,7 @@ var typeQuery = NewBaseQuery(`
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_types.category,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_types.privileges
 	FROM mz_types
@@ -131,7 +133,9 @@ var typeQuery = NewBaseQuery(`
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_types.owner_id = mz_roles.id`)
+		ON mz_types.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_types.id = mz_comments.id`)
 
 func TypeId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/view.go
+++ b/pkg/materialize/view.go
@@ -55,6 +55,7 @@ type ViewParams struct {
 	ViewName     sql.NullString `db:"name"`
 	SchemaName   sql.NullString `db:"schema_name"`
 	DatabaseName sql.NullString `db:"database_name"`
+	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   sql.NullString `db:"privileges"`
 }
@@ -65,6 +66,7 @@ var viewQuery = NewBaseQuery(`
 		mz_views.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_views.privileges
 	FROM mz_views
@@ -73,7 +75,9 @@ var viewQuery = NewBaseQuery(`
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_views.owner_id = mz_roles.id`)
+		ON mz_views.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_views.id = mz_comments.id`)
 
 func ViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/materialize/view.go
+++ b/pkg/materialize/view.go
@@ -66,7 +66,7 @@ var viewQuery = NewBaseQuery(`
 		mz_views.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
-		mz_comments.comment AS comment,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_views.privileges
 	FROM mz_views
@@ -76,8 +76,12 @@ var viewQuery = NewBaseQuery(`
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
 		ON mz_views.owner_id = mz_roles.id
-	LEFT JOIN mz_internal.mz_comments
-		ON mz_views.id = mz_comments.id`)
+	LEFT JOIN (
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'view'
+	) comments
+		ON mz_views.id = comments.id`)
 
 func ViewId(conn *sqlx.DB, obj MaterializeObject) (string, error) {
 	p := map[string]string{

--- a/pkg/provider/acceptance_table_test.go
+++ b/pkg/provider/acceptance_table_test.go
@@ -29,6 +29,7 @@ func TestAccTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_table.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_table.test", "ownership_role", "mz_system"),
+					resource.TestCheckResourceAttr("materialize_table.test", "comment", "comment"),
 					resource.TestCheckResourceAttr("materialize_table.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, tableName)),
 					resource.TestCheckResourceAttr("materialize_table.test", "column.#", "3"),
 					resource.TestCheckResourceAttr("materialize_table.test", "ownership_role", "mz_system"),
@@ -118,13 +119,15 @@ resource "materialize_role" "test" {
 
 resource "materialize_table" "test" {
 	name = "%s"
+	comment = "comment"
 	column {
 		name = "column_1"
 		type = "text"
 	}
 	column {
-		name = "column_2"
-		type = "int"
+		name    = "column_2"
+		type    = "int"
+		comment = "comment"
 	}
 	column {
 		name     = "column_3"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -193,6 +193,17 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			})
 			return nil, diags
 		}
+
+		// TODO: Remove this once enable_comment is enabled by default
+		_, err = db.Exec("ALTER SYSTEM SET enable_comment = true;")
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Unable to enable connection comment",
+				Detail:   "Unable to enable connection comment for authenticated Materialize client",
+			})
+			return nil, diags
+		}
 	}
 
 	return db, diags

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -14,7 +14,7 @@ import (
 
 var clusterSchema = map[string]*schema.Schema{
 	"name":           ObjectNameSchema("cluster", true, true),
-	"comment":        CommentSchema(),
+	"comment":        CommentSchema(false),
 	"ownership_role": OwnershipRoleSchema(),
 	"size":           SizeSchema("managed cluster", false, false),
 	"replication_factor": {

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -90,7 +90,11 @@ func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	replicaName := d.Get("name").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	o := materialize.MaterializeObject{Name: replicaName, ClusterName: clusterName}
+	o := materialize.MaterializeObject{
+		ObjectType:  "CLUSTER REPLICA",
+		Name:        replicaName,
+		ClusterName: clusterName,
+	}
 	b := materialize.NewClusterReplicaBuilder(meta.(*sqlx.DB), o)
 
 	if v, ok := d.GetOk("size"); ok {

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -23,6 +23,7 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 		"introspection_interval":        "10s",
 		"introspection_debugging":       true,
 		"idle_arrangement_merge_effort": 100,
+		"comment":                       "object comment",
 	}
 	d := schema.TestResourceDataRaw(t, ClusterReplica().Schema, in)
 	r.NotNil(d)
@@ -37,6 +38,9 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 			INTROSPECTION DEBUGGING = TRUE,
 			IDLE ARRANGEMENT MERGE EFFORT = 100;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Comment
+		mock.ExpectExec(`COMMENT ON CLUSTER REPLICA "cluster"."replica" IS 'object comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
 		ip := `WHERE mz_cluster_replicas.name = 'replica' AND mz_clusters.name = 'cluster'`

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -40,6 +40,10 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("comment", s.Comment.String); err != nil {
+		return diag.FromErr(err)
+	}
+
 	b := materialize.Connection{ConnectionName: s.ConnectionName.String, SchemaName: s.SchemaName.String, DatabaseName: s.DatabaseName.String}
 	if err := d.Set("qualified_sql_name", b.QualifiedName()); err != nil {
 		return diag.FromErr(err)
@@ -69,6 +73,15 @@ func connectionUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("comment") {
+		_, newComment := d.GetChange("comment")
+		b := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+
+		if err := b.Object(newComment.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_connection_postgres.go
+++ b/pkg/resources/resource_connection_postgres.go
@@ -16,6 +16,7 @@ var connectionPostgresSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("connection", false),
 	"database_name":      DatabaseNameSchema("connection", false),
 	"qualified_sql_name": QualifiedNameSchema("connection"),
+	"comment":            CommentSchema(false),
 	"database": {
 		Description: "The target Postgres database.",
 		Type:        schema.TypeString,
@@ -147,6 +148,17 @@ func connectionPostgresCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
+			return diag.FromErr(err)
+		}
+	}
+
+	// object comment
+	if v, ok := d.GetOk("comment"); ok {
+		comment := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+
+		if err := comment.Object(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
 			b.Drop()
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_grant_materialized_view_test.go
+++ b/pkg/resources/resource_grant_materialized_view_test.go
@@ -36,11 +36,11 @@ func TestResourceGrantMaterializedViewCreate(t *testing.T) {
 
 		// Query Grant Id
 		gp := `WHERE mz_databases.name = 'database' AND mz_materialized_views.name = 'mview' AND mz_schemas.name = 'schema'`
-		testhelpers.MockMaterailizeViewScan(mock, gp)
+		testhelpers.MockMaterializeViewScan(mock, gp)
 
 		// Query Params
 		pp := `WHERE mz_materialized_views.id = 'u1'`
-		testhelpers.MockMaterailizeViewScan(mock, pp)
+		testhelpers.MockMaterializeViewScan(mock, pp)
 
 		if err := grantMaterializedViewCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_table_test.go
+++ b/pkg/resources/resource_grant_table_test.go
@@ -35,11 +35,11 @@ func TestResourceGrantTableCreate(t *testing.T) {
 		testhelpers.MockRoleScan(mock, rp)
 
 		// Query Grant Id
-		gp := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
+		gp := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
 		testhelpers.MockTableScan(mock, gp)
 
 		// Query Params
-		pp := `WHERE mz_comments.object_sub_id IS NULL AND mz_tables.id = 'u1'`
+		pp := `WHERE mz_tables.id = 'u1'`
 		testhelpers.MockTableScan(mock, pp)
 
 		if err := grantTableCreate(context.TODO(), d, db); err != nil {

--- a/pkg/resources/resource_grant_table_test.go
+++ b/pkg/resources/resource_grant_table_test.go
@@ -35,11 +35,11 @@ func TestResourceGrantTableCreate(t *testing.T) {
 		testhelpers.MockRoleScan(mock, rp)
 
 		// Query Grant Id
-		gp := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
+		gp := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
 		testhelpers.MockTableScan(mock, gp)
 
 		// Query Params
-		pp := `WHERE mz_tables.id = 'u1'`
+		pp := `WHERE mz_comments.object_sub_id IS NULL AND mz_tables.id = 'u1'`
 		testhelpers.MockTableScan(mock, pp)
 
 		if err := grantTableCreate(context.TODO(), d, db); err != nil {

--- a/pkg/resources/resource_materialized_view_test.go
+++ b/pkg/resources/resource_materialized_view_test.go
@@ -32,11 +32,11 @@ func TestResourceMaterializedViewCreate(t *testing.T) {
 
 		// Query Id
 		ip := `WHERE mz_databases.name = 'database' AND mz_materialized_views.name = 'materialized_view' AND mz_schemas.name = 'schema'`
-		testhelpers.MockMaterailizeViewScan(mock, ip)
+		testhelpers.MockMaterializeViewScan(mock, ip)
 
 		// Query Params
 		pp := `WHERE mz_materialized_views.id = 'u1'`
-		testhelpers.MockMaterailizeViewScan(mock, pp)
+		testhelpers.MockMaterializeViewScan(mock, pp)
 
 		if err := materializedViewCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
@@ -58,7 +58,7 @@ func TestResourceMaterializedViewUpdate(t *testing.T) {
 
 		// Query Params
 		pp := `WHERE mz_materialized_views.id = 'u1'`
-		testhelpers.MockMaterailizeViewScan(mock, pp)
+		testhelpers.MockMaterializeViewScan(mock, pp)
 
 		if err := materializedViewUpdate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_sink.go
+++ b/pkg/resources/resource_sink.go
@@ -53,6 +53,10 @@ func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 
+	if err := d.Set("comment", s.Comment.String); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -85,6 +89,15 @@ func sinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		b := materialize.NewOwnershipBuilder(meta.(*sqlx.DB), o)
 
 		if err := b.Alter(newRole.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("comment") {
+		_, newComment := d.GetChange("comment")
+		b := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+
+		if err := b.Object(newComment.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -16,6 +16,7 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("source", false),
 	"database_name":      DatabaseNameSchema("source", false),
 	"qualified_sql_name": QualifiedNameSchema("source"),
+	"comment":            CommentSchema(false),
 	"cluster_name":       ObjectClusterNameSchema("source"),
 	"size":               ObjectSizeSchema("source"),
 	"kafka_connection":   IdentifierSchema("kafka_connection", "The Kafka connection to use in the source.", true),
@@ -270,6 +271,17 @@ func sourceKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
+			return diag.FromErr(err)
+		}
+	}
+
+	// object comment
+	if v, ok := d.GetOk("comment"); ok {
+		comment := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+
+		if err := comment.Object(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
 			b.Drop()
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_source_webhook.go
+++ b/pkg/resources/resource_source_webhook.go
@@ -16,6 +16,7 @@ var sourceWebhookSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("source", false),
 	"database_name":      DatabaseNameSchema("source", false),
 	"qualified_sql_name": QualifiedNameSchema("source"),
+	"comment":            CommentSchema(false),
 	"cluster_name": {
 		Description: "The cluster to maintain this source.",
 		Type:        schema.TypeString,
@@ -158,6 +159,17 @@ func sourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if err := ownership.Alter(v.(string)); err != nil {
 			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
+			b.Drop()
+			return diag.FromErr(err)
+		}
+	}
+
+	// object comment
+	if v, ok := d.GetOk("comment"); ok {
+		comment := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+
+		if err := comment.Object(v.(string)); err != nil {
+			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
 			b.Drop()
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -17,7 +17,7 @@ var tableSchema = map[string]*schema.Schema{
 	"schema_name":        SchemaNameSchema("table", false),
 	"database_name":      DatabaseNameSchema("table", false),
 	"qualified_sql_name": QualifiedNameSchema("table"),
-	"comment":            CommentSchema(),
+	"comment":            CommentSchema(false),
 	"column": {
 		Description: "Column of the table.",
 		Type:        schema.TypeList,
@@ -46,7 +46,7 @@ var tableSchema = map[string]*schema.Schema{
 					Optional:    true,
 					Default:     false,
 				},
-				"comment": CommentSchema(),
+				"comment": CommentSchema(false),
 			},
 		},
 		Optional: true,

--- a/pkg/resources/resource_table_test.go
+++ b/pkg/resources/resource_table_test.go
@@ -17,7 +17,8 @@ var inTable = map[string]interface{}{
 	"schema_name":    "schema",
 	"database_name":  "database",
 	"ownership_role": "joe",
-	"column":         []interface{}{map[string]interface{}{"name": "column", "type": "text", "nullable": true}},
+	"comment":        "object comment",
+	"column":         []interface{}{map[string]interface{}{"name": "column", "type": "text", "nullable": true, "comment": "column comment"}},
 }
 
 func TestResourceTableCreate(t *testing.T) {
@@ -31,6 +32,10 @@ func TestResourceTableCreate(t *testing.T) {
 
 		// Ownership
 		mock.ExpectExec(`ALTER TABLE "database"."schema"."table" OWNER TO "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Comment
+		mock.ExpectExec(`COMMENT ON TABLE "database"."schema"."table" IS 'object comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`COMMENT ON COLUMN "database"."schema"."table"."column" IS 'column comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
 		ip := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`

--- a/pkg/resources/resource_table_test.go
+++ b/pkg/resources/resource_table_test.go
@@ -38,11 +38,11 @@ func TestResourceTableCreate(t *testing.T) {
 		mock.ExpectExec(`COMMENT ON COLUMN "database"."schema"."table"."column" IS 'column comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
-		ip := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
+		ip := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
 		testhelpers.MockTableScan(mock, ip)
 
 		// Query Params
-		pp := `WHERE mz_tables.id = 'u1'`
+		pp := `WHERE mz_comments.object_sub_id IS NULL AND mz_tables.id = 'u1'`
 		testhelpers.MockTableScan(mock, pp)
 
 		// Query Columns

--- a/pkg/resources/resource_table_test.go
+++ b/pkg/resources/resource_table_test.go
@@ -38,11 +38,11 @@ func TestResourceTableCreate(t *testing.T) {
 		mock.ExpectExec(`COMMENT ON COLUMN "database"."schema"."table"."column" IS 'column comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
-		ip := `WHERE mz_comments.object_sub_id IS NULL AND mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
+		ip := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
 		testhelpers.MockTableScan(mock, ip)
 
 		// Query Params
-		pp := `WHERE mz_comments.object_sub_id IS NULL AND mz_tables.id = 'u1'`
+		pp := `WHERE mz_tables.id = 'u1'`
 		testhelpers.MockTableScan(mock, pp)
 
 		// Query Columns

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -432,3 +432,12 @@ func PrivilegeSchema(objectType string) *schema.Schema {
 		ValidateFunc: validPrivileges(objectType),
 	}
 }
+
+func CommentSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "**Private Preview** Comment on an object in the database.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		ForceNew:    false,
+	}
+}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -433,11 +433,11 @@ func PrivilegeSchema(objectType string) *schema.Schema {
 	}
 }
 
-func CommentSchema() *schema.Schema {
+func CommentSchema(forceNew bool) *schema.Schema {
 	return &schema.Schema{
 		Description: "**Private Preview** Comment on an object in the database.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		ForceNew:    false,
+		ForceNew:    forceNew,
 	}
 }

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -313,7 +313,7 @@ func MockSchemaScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_roles
 		ON mz_schemas.owner_id = mz_roles.id
 	LEFT JOIN mz_internal.mz_comments
-		ON mz_clusters.id = mz_comments.id`
+		ON mz_schemas.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "schema_name", "database_name", "owner_name", "privileges"}).
@@ -328,6 +328,7 @@ func MockSecretScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_secrets.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,	
 		mz_roles.name AS owner_name,
 		mz_secrets.privileges
 	FROM mz_secrets
@@ -336,7 +337,9 @@ func MockSecretScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_secrets.owner_id = mz_roles.id`
+		ON mz_secrets.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_secrets.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -32,14 +32,17 @@ func MockClusterReplicaScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_clusters.name AS cluster_name,
 		mz_cluster_replicas.size,
 		mz_cluster_replicas.availability_zone,
-		mz_cluster_replicas.disk
+		mz_cluster_replicas.disk,
+		mz_comments.comment AS comment
 	FROM mz_cluster_replicas
 	JOIN mz_clusters
-		ON mz_cluster_replicas.cluster_id = mz_clusters.id`
+		ON mz_cluster_replicas.cluster_id = mz_clusters.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_cluster_replicas.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
-	ir := mock.NewRows([]string{"id", "replica_name", "cluster_name", "size", "availability_zone", "disk"}).
-		AddRow("u1", "replica", "cluster", "small", "use1-az2", false)
+	ir := mock.NewRows([]string{"id", "replica_name", "cluster_name", "size", "availability_zone", "disk", "comment"}).
+		AddRow("u1", "replica", "cluster", "small", "use1-az2", false, "comment")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -305,12 +305,15 @@ func MockSchemaScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_schemas.id,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_schemas.privileges
 	FROM mz_schemas JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_schemas.owner_id = mz_roles.id`
+		ON mz_schemas.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_clusters.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "schema_name", "database_name", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -52,15 +52,18 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_clusters.size,
 		mz_clusters.replication_factor,
 		mz_clusters.disk,
+		mz_comments.comment AS comment,	
 		mz_roles.name AS owner_name,
 		mz_clusters.privileges
 	FROM mz_clusters
 	JOIN mz_roles
-		ON mz_clusters.owner_id = mz_roles.id`
+		ON mz_clusters.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_clusters.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
-	ir := mock.NewRows([]string{"id", "name", "managed", "size", "replication_factor", "disk", "owner_name", "privileges"}).
-		AddRow("u1", "cluster", true, "small", 2, true, "joe", "{u1=UC/u18}")
+	ir := mock.NewRows([]string{"id", "name", "managed", "size", "replication_factor", "disk", "comment", "owner_name", "privileges"}).
+		AddRow("u1", "cluster", true, "small", 2, true, "comment", "joe", "{u1=UC/u18}")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -239,7 +239,7 @@ func MockIndexScan(mock sqlmock.Sqlmock, predicate string) {
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
-func MockMaterailizeViewScan(mock sqlmock.Sqlmock, predicate string) {
+func MockMaterializeViewScan(mock sqlmock.Sqlmock, predicate string) {
 	b := `
 	SELECT
 		mz_materialized_views.id,
@@ -247,6 +247,7 @@ func MockMaterailizeViewScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_clusters.name AS cluster_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_materialized_views.privileges
 	FROM mz_materialized_views
@@ -257,7 +258,9 @@ func MockMaterailizeViewScan(mock sqlmock.Sqlmock, predicate string) {
 	LEFT JOIN mz_clusters
 		ON mz_materialized_views.cluster_id = mz_clusters.id
 	JOIN mz_roles
-		ON mz_materialized_views.owner_id = mz_roles.id`
+		ON mz_materialized_views.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_materialized_views.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "materialized_view_name", "schema_name", "database_name", "cluster_name", "owner_name", "privileges"}).
@@ -523,6 +526,7 @@ func MockViewScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_views.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_views.privileges
 	FROM mz_views
@@ -531,7 +535,9 @@ func MockViewScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_views.owner_id = mz_roles.id`
+		ON mz_views.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_views.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := sqlmock.NewRows([]string{"id", "name", "schema_name", "database_name", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -177,11 +177,14 @@ func MockDatabaseScan(mock sqlmock.Sqlmock, predicate string) {
 	SELECT
 		mz_databases.id,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_databases.privileges
 	FROM mz_databases
 	JOIN mz_roles
-		ON mz_databases.owner_id = mz_roles.id`
+		ON mz_databases.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_databases.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "database_name", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -425,9 +425,13 @@ func MockTableColumnScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_columns.name,
 		mz_columns.position,
 		mz_columns.nullable,
+		mz_comments.comment,
 		mz_columns.type,
 		mz_columns.default
-	FROM mz_columns`
+	FROM mz_columns
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_columns.id = mz_comments.id
+		AND mz_columns.position = mz_comments.object_sub_id`
 
 	q := mockQueryBuilder(b, predicate, "ORDER BY mz_columns.position")
 	ir := mock.NewRows([]string{"id", "name", "position", "nullable", "type", "default"}).
@@ -448,6 +452,7 @@ func MockTableScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_tables.name,
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_tables.privileges
 	FROM mz_tables
@@ -456,11 +461,13 @@ func MockTableScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_tables.owner_id = mz_roles.id`
+		ON mz_tables.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_tables.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
-	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "owner_name", "privileges"}).
-		AddRow("u1", "table", "schema", "database", "materialize", "{u1=arwd/u18}")
+	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "comment", "owner_name", "privileges"}).
+		AddRow("u1", "table", "schema", "database", "comment", "materialize", "{u1=arwd/u18}")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -86,6 +86,7 @@ func MockConnectionScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_connections.type AS connection_type,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_connections.privileges
 	FROM mz_connections
@@ -94,7 +95,13 @@ func MockConnectionScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_connections.owner_id = mz_roles.id`
+		ON mz_connections.owner_id = mz_roles.id
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'connection'
+	\) comments
+		ON mz_connections.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "connection_name", "schema_name", "database_name", "connection_type", "owner_name", "privileges"}).
@@ -110,6 +117,7 @@ func MockConnectionAwsPrivatelinkScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_aws_privatelink_connections.principal,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name
 	FROM mz_connections
 	JOIN mz_schemas
@@ -119,7 +127,13 @@ func MockConnectionAwsPrivatelinkScan(mock sqlmock.Sqlmock, predicate string) {
 	LEFT JOIN mz_aws_privatelink_connections
 		ON mz_connections.id = mz_aws_privatelink_connections.id
 	JOIN mz_roles
-		ON mz_connections.owner_id = mz_roles.id`
+		ON mz_connections.owner_id = mz_roles.id
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'connection'
+	\) comments
+		ON mz_connections.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "connection_name", "schema_name", "database_name", "principal"}).
@@ -136,6 +150,7 @@ func MockConnectionSshTunnelScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_databases.name AS database_name,
 		mz_ssh_tunnel_connections.public_key_1,
 		mz_ssh_tunnel_connections.public_key_2,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name
 	FROM mz_connections
 	JOIN mz_schemas
@@ -145,7 +160,13 @@ func MockConnectionSshTunnelScan(mock sqlmock.Sqlmock, predicate string) {
 	LEFT JOIN mz_ssh_tunnel_connections
 		ON mz_connections.id = mz_ssh_tunnel_connections.id
 	JOIN mz_roles
-		ON mz_connections.owner_id = mz_roles.id`
+		ON mz_connections.owner_id = mz_roles.id
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'connection'
+	\) comments
+		ON mz_connections.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "connection_name", "schema_name", "database_name", "public_key_1", "public_key_2"}).
@@ -236,14 +257,21 @@ func MockIndexScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_indexes.name AS index_name,
 		mz_objects.name AS obj_name,
 		mz_schemas.name AS obj_schema_name,
-		mz_databases.name AS obj_database_name
+		mz_databases.name AS obj_database_name,
+		comments.comment AS comment
 	FROM mz_indexes
 	JOIN mz_objects
 		ON mz_indexes.on_id = mz_objects.id
 	LEFT JOIN mz_schemas
 		ON mz_objects.schema_id = mz_schemas.id
 	LEFT JOIN mz_databases
-		ON mz_schemas.database_id = mz_databases.id`
+		ON mz_schemas.database_id = mz_databases.id
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'index'
+	\) comments
+		ON mz_indexes.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "index_name", "obj_name", "obj_schema_name", "obj_database_name"}).
@@ -294,10 +322,17 @@ func MockSystemPrivilege(mock sqlmock.Sqlmock) {
 func MockRoleScan(mock sqlmock.Sqlmock, predicate string) {
 	b := `
 	SELECT
-		id,
-		name AS role_name,
-		inherit
-	FROM mz_roles`
+		mz_roles.id,
+		mz_roles.name AS role_name,
+		mz_roles.inherit,
+		comments.comment AS comment
+	FROM mz_roles
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'role'
+	\) comments
+		ON mz_roles.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "role_name", "inherit"}).
@@ -424,6 +459,7 @@ func MockSourceScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_sources.envelope_type,
 		mz_connections.name as connection_name,
 		mz_clusters.name as cluster_name,
+		comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_sources.privileges
 	FROM mz_sources
@@ -436,7 +472,13 @@ func MockSourceScan(mock sqlmock.Sqlmock, predicate string) {
 	LEFT JOIN mz_clusters
 		ON mz_sources.cluster_id = mz_clusters.id
 	JOIN mz_roles
-		ON mz_sources.owner_id = mz_roles.id`
+		ON mz_sources.owner_id = mz_roles.id
+	LEFT JOIN \(
+		SELECT id, comment
+		FROM mz_internal.mz_comments
+		WHERE object_type = 'source'
+	\) comments
+		ON mz_sources.id = comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "source_type", "size", "envelope_type", "connection_name", "cluster_name", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -497,6 +497,7 @@ func MockTypeScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_schemas.name AS schema_name,
 		mz_databases.name AS database_name,
 		mz_types.category,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name,
 		mz_types.privileges
 	FROM mz_types
@@ -505,7 +506,9 @@ func MockTypeScan(mock sqlmock.Sqlmock, predicate string) {
 	JOIN mz_databases
 		ON mz_schemas.database_id = mz_databases.id
 	JOIN mz_roles
-		ON mz_types.owner_id = mz_roles.id`
+		ON mz_types.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_types.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "category", "owner_name", "privileges"}).

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -359,6 +359,7 @@ func MockSinkScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_sinks.envelope_type,
 		mz_connections.name as connection_name,
 		mz_clusters.name as cluster_name,
+		mz_comments.comment AS comment,
 		mz_roles.name AS owner_name
 	FROM mz_sinks
 	JOIN mz_schemas
@@ -370,7 +371,9 @@ func MockSinkScan(mock sqlmock.Sqlmock, predicate string) {
 	LEFT JOIN mz_clusters
 		ON mz_sinks.cluster_id = mz_clusters.id
 	JOIN mz_roles
-		ON mz_sinks.owner_id = mz_roles.id`
+		ON mz_sinks.owner_id = mz_roles.id
+	LEFT JOIN mz_internal.mz_comments
+		ON mz_sinks.id = mz_comments.id`
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "sink_type", "size", "envelope_type", "connection_name", "cluster_name", "owner_name"}).


### PR DESCRIPTION
Add support for [`COMMENT`](https://materialize.com/docs/sql/comment-on/) for both objects and columns within objects:

- [x] Cluster
- [x] Cluster Replica
- [x] Database
- [x] Index (Materialize Object issue)
- [x] Materialized View
- [x] Role (Materialize Object issue)
- [x] Schema
- [x] Secret
- [x] Sink
- [x] Source (Multi)
- [x] Connection (Multi)
- [x] Table
- [x] Table (Column)
- [x] Type
- [x] View