### PR TITLE
Add NOT ENFORCED for sink keys

### DIFF
--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -64,7 +64,7 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
-- `not_enforced` (Boolean) Disable Materialize's validation of the key's uniqueness.
+- `key_not_enforced` (Boolean) Disable Materialize's validation of the key's uniqueness.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the sink schema. Defaults to `public`.
 - `size` (String) The size of the sink. If not specified, the `cluster_name` option must be specified.

--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -64,6 +64,7 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 - `envelope` (Block List, Max: 1) How to interpret records (e.g. Debezium, Upsert). (see [below for nested schema](#nestedblock--envelope))
 - `format` (Block List, Max: 1) How to decode raw bytes from different formats into data structures it can understand at runtime. (see [below for nested schema](#nestedblock--format))
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
+- `not_enforced` (Boolean) Disable Materialize's validation of the key's uniqueness.
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the sink schema. Defaults to `public`.
 - `size` (String) The size of the sink. If not specified, the `cluster_name` option must be specified.

--- a/integration/sink.tf
+++ b/integration/sink.tf
@@ -27,8 +27,8 @@ resource "materialize_sink_kafka" "sink_kafka" {
   envelope {
     debezium = true
   }
-  key          = ["counter"]
-  not_enforced = true
+  key              = ["counter"]
+  key_not_enforced = true
 }
 
 output "qualified_sink_kafka" {

--- a/integration/sink.tf
+++ b/integration/sink.tf
@@ -27,7 +27,8 @@ resource "materialize_sink_kafka" "sink_kafka" {
   envelope {
     debezium = true
   }
-  key = ["counter"]
+  key          = ["counter"]
+  not_enforced = true
 }
 
 output "qualified_sink_kafka" {

--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -34,6 +34,7 @@ type SinkKafkaBuilder struct {
 	format          SinkFormatSpecStruct
 	envelope        KafkaSinkEnvelopeStruct
 	snapshot        bool
+	notEnforced     bool
 }
 
 func NewSinkKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *SinkKafkaBuilder {
@@ -88,6 +89,11 @@ func (b *SinkKafkaBuilder) Snapshot(s bool) *SinkKafkaBuilder {
 	return b
 }
 
+func (b *SinkKafkaBuilder) NotEnforced(s bool) *SinkKafkaBuilder {
+	b.notEnforced = true
+	return b
+}
+
 func (b *SinkKafkaBuilder) Create() error {
 	q := strings.Builder{}
 	q.WriteString(fmt.Sprintf(`CREATE SINK %s`, b.QualifiedName()))
@@ -110,6 +116,10 @@ func (b *SinkKafkaBuilder) Create() error {
 	if len(b.key) > 0 {
 		o := strings.Join(b.key[:], ", ")
 		q.WriteString(fmt.Sprintf(` KEY (%s)`, o))
+	}
+
+	if b.notEnforced {
+		q.WriteString(` NOT ENFORCED`)
 	}
 
 	if b.format.Json {

--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -34,7 +34,7 @@ type SinkKafkaBuilder struct {
 	format          SinkFormatSpecStruct
 	envelope        KafkaSinkEnvelopeStruct
 	snapshot        bool
-	notEnforced     bool
+	keyNotEnforced  bool
 }
 
 func NewSinkKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *SinkKafkaBuilder {
@@ -89,8 +89,8 @@ func (b *SinkKafkaBuilder) Snapshot(s bool) *SinkKafkaBuilder {
 	return b
 }
 
-func (b *SinkKafkaBuilder) NotEnforced(s bool) *SinkKafkaBuilder {
-	b.notEnforced = true
+func (b *SinkKafkaBuilder) KeyNotEnforced(s bool) *SinkKafkaBuilder {
+	b.keyNotEnforced = true
 	return b
 }
 
@@ -118,7 +118,7 @@ func (b *SinkKafkaBuilder) Create() error {
 		q.WriteString(fmt.Sprintf(` KEY (%s)`, o))
 	}
 
-	if b.notEnforced {
+	if b.keyNotEnforced {
 		q.WriteString(` NOT ENFORCED`)
 	}
 

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -68,6 +68,13 @@ var sinkKafkaSchema = map[string]*schema.Schema{
 		Default:     true,
 	},
 	"ownership_role": OwnershipRoleSchema(),
+	"not_enforced": {
+		Description: "Disable Materialize's validation of the key's uniqueness.",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     false,
+	},
 }
 
 func SinkKafka() *schema.Resource {
@@ -120,6 +127,10 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 	if v, ok := d.GetOk("key"); ok {
 		keys := materialize.GetSliceValueString(v.([]interface{}))
 		b.Key(keys)
+	}
+
+	if v, ok := d.GetOk("not_enforced"); ok {
+		b.NotEnforced(v.(bool))
 	}
 
 	if v, ok := d.GetOk("format"); ok {

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -68,7 +68,7 @@ var sinkKafkaSchema = map[string]*schema.Schema{
 		Default:     true,
 	},
 	"ownership_role": OwnershipRoleSchema(),
-	"not_enforced": {
+	"key_not_enforced": {
 		Description: "Disable Materialize's validation of the key's uniqueness.",
 		Type:        schema.TypeBool,
 		Optional:    true,
@@ -129,8 +129,8 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 		b.Key(keys)
 	}
 
-	if v, ok := d.GetOk("not_enforced"); ok {
-		b.NotEnforced(v.(bool))
+	if v, ok := d.GetOk("key_not_enforced"); ok {
+		b.KeyNotEnforced(v.(bool))
 	}
 
 	if v, ok := d.GetOk("format"); ok {

--- a/pkg/resources/resource_sink_kafka_test.go
+++ b/pkg/resources/resource_sink_kafka_test.go
@@ -22,6 +22,7 @@ var inSinkKafka = map[string]interface{}{
 	"kafka_connection": []interface{}{map[string]interface{}{"name": "kafka_conn"}},
 	"topic":            "topic",
 	"key":              []interface{}{"key_1", "key_2"},
+	"not_enforced":     true,
 	"format":           []interface{}{map[string]interface{}{"avro": []interface{}{map[string]interface{}{"avro_key_fullname": "avro_key_fullname", "avro_value_fullname": "avro_value_fullname", "schema_registry_connection": []interface{}{map[string]interface{}{"name": "csr_conn", "database_name": "database", "schema_name": "schema"}}}}}},
 	"envelope":         []interface{}{map[string]interface{}{"upsert": true}},
 	"snapshot":         false,
@@ -35,7 +36,7 @@ func TestResourceSinkKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE SINK "database"."schema"."sink" IN CLUSTER "cluster" FROM "database"."public"."item" INTO KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'topic'\) KEY \(key_1, key_2\) FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_conn" WITH \(AVRO KEY FULLNAME 'avro_key_fullname' AVRO VALUE FULLNAME 'avro_value_fullname'\) ENVELOPE UPSERT WITH \( SIZE = 'small' SNAPSHOT = false\);`,
+			`CREATE SINK "database"."schema"."sink" IN CLUSTER "cluster" FROM "database"."public"."item" INTO KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'topic'\) KEY \(key_1, key_2\) NOT ENFORCED FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."csr_conn" WITH \(AVRO KEY FULLNAME 'avro_key_fullname' AVRO VALUE FULLNAME 'avro_value_fullname'\) ENVELOPE UPSERT WITH \( SIZE = 'small' SNAPSHOT = false\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id

--- a/pkg/resources/resource_sink_kafka_test.go
+++ b/pkg/resources/resource_sink_kafka_test.go
@@ -22,7 +22,7 @@ var inSinkKafka = map[string]interface{}{
 	"kafka_connection": []interface{}{map[string]interface{}{"name": "kafka_conn"}},
 	"topic":            "topic",
 	"key":              []interface{}{"key_1", "key_2"},
-	"not_enforced":     true,
+	"key_not_enforced": true,
 	"format":           []interface{}{map[string]interface{}{"avro": []interface{}{map[string]interface{}{"avro_key_fullname": "avro_key_fullname", "avro_value_fullname": "avro_value_fullname", "schema_registry_connection": []interface{}{map[string]interface{}{"name": "csr_conn", "database_name": "database", "schema_name": "schema"}}}}}},
 	"envelope":         []interface{}{map[string]interface{}{"upsert": true}},
 	"snapshot":         false,


### PR DESCRIPTION
Adds a missing `NOT ENFORCED` option to the sink resource.

> https://materialize.com/docs/sql/create-sink/kafka/