### PR TITLE
Grant Fails Object Removed

### DIFF
--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -41,7 +42,10 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 
 	privileges, err := materialize.ScanPrivileges(meta.(*sqlx.DB), key.objectType, key.objectId)
-	if err != nil {
+	if err == sql.ErrNoRows {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Prevent `grantRead` from failing if the the underlying object that the grant is on has been dropped.

New workflow (integration tests as example):

1. Deploy project `terraform apply`
2. Drop object `DROP TABLE example_database.example_schema.simple_table;`
3. Run `terraform plan` will now succeed and look to recreate the table and grants:
```
  # materialize_table.simple_table will be created
  + resource "materialize_table" "simple_table" {
      + comment            = "table comment"
      + database_name      = "example_database"
      + id                 = (known after apply)
      + name               = "simple_table"
      + ownership_role     = (known after apply)
      + qualified_sql_name = (known after apply)
      + schema_name        = "example_schema"

      + column {
          + name     = "column_1"
          + nullable = false
          + type     = "text"
        }
      + column {
          + comment  = "column_2 comment"
          + name     = "column_2"
          + nullable = false
          + type     = "integer"
        }
      + column {
          + name     = "column_3"
          + nullable = true
          + type     = "text"
        }
    }

  # materialize_table_grant.dev_role_table_grant_insert will be created
  + resource "materialize_table_grant" "dev_role_table_grant_insert" {
      + database_name = "example_database"
      + id            = (known after apply)
      + privilege     = "INSERT"
      + role_name     = "dev_role"
      + schema_name   = "example_schema"
      + table_name    = "simple_table"
    }
```