### PR TITLE
Kafka Security Protocol

### DIFF
--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -89,6 +89,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 - `sasl_password` (Block List, Max: 1) The SASL password for the Kafka broker. (see [below for nested schema](#nestedblock--sasl_password))
 - `sasl_username` (Block List, Max: 1) The SASL username for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--sasl_username))
 - `schema_name` (String) The identifier for the connection schema. Defaults to `public`.
+- `security_protocol` (String) The security protocol to use.
 - `ssh_tunnel` (Block List, Max: 1) The SSH tunnel configuration for the Kafka broker. (see [below for nested schema](#nestedblock--ssh_tunnel))
 - `ssl_certificate` (Block List, Max: 1) The client certificate for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--ssl_certificate))
 - `ssl_certificate_authority` (Block List, Max: 1) The CA certificate for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--ssl_certificate_authority))

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -40,9 +40,10 @@ resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
     database_name = materialize_secret.kafka_password.database_name
     schema_name   = materialize_secret.kafka_password.schema_name
   }
-  sasl_mechanisms = "SCRAM-SHA-256"
-  progress_topic  = "progress_topic"
-  validate        = false
+  security_protocol = "SASL_PLAINTEXT"
+  sasl_mechanisms   = "SCRAM-SHA-256"
+  progress_topic    = "progress_topic"
+  validate          = false
 }
 
 resource "materialize_connection_postgres" "postgres_connection" {

--- a/pkg/materialize/connection_kafka.go
+++ b/pkg/materialize/connection_kafka.go
@@ -34,16 +34,17 @@ func GetKafkaBrokersStruct(v interface{}) []KafkaBroker {
 
 type ConnectionKafkaBuilder struct {
 	Connection
-	kafkaBrokers        []KafkaBroker
-	kafkaProgressTopic  string
-	kafkaSSLCa          ValueSecretStruct
-	kafkaSSLCert        ValueSecretStruct
-	kafkaSSLKey         IdentifierSchemaStruct
-	kafkaSASLMechanisms string
-	kafkaSASLUsername   ValueSecretStruct
-	kafkaSASLPassword   IdentifierSchemaStruct
-	kafkaSSHTunnel      IdentifierSchemaStruct
-	validate            bool
+	kafkaBrokers          []KafkaBroker
+	kafkaSecurityProtocol string
+	kafkaProgressTopic    string
+	kafkaSSLCa            ValueSecretStruct
+	kafkaSSLCert          ValueSecretStruct
+	kafkaSSLKey           IdentifierSchemaStruct
+	kafkaSASLMechanisms   string
+	kafkaSASLUsername     ValueSecretStruct
+	kafkaSASLPassword     IdentifierSchemaStruct
+	kafkaSSHTunnel        IdentifierSchemaStruct
+	validate              bool
 }
 
 func NewConnectionKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionKafkaBuilder {
@@ -55,6 +56,11 @@ func NewConnectionKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *Connection
 
 func (b *ConnectionKafkaBuilder) KafkaBrokers(kafkaBrokers []KafkaBroker) *ConnectionKafkaBuilder {
 	b.kafkaBrokers = kafkaBrokers
+	return b
+}
+
+func (b *ConnectionKafkaBuilder) KafkaSecurityProtocol(kafkaSecurityProtocol string) *ConnectionKafkaBuilder {
+	b.kafkaSecurityProtocol = kafkaSecurityProtocol
 	return b
 }
 
@@ -135,6 +141,9 @@ func (b *ConnectionKafkaBuilder) Create() error {
 		q.WriteString(`)`)
 	}
 
+	if b.kafkaSecurityProtocol != "" {
+		q.WriteString(fmt.Sprintf(`, SECURITY PROTOCOL = %s`, QuoteString(b.kafkaSecurityProtocol)))
+	}
 	if b.kafkaProgressTopic != "" {
 		q.WriteString(fmt.Sprintf(`, PROGRESS TOPIC %s`, QuoteString(b.kafkaProgressTopic)))
 	}

--- a/pkg/materialize/connection_kafka_test.go
+++ b/pkg/materialize/connection_kafka_test.go
@@ -13,7 +13,7 @@ var connKafka = MaterializeObject{Name: "kafka_conn", SchemaName: "schema", Data
 func TestConnectionKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), SECURITY PROTOCOL = 'PLAIN', PROGRESS TOPIC 'topic', SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'user', SASL PASSWORD = SECRET "database"."schema"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, connKafka)
@@ -23,6 +23,7 @@ func TestConnectionKafkaCreate(t *testing.T) {
 			},
 		})
 		b.KafkaProgressTopic("topic")
+		b.KafkaSecurityProtocol("PLAIN")
 		b.KafkaSASLMechanisms("PLAIN")
 		b.KafkaSASLUsername(ValueSecretStruct{Text: "user"})
 		b.KafkaSASLPassword(IdentifierSchemaStruct{Name: "password", DatabaseName: "database", SchemaName: "schema"})
@@ -144,7 +145,7 @@ func TestConnectionKafkaBrokersSshCreate(t *testing.T) {
 func TestConnectionKafkaSslCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = SECRET "database"."schema"."ca", SSL CERTIFICATE = SECRET "database"."schema"."cert", SSL KEY = SECRET "database"."schema"."key"\);`,
+			`CREATE CONNECTION "database"."schema"."kafka_conn" TO KAFKA \(BROKERS \('localhost:9092'\), SECURITY PROTOCOL = 'SSL', PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = SECRET "database"."schema"."ca", SSL CERTIFICATE = SECRET "database"."schema"."cert", SSL KEY = SECRET "database"."schema"."key"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewConnectionKafkaBuilder(db, connKafka)
@@ -154,6 +155,7 @@ func TestConnectionKafkaSslCreate(t *testing.T) {
 			},
 		})
 		b.KafkaProgressTopic("topic")
+		b.KafkaSecurityProtocol("SSL")
 		b.KafkaSSLKey(IdentifierSchemaStruct{SchemaName: "schema", Name: "key", DatabaseName: "database"})
 		b.KafkaSSLCert(ValueSecretStruct{Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "cert", DatabaseName: "database"}})
 		b.KafkaSSLCa(ValueSecretStruct{Secret: IdentifierSchemaStruct{SchemaName: "schema", Name: "ca", DatabaseName: "database"}})

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -60,7 +60,7 @@ var aliases = map[string]string{
 	"uint":    "uint4",
 }
 
-var session_variables = []string{
+var sessionVariables = []string{
 	"cluster",
 	"cluster_replica",
 	"database",
@@ -90,4 +90,11 @@ var session_variables = []string{
 	"standard_conforming_strings",
 	"statement_timeout",
 	"timezone",
+}
+
+var securityProtocols = []string{
+	"PLAINTEXT",
+	"SASL_PLAINTEXT",
+	"SSL",
+	"SASL_SSL",
 }

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 
@@ -45,6 +46,16 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 			},
 		},
 	},
+	"security_protocol": {
+		Description:  "The security protocol to use.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringInSlice(securityProtocols, true),
+		StateFunc: func(val any) string {
+			return strings.ToUpper(val.(string))
+		},
+	},
 	"progress_topic": {
 		Description: "The name of a topic that Kafka sinks can use to track internal consistency metadata.",
 		Type:        schema.TypeString,
@@ -60,7 +71,10 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice(saslMechanisms, true),
 		RequiredWith: []string{"sasl_username", "sasl_password"},
-		ForceNew:     true,
+		StateFunc: func(val any) string {
+			return strings.ToUpper(val.(string))
+		},
+		ForceNew: true,
 	},
 	"sasl_username":  ValueSecretSchema("sasl_username", "The SASL username for the Kafka broker.", false),
 	"sasl_password":  IdentifierSchema("sasl_password", "The SASL password for the Kafka broker.", false),
@@ -97,6 +111,10 @@ func connectionKafkaCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("kafka_broker"); ok {
 		brokers := materialize.GetKafkaBrokersStruct(v)
 		b.KafkaBrokers(brokers)
+	}
+
+	if v, ok := d.GetOk("security_protocol"); ok {
+		b.KafkaSecurityProtocol(v.(string))
 	}
 
 	if v, ok := d.GetOk("progress_topic"); ok {

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -18,6 +18,7 @@ var inKafka = map[string]interface{}{
 	"database_name":             "database",
 	"service_name":              "service",
 	"kafka_broker":              []interface{}{map[string]interface{}{"broker": "b-1.hostname-1:9096", "target_group_port": 9001, "availability_zone": "use1-az1", "privatelink_conn": "privatelink_conn"}},
+	"security_protocol":         "SASL_PLAINTEXT",
 	"progress_topic":            "topic",
 	"ssl_certificate_authority": []interface{}{map[string]interface{}{"text": "key"}},
 	"ssl_certificate":           []interface{}{map[string]interface{}{"secret": []interface{}{map[string]interface{}{"name": "cert"}}}},
@@ -37,7 +38,7 @@ func TestResourceConnectionKafkaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE CONNECTION "database"."schema"."conn" TO KAFKA \(BROKERS \('b-1.hostname-1:9096' USING SSH TUNNEL "materialize"."public"."tunnel"\), PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = 'key', SSL CERTIFICATE = SECRET "materialize"."public"."cert", SSL KEY = SECRET "materialize"."public"."key", SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'username', SASL PASSWORD = SECRET "materialize"."public"."password"\);`,
+			`CREATE CONNECTION "database"."schema"."conn" TO KAFKA \(BROKERS \('b-1.hostname-1:9096' USING SSH TUNNEL "materialize"."public"."tunnel"\), SECURITY PROTOCOL = 'SASL_PLAINTEXT', PROGRESS TOPIC 'topic', SSL CERTIFICATE AUTHORITY = 'key', SSL CERTIFICATE = SECRET "materialize"."public"."cert", SSL KEY = SECRET "materialize"."public"."key", SASL MECHANISMS = 'PLAIN', SASL USERNAME = 'username', SASL PASSWORD = SECRET "materialize"."public"."password"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id

--- a/pkg/resources/resource_role.go
+++ b/pkg/resources/resource_role.go
@@ -34,7 +34,7 @@ var roleSchema = map[string]*schema.Schema{
 					Description:  "The name of the session variable.",
 					Type:         schema.TypeString,
 					Required:     true,
-					ValidateFunc: validation.StringInSlice(session_variables, true),
+					ValidateFunc: validation.StringInSlice(sessionVariables, true),
 				},
 				"value": {
 					Description: "The value for the session variable.",


### PR DESCRIPTION
Fixes #348 

Add support for [Security Protocol](https://materialize.com/docs/sql/create-connection/#kafka-auth) for Kafka Connections.