### PR TITLE
Update Webhook Source

### DIFF
--- a/docs/resources/source_webhook.md
+++ b/docs/resources/source_webhook.md
@@ -36,6 +36,8 @@ resource "materialize_source_webhook" "example_webhook" {
 - `cluster_name` (String) The cluster to maintain this source.
 - `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
+- `exclude_headers` (List of String) Headers to exclude from mapping.
+- `include_header` (Block List) Map a header value from a request into a column. (see [below for nested schema](#nestedblock--include_header))
 - `include_headers` (Boolean) Include headers in the webhook.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
@@ -57,6 +59,7 @@ Required:
 Optional:
 
 - `alias` (String) The alias for the check options.
+- `bytes` (Boolean) Change type to `bytea`.
 
 <a id="nestedblock--check_options--field"></a>
 ### Nested Schema for `check_options.field`
@@ -80,6 +83,19 @@ Optional:
 - `schema_name` (String) The secret schema name.
 
 
+
+
+<a id="nestedblock--include_header"></a>
+### Nested Schema for `include_header`
+
+Required:
+
+- `header` (String) The name for the header.
+
+Optional:
+
+- `alias` (String) The alias for the header.
+- `bytes` (Boolean) Change type to `bytea`.
 
 
 <a id="nestedatt--subsource"></a>

--- a/docs/resources/source_webhook.md
+++ b/docs/resources/source_webhook.md
@@ -36,9 +36,8 @@ resource "materialize_source_webhook" "example_webhook" {
 - `cluster_name` (String) The cluster to maintain this source.
 - `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `exclude_headers` (List of String) Headers to exclude from mapping.
 - `include_header` (Block List) Map a header value from a request into a column. (see [below for nested schema](#nestedblock--include_header))
-- `include_headers` (Boolean) Include headers in the webhook.
+- `include_headers` (Block List, Max: 1) Include headers in the webhook. (see [below for nested schema](#nestedblock--include_headers))
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
 
@@ -96,6 +95,16 @@ Optional:
 
 - `alias` (String) The alias for the header.
 - `bytes` (Boolean) Change type to `bytea`.
+
+
+<a id="nestedblock--include_headers"></a>
+### Nested Schema for `include_headers`
+
+Optional:
+
+- `all` (Boolean) Include all headers.
+- `not` (List of String) Headers that should be excluded.
+- `only` (List of String) Headers that should be included.
 
 
 <a id="nestedatt--subsource"></a>

--- a/integration/source.tf
+++ b/integration/source.tf
@@ -131,9 +131,12 @@ resource "materialize_source_webhook" "example_webhook_source" {
   name    = "example_webhook_source"
   comment = "source webhook comment"
 
-  cluster_name    = materialize_cluster.cluster_source.name
-  body_format     = "json"
-  include_headers = false
+  include_headers {
+    all = true
+  }
+
+  cluster_name = materialize_cluster.cluster_source.name
+  body_format  = "json"
 }
 
 resource "materialize_source_grant" "source_grant_select" {

--- a/pkg/materialize/generic.go
+++ b/pkg/materialize/generic.go
@@ -34,6 +34,10 @@ type Builder struct {
 }
 
 func (b *Builder) exec(statement string) error {
+	if statement[len(statement)-1:] != ";" {
+		statement += ";"
+	}
+
 	_, err := b.conn.Exec(statement)
 	if err != nil {
 		log.Printf("[DEBUG] error executing: %s", statement)

--- a/pkg/materialize/source_webhook_test.go
+++ b/pkg/materialize/source_webhook_test.go
@@ -44,13 +44,12 @@ func TestSourceWebhookCreateIncludeHeaders(t *testing.T) {
 			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS \(NOT 'authorization', NOT 'x-api-key'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		var excludeHeaders = []string{"authorization", "x-api-key"}
-
 		b := NewSourceWebhookBuilder(db, sourceWebhook)
 		b.ClusterName("cluster")
 		b.BodyFormat("JSON")
-		b.IncludeHeaders(true)
-		b.ExcludeHeaders(excludeHeaders)
+		b.IncludeHeaders(IncludeHeadersStruct{
+			Not: []string{"authorization", "x-api-key"},
+		})
 
 		if err := b.Create(); err != nil {
 			t.Fatal(err)
@@ -132,7 +131,7 @@ func TestSourceWebhookCreateSegment(t *testing.T) {
 		b.ClusterName("cluster")
 		b.BodyFormat("JSON")
 		b.IncludeHeader(includeHeader)
-		b.IncludeHeaders(true)
+		b.IncludeHeaders(IncludeHeadersStruct{All: true})
 		b.CheckOptions(checkOptions)
 		b.CheckExpression("decode(headers->'x-signature', 'hex') = hmac(body, secret, 'sha1')")
 

--- a/pkg/materialize/source_webhook_test.go
+++ b/pkg/materialize/source_webhook_test.go
@@ -9,33 +9,28 @@ import (
 )
 
 var sourceWebhook = MaterializeObject{Name: "webhook_source", SchemaName: "schema", DatabaseName: "database"}
-var checkOptions = []CheckOptionsStruct{
-	{
-		Field: FieldStruct{
-			Body: true,
-		},
-		Alias: "bytes",
-	},
-	{
-		Field: FieldStruct{
-			Headers: true,
-		},
-		Alias: "headers",
-	},
-}
 
-func TestSourceWebhookCreate(t *testing.T) {
+func TestSourceWebhookCreateExposeHeaders(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS CHECK \( WITH \(BODY AS bytes\, HEADERS AS headers\) check_expression\);`,
+			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'timestamp' AS ts INCLUDE HEADER 'x-event-type' AS event_type;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		var includeHeader = []HeaderStruct{
+			{
+				Header: "timestamp",
+				Alias:  "ts",
+			},
+			{
+				Header: "x-event-type",
+				Alias:  "event_type",
+			},
+		}
 
 		b := NewSourceWebhookBuilder(db, sourceWebhook)
 		b.ClusterName("cluster")
 		b.BodyFormat("JSON")
-		b.IncludeHeaders(true)
-		b.CheckOptions(checkOptions)
-		b.CheckExpression("check_expression")
+		b.IncludeHeader(includeHeader)
 
 		if err := b.Create(); err != nil {
 			t.Fatal(err)
@@ -43,25 +38,140 @@ func TestSourceWebhookCreate(t *testing.T) {
 	})
 }
 
-func TestSourceWebhookCreateSecret(t *testing.T) {
+func TestSourceWebhookCreateIncludeHeaders(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT AVRO CHECK \( WITH \(SECRET "database"."schema"."secret"\) \);`,
+			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADERS \(NOT 'authorization', NOT 'x-api-key'\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		var c = []CheckOptionsStruct{
+		var excludeHeaders = []string{"authorization", "x-api-key"}
+
+		b := NewSourceWebhookBuilder(db, sourceWebhook)
+		b.ClusterName("cluster")
+		b.BodyFormat("JSON")
+		b.IncludeHeaders(true)
+		b.ExcludeHeaders(excludeHeaders)
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestSourceWebhookCreateValidated(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON CHECK \( WITH \(HEADERS, BODY AS request_body, SECRET "database"."schema"."my_webhook_shared_secret"\) decode\(headers->'x-signature', 'base64'\) = hmac\(request_body, my_webhook_shared_secret, 'sha256'\)\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		var checkOptions = []CheckOptionsStruct{
+			{
+				Field: FieldStruct{Headers: true},
+			},
+			{
+				Field: FieldStruct{Body: true},
+				Alias: "request_body",
+			},
 			{
 				Field: FieldStruct{
-					Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "secret", DatabaseName: "database"},
+					Secret: IdentifierSchemaStruct{
+						DatabaseName: "database",
+						SchemaName:   "schema",
+						Name:         "my_webhook_shared_secret",
+					},
 				},
 			},
 		}
 
 		b := NewSourceWebhookBuilder(db, sourceWebhook)
 		b.ClusterName("cluster")
-		b.BodyFormat("AVRO")
-		b.IncludeHeaders(false)
-		b.CheckOptions(c)
+		b.BodyFormat("JSON")
+		b.CheckOptions(checkOptions)
+		b.CheckExpression("decode(headers->'x-signature', 'base64') = hmac(request_body, my_webhook_shared_secret, 'sha256')")
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestSourceWebhookCreateSegment(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON INCLUDE HEADER 'event-type' AS event_type INCLUDE HEADERS CHECK \( WITH \(BODY BYTES, HEADERS, SECRET "database"."schema"."my_webhook_shared_secret" AS secret BYTES\) decode\(headers->'x-signature', 'hex'\) = hmac\(body, secret, 'sha1'\)\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		var includeHeader = []HeaderStruct{
+			{
+				Header: "event-type",
+				Alias:  "event_type",
+			},
+		}
+		var checkOptions = []CheckOptionsStruct{
+			{
+				Field: FieldStruct{Body: true},
+				Bytes: true,
+			},
+			{
+				Field: FieldStruct{Headers: true},
+			},
+			{
+				Field: FieldStruct{
+					Secret: IdentifierSchemaStruct{
+						DatabaseName: "database",
+						SchemaName:   "schema",
+						Name:         "my_webhook_shared_secret",
+					},
+				},
+				Alias: "secret",
+				Bytes: true,
+			},
+		}
+
+		b := NewSourceWebhookBuilder(db, sourceWebhook)
+		b.ClusterName("cluster")
+		b.BodyFormat("JSON")
+		b.IncludeHeader(includeHeader)
+		b.IncludeHeaders(true)
+		b.CheckOptions(checkOptions)
+		b.CheckExpression("decode(headers->'x-signature', 'hex') = hmac(body, secret, 'sha1')")
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestSourceWebhookCreateRudderstack(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."webhook_source" IN CLUSTER "cluster" FROM WEBHOOK BODY FORMAT JSON CHECK \( WITH \(HEADERS, BODY AS request_body, SECRET "database"."schema"."my_webhook_shared_secret"\) headers->'authorization' = rudderstack_shared_secret\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		var checkOptions = []CheckOptionsStruct{
+			{
+				Field: FieldStruct{Headers: true},
+			},
+			{
+				Field: FieldStruct{Body: true},
+				Alias: "request_body",
+			},
+			{
+				Field: FieldStruct{
+					Secret: IdentifierSchemaStruct{
+						DatabaseName: "database",
+						SchemaName:   "schema",
+						Name:         "my_webhook_shared_secret",
+					},
+				},
+			},
+		}
+
+		b := NewSourceWebhookBuilder(db, sourceWebhook)
+		b.ClusterName("cluster")
+		b.BodyFormat("JSON")
+		b.CheckOptions(checkOptions)
+		b.CheckExpression("headers->'authorization' = rudderstack_shared_secret")
 
 		if err := b.Create(); err != nil {
 			t.Fatal(err)

--- a/pkg/provider/acceptance_source_webhook_test.go
+++ b/pkg/provider/acceptance_source_webhook_test.go
@@ -29,7 +29,10 @@ func TestAccSourceWebhook_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "cluster_name", clusterName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "body_format", "json"),
-					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers", "false"),
+					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers.0.only.0", "a"),
+					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers.0.only.1", "b"),
+					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers.0.not.0", "c"),
+					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers.0.not.1", "d"),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "ownership_role", roleName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "size", ""),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "check_options.0.field.0.body", "true"),
@@ -101,7 +104,6 @@ func TestAccSourceWebhook_update(t *testing.T) {
 					testAccCheckSourceWebhookExists("materialize_source_webhook.test"),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "name", newSourceName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "body_format", "json"),
-					resource.TestCheckResourceAttr("materialize_source_webhook.test", "include_headers", "false"),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "ownership_role", roleName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "size", ""),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "check_options.0.field.0.body", "true"),
@@ -136,8 +138,12 @@ resource "materialize_source_webhook" "test" {
 	name = "%[4]s"
 	cluster_name = materialize_cluster.example_cluster.name
 	body_format = "json"
-	include_headers = false
 	ownership_role = materialize_role.test.name
+
+	include_headers {
+		only = ["a", "b"]
+		not  = ["c", "d"]
+	}
 
 	check_options {
 		field {

--- a/pkg/resources/resource_source_webhook_test.go
+++ b/pkg/resources/resource_source_webhook_test.go
@@ -13,12 +13,16 @@ import (
 )
 
 var inSourceWebhook = map[string]interface{}{
-	"name":            "webhook_source",
-	"schema_name":     "schema",
-	"database_name":   "database",
-	"cluster_name":    "cluster",
-	"body_format":     "JSON",
-	"include_headers": true,
+	"name":          "webhook_source",
+	"schema_name":   "schema",
+	"database_name": "database",
+	"cluster_name":  "cluster",
+	"body_format":   "JSON",
+	"include_headers": []interface{}{
+		map[string]interface{}{
+			"all": true,
+		},
+	},
 	"check_options": []interface{}{
 		map[string]interface{}{
 			"field": []interface{}{map[string]interface{}{


### PR DESCRIPTION
Including additional functionality for [webhook source](https://materialize.com/docs/sql/create-source/webhook/). Specifically:

* Adding the ability to [expose headers](https://materialize.com/docs/sql/create-source/webhook/#exposing-headers) with `INCLUDE HEADER` via the `include_header` attribute
* Ability to [exclude headers](https://materialize.com/docs/sql/create-source/webhook/#excluding-header-fields). This is now back of `include_headers` which allows users to specifically set headers using `only`, excluding with `not` and just setting `INCLUDE HEADERS` by setting `all` to true.
```
	include_headers {
                all    = true
		only = ["a", "b"] -- cannot be used with all
		not  = ["c", "d"] -- cannot be used with all 
	}
```
* Ability to set check options as `BYTES`

Also adding more use cases from the [documentation](https://materialize.com/docs/sql/create-source/webhook/#exposing-headers) in the unit tests as well as the specific use cases for [segment](https://materialize.com/docs/ingest-data/segment/) and [rudderstack](https://materialize.com/docs/ingest-data/rudderstack/).