### PR TITLE
Handle usernames with special characters in them

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           MZ_HOST: localhost
           MZ_USER: mz_system
-          MZ_SSLMODE: "false"
+          MZ_SSLMODE: disable
           MZ_PORT: 6877
 
       - name: Docker Compose Down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### BugFixes
+
+* Handle `user` values that contain special characters, without requiring manual
+  URL escaping (e.g., escaping `you@corp.com` as `you%40corp.com`).
+
 ## 0.3.0 - 2023-11-16
 
 ### Features
@@ -19,7 +26,7 @@
     name          = "source_postgres"
     schema_name   = "my_schema"
     database_name = "my_database"
-  
+
     postgres_connection {
         name          = "postgres_connection"
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To run the acceptance tests which will simulate running Terraform commands you w
 ```bash
 export MZ_HOST=localhost
 export MZ_USER=mz_system
-export MZ_SSLMODE="false"
+export MZ_SSLMODE=disable
 export MZ_PORT=6877
 
 # Start all containers
@@ -175,7 +175,7 @@ Schema: map[string]*schema.Schema{
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"size": { // Add new field 
+				"size": { // Add new field
 					Type:     schema.TypeString,
 					Computed: true,
 				},

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -12,5 +12,5 @@ provider "materialize" {
   password = "password"
   port     = 6877
   database = "materialize"
-  sslmode  = false
+  sslmode  = "disable"
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
-			return provider.Provider()
+			return provider.Provider(version)
 		},
 	})
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
+	"net/url"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/datasources"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/resources"
@@ -14,7 +14,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func Provider() *schema.Provider {
+func Provider(version string) *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"host": {
@@ -48,17 +48,17 @@ func Provider() *schema.Provider {
 				Description: "The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_DATABASE", "materialize"),
 			},
-			"application_name": {
+			"application_name_suffix": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "terraform-provider-materialize",
-				Description: "The application name to include in the connection string",
+				Default:     "",
+				Description: "A suffix to include in the `application_name` session parameter when connecting to Materialize.",
 			},
 			"sslmode": {
-				Type:        schema.TypeBool,
+				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("MZ_SSLMODE", true),
-				Description: "For testing purposes, disable SSL.",
+				DefaultFunc: schema.EnvDefaultFunc("MZ_SSLMODE", "require"),
+				Description: "For testing purposes, the SSL mode to use.",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -122,42 +122,39 @@ func Provider() *schema.Provider {
 			"materialize_type":              datasources.Type(),
 			"materialize_view":              datasources.View(),
 		},
-		ConfigureContextFunc: providerConfigure,
+		ConfigureContextFunc: func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+			return providerConfigure(ctx, d, version)
+		},
 	}
 }
 
-func connectionString(host, user, password string, port int, database string, sslmode bool, application string) string {
-	c := strings.Builder{}
-	c.WriteString(fmt.Sprintf("postgres://%s:%s@%s:%d/%s", user, password, host, port, database))
-
-	params := []string{}
-
-	if sslmode {
-		params = append(params, "sslmode=require")
-	} else {
-		params = append(params, "sslmode=disable")
-	}
-
-	params = append(params, fmt.Sprintf("application_name=%s", application))
-	p := strings.Join(params[:], "&")
-
-	c.WriteString(fmt.Sprintf("?%s", p))
-	return c.String()
-}
-
-func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func providerConfigure(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
 	host := d.Get("host").(string)
 	user := d.Get("user").(string)
 	password := d.Get("password").(string)
 	port := d.Get("port").(int)
 	database := d.Get("database").(string)
-	application := d.Get("application_name").(string)
-	sslmode := d.Get("sslmode").(bool)
+	application_name_suffix := d.Get("application_name_suffix").(string)
+	sslmode := d.Get("sslmode").(string)
 
-	connStr := connectionString(host, user, password, port, database, sslmode, application)
+	application_name := fmt.Sprintf("terraform-provider-materialize v%s", version)
+	if application_name_suffix != "" {
+		application_name += " " + application_name_suffix
+	}
+
+	url := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   database,
+		RawQuery: url.Values{
+			"application_name": {application_name},
+			"sslmode":          {sslmode},
+		}.Encode(),
+	}
 
 	var diags diag.Diagnostics
-	db, err := sqlx.Open("pgx", connStr)
+	db, err := sqlx.Open("pgx", url.String())
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -9,32 +9,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jmoiron/sqlx"
-	"github.com/stretchr/testify/require"
 )
 
-func TestConnectionString(t *testing.T) {
-	r := require.New(t)
-	c := connectionString("host", "user", "pass", 6875, "database", true, "tf")
-	r.Equal(`postgres://user:pass@host:6875/database?sslmode=require&application_name=tf`, c)
-}
-
-func TestConnectionStringTesting(t *testing.T) {
-	r := require.New(t)
-	c := connectionString("host", "user", "pass", 6875, "database", false, "tf")
-	r.Equal(`postgres://user:pass@host:6875/database?sslmode=disable&application_name=tf`, c)
-}
-
 func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
+	if err := Provider("test").InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
-	var _ *schema.Provider = Provider()
+	var _ *schema.Provider = Provider("test")
 }
 
-var testAccProvider = Provider()
+var testAccProvider = Provider("test")
 var testAccProviderFactories = map[string]func() (*schema.Provider, error){
 	"materialize": func() (*schema.Provider, error) { return testAccProvider, nil },
 }


### PR DESCRIPTION
Which, in practice, is all usernames in production, since they're all email addresses that contain an `@` sign.

Also:

  * Make the `sslmode` parameter a string rather than a Boolean. It's a hidden parameter for testing, so might as well allow the full power of the underlying `sslmode` option. Makes the code simpler.

  * Rename `application_name` to `application_name_suffix`, and force include "terraform-provider-materialize vX.Y.Z" in the name. While this is also a hidden parameter, no point allowing someone to easily mess with our metrics by changing the application name. The `application_name_suffix` parameter allows the downstream Pulumi provider to inject "(Pulumi version ...)" into the application name. Possibly it could also be useful to end users, if they want to distinguish between different Terraform projects.

----

@dehume when this merges, a new release of the Pulumi provider would be great. We're bumping into this as we set up mz-on-mz: https://github.com/MaterializeInc/i2/pull/1370/files#diff-24af2d7896d8dfce91831fe5a92050e971abd23b8ca9192d4bd17b2a852b4f67R51-R54

cc @necaris 