### PR TITLE
Update resource.tf

### DIFF
--- a/examples/resources/materialize_connection_kafka/resource.tf
+++ b/examples/resources/materialize_connection_kafka/resource.tf
@@ -4,7 +4,7 @@ resource "materialize_connection_kafka" "example_kafka_connection" {
   kafka_broker {
     broker = "b-1.hostname-1:9096"
   }
-  sasl_username = {
+  sasl_username {
     text = "user"
   }
   sasl_password {


### PR DESCRIPTION
fix the example for terraform.materialize_connection_kafka
before this fix, it throws an error 
```

│   on main.tf line 45, in resource "materialize_connection_kafka" "upstash":
│   45:   sasl_username = {
│
│ An argument named "sasl_username" is not expected here. Did you mean to define a block of type "sasl_username"?
╵
```