### PR TITLE
Add ForceNew for table column name changes

### DIFF
--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -33,6 +33,7 @@ var tableSchema = map[string]*schema.Schema{
 					Description: "The data type of the column indicated by name.",
 					Type:        schema.TypeString,
 					Required:    true,
+					ForceNew:    true,
 					StateFunc: func(val any) string {
 						alias, ok := aliases[val.(string)]
 						if ok {
@@ -44,6 +45,7 @@ var tableSchema = map[string]*schema.Schema{
 				"nullable": {
 					Description: "Do not allow the column to contain NULL values. Columns without this constraint can contain NULL values.",
 					Type:        schema.TypeBool,
+					ForceNew:    true,
 					Optional:    true,
 					Default:     false,
 				},
@@ -233,15 +235,22 @@ func tableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if d.HasChange("columns") {
-		_, newColumns := d.GetChange("columns")
-		columns := materialize.GetTableColumnStruct(newColumns.([]interface{}))
-		comment := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+	if d.HasChange("column") {
+		oldColumns, newColumns := d.GetChange("column")
+		oldColumnsList := oldColumns.([]interface{})
+		newColumnsList := newColumns.([]interface{})
 
-		// Reset all comments if change present
-		for _, c := range columns {
-			if c.Comment != "" {
-				if err := comment.Column(c.ColName, c.Comment); err != nil {
+		for index, newColMap := range newColumnsList {
+			newCol := newColMap.(map[string]interface{})
+			oldCol := oldColumnsList[index].(map[string]interface{})
+
+			// Check specifically if the column comment has changed.
+			if newCol["comment"] != oldCol["comment"] {
+				// Apply the comment change
+				comment := materialize.NewCommentBuilder(meta.(*sqlx.DB), o)
+				colName := newCol["name"].(string)
+				colComment := newCol["comment"].(string)
+				if err := comment.Column(colName, colComment); err != nil {
 					return diag.FromErr(err)
 				}
 			}

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -27,6 +27,7 @@ var tableSchema = map[string]*schema.Schema{
 					Description: "The name of the column to be created in the table.",
 					Type:        schema.TypeString,
 					Required:    true,
+					ForceNew:    true,
 				},
 				"type": {
 					Description: "The data type of the column indicated by name.",


### PR DESCRIPTION
As discussed [here](https://materializeinc.slack.com/archives/C015RHB3LDR/p1699958008429369), adding a `ForceNew` for table column name changes as we do not yet support `RENAME COLUMN`:

> https://github.com/MaterializeInc/materialize/issues/5301