### PR TITLE
Update Go Version

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - pkg/**
+      - main.go
+      - go.mod
   schedule:
     - cron: 0 11 * * 0
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - pkg/**
       - integration/**
+      - main.go
+      - go.mod
   schedule:
     - cron: 0 11 * * 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - pkg/**
+      - main.go
+      - go.mod
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Correct `ForceNew` for column attributes in `materialize_table` [#363](https://github.com/MaterializeInc/terraform-provider-materialize/pull/363)
 
 ### Misc
+* Update go.mod version to `1.20` [#369](https://github.com/MaterializeInc/terraform-provider-materialize/pull/369)
 
 ### Breaking Changes
 * Previously, blocks within resources that included optional `schema_name` and `database_name` attributes would inherit the top level attributes of the resource if set. So in the following example:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MaterializeInc/terraform-provider-materialize
 
-go 1.18
+go 1.20
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Release for `0.3.0` failed while building one of the binaries:
```
Error: ../../../go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/terraform/state.go:321:16: undefined: errors.Join
note: module requires Go 1.20
```
Updating `go.mod` to 1.20. This is also the go version used across our other Github Actions ([documentation](https://github.com/MaterializeInc/terraform-provider-materialize/blob/main/.github/workflows/documentation.yml#L22), [test](https://github.com/MaterializeInc/terraform-provider-materialize/blob/main/.github/workflows/test.yml#L15)