### PR TITLE
Prevent Privilege Read Errors

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -14,6 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - run: go mod download
+
       - name: Docker Compose Up
         run: docker compose up --build -d
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -19,10 +19,12 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - run: go mod download
-
       - name: Docker Compose Up
         run: docker compose up --build -d
+
+      - run: go get .
+
+      - run: go build -v ./...
 
       - name: make testacc
         run: make testacc

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -22,10 +22,6 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d
 
-      - run: go get .
-
-      - run: go build -v ./...
-
       - name: make testacc
         run: make testacc
         env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,10 +22,6 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - run: go get .
-
-      - run: go build -v ./...
-
       - run: go generate ./...
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,8 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: "go.mod"
+          cache: true
 
       - run: go mod download
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,9 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - run: go mod download
+      - run: go get .
+
+      - run: go build -v ./...
 
       - run: go generate ./...
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,4 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - run: go get .
-
-      - run: go build -v ./...
-
       - run: go test -v -cover ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: "go.mod"
+          cache: true
 
       - run: go mod download
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
-      - run: go mod download
+      - run: go get .
+
+      - run: go build -v ./...
 
       - run: go test -v -cover ./...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     image: postgres
     container_name: materialized_init
     depends_on:
-      - materialized
+      materialized: {condition: service_healthy}
     command: >-
       sh -c '
       echo "Waiting for materialized to start..." &&
@@ -77,6 +77,7 @@ services:
     container_name: provider
     depends_on:
       materialized: {condition: service_healthy}
+      redpanda: {condition: service_healthy}
     volumes:
       - ./integration:/usr/src/app/integration
     environment:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/lib/pq v1.2.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819
 )

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,6 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
-github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -119,7 +118,6 @@ github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80s
 github.com/jackc/pgx v3.6.2+incompatible h1:2zP5OD7kiyR3xzRYMhOcXVvkDZsImVXfj+yIyTQf3/o=
 github.com/jackc/pgx v3.6.2+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
@@ -130,7 +128,6 @@ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -173,7 +170,6 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
@@ -201,7 +197,6 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
-github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -286,7 +281,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
-gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -118,6 +119,7 @@ github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80s
 github.com/jackc/pgx v3.6.2+incompatible h1:2zP5OD7kiyR3xzRYMhOcXVvkDZsImVXfj+yIyTQf3/o=
 github.com/jackc/pgx v3.6.2+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
@@ -128,6 +130,7 @@ github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -170,6 +173,7 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
@@ -197,6 +201,7 @@ github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.1 h1:t9fyA35fwjjUMcmL5hLER+e/rEPqrbCK1/OSE4SI9KA=
 github.com/zclconf/go-cty v1.14.1/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -281,6 +286,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
+gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -40,10 +40,9 @@ resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
     database_name = materialize_secret.kafka_password.database_name
     schema_name   = materialize_secret.kafka_password.schema_name
   }
-  security_protocol = "SASL_PLAINTEXT"
-  sasl_mechanisms   = "SCRAM-SHA-256"
-  progress_topic    = "progress_topic"
-  validate          = false
+  sasl_mechanisms = "SCRAM-SHA-256"
+  progress_topic  = "progress_topic"
+  validate        = false
 }
 
 resource "materialize_connection_postgres" "postgres_connection" {

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -1,0 +1,69 @@
+variable "teams" {
+  type = map(any)
+  default = {
+    bi_select = {
+      grantee : "bi",
+      privilege : "SELECT",
+    },
+    "bi_insert" = {
+      grantee : "bi",
+      privilege : "INSERT",
+    },
+    "ds_select" = {
+      grantee : "ds",
+      privilege : "SELECT",
+    },
+    "de_select" = {
+      grantee : "de",
+      privilege : "SELECT",
+    },
+    "de_update" = {
+      grantee : "de",
+      privilege : "UPDATE",
+    },
+  }
+}
+
+resource "materialize_role" "bi" {
+  name = "bi"
+}
+
+resource "materialize_role" "ds" {
+  name = "ds"
+}
+
+resource "materialize_role" "de" {
+  name = "de"
+}
+
+resource "materialize_table_grant_default_privilege" "complex" {
+  for_each         = var.teams
+  privilege        = each.value.privilege
+  grantee_name     = each.value.grantee
+  target_role_name = materialize_role.target.name
+  database_name    = materialize_database.database.name
+  schema_name      = materialize_schema.schema.name
+
+  depends_on = [materialize_role.bi, materialize_role.ds, materialize_role.de]
+}
+
+resource "materialize_role" "op" {
+  name = "op"
+}
+
+# Non-deterministic grants
+resource "materialize_table_grant_default_privilege" "base" {
+  privilege        = "UPDATE"
+  grantee_name     = materialize_role.de.name
+  target_role_name = materialize_role.target.name
+  database_name    = materialize_database.database.name
+  schema_name      = materialize_schema.schema.name
+}
+
+resource "materialize_table_grant_default_privilege" "duplicate" {
+  privilege        = "UPDATE"
+  grantee_name     = materialize_role.de.name
+  target_role_name = materialize_role.target.name
+  database_name    = materialize_database.database.name
+  schema_name      = materialize_schema.schema.name
+}

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 // DDL
@@ -175,7 +176,7 @@ type ClusterParams struct {
 	Disk              sql.NullBool   `db:"disk"`
 	Comment           sql.NullString `db:"comment"`
 	OwnerName         sql.NullString `db:"owner_name"`
-	Privileges        sql.NullString `db:"privileges"`
+	Privileges        pq.StringArray `db:"privileges"`
 }
 
 var clusterQuery = NewBaseQuery(`

--- a/pkg/materialize/connection.go
+++ b/pkg/materialize/connection.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type ValueSecretStruct struct {
@@ -61,7 +62,7 @@ type ConnectionParams struct {
 	ConnectionType sql.NullString `db:"connection_type"`
 	Comment        sql.NullString `db:"comment"`
 	OwnerName      sql.NullString `db:"owner_name"`
-	Privileges     sql.NullString `db:"privileges"`
+	Privileges     pq.StringArray `db:"privileges"`
 }
 
 var connectionQuery = NewBaseQuery(`

--- a/pkg/materialize/database.go
+++ b/pkg/materialize/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type DatabaseBuilder struct {
@@ -38,7 +39,7 @@ type DatabaseParams struct {
 	DatabaseName sql.NullString `db:"database_name"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var databaseQuery = NewBaseQuery(`

--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type MaterializedViewBuilder struct {
@@ -87,7 +88,7 @@ type MaterializedViewParams struct {
 	Cluster              sql.NullString `db:"cluster_name"`
 	Comment              sql.NullString `db:"comment"`
 	OwnerName            sql.NullString `db:"owner_name"`
-	Privileges           sql.NullString `db:"privileges"`
+	Privileges           pq.StringArray `db:"privileges"`
 }
 
 var materializedViewQuery = NewBaseQuery(`

--- a/pkg/materialize/privilege_default_privilege.go
+++ b/pkg/materialize/privilege_default_privilege.go
@@ -139,32 +139,16 @@ func ScanDefaultPrivilege(conn *sqlx.DB, objectType, granteeId, targetRoleId, da
 	return c, nil
 }
 
-type DefaultPrivilegeMapKey struct {
-	ObjectType string
-	GranteeId  string
-	DatabaseId string
-	SchemaId   string
-}
-
-func ParseDefaultPrivileges(privileges []DefaultPrivilegeParams) (map[DefaultPrivilegeMapKey][]string, error) {
-	mapping := make(map[DefaultPrivilegeMapKey][]string)
-
+func MapDefaultGrantPrivileges(privileges []DefaultPrivilegeParams) (map[string][]string, error) {
+	mapping := make(map[string][]string)
 	for _, p := range privileges {
-		key := DefaultPrivilegeMapKey{
-			ObjectType: p.ObjectType.String,
-			GranteeId:  p.GranteeId.String,
-			DatabaseId: p.DatabaseId.String,
-			SchemaId:   p.SchemaId.String,
-		}
-
+		key := p.ObjectType.String + "|" + p.GranteeId.String + "|" + p.DatabaseId.String + "|" + p.SchemaId.String
 		parsedPrivileges := []string{}
 		for _, rp := range strings.Split(p.Privileges.String, "") {
-			v := Permissions[rp]
-			parsedPrivileges = append(parsedPrivileges, v)
+			pName, _ := PrivilegeName(rp)
+			parsedPrivileges = append(parsedPrivileges, pName)
 		}
-
 		mapping[key] = parsedPrivileges
 	}
-
 	return mapping, nil
 }

--- a/pkg/materialize/privilege_default_privilege.go
+++ b/pkg/materialize/privilege_default_privilege.go
@@ -139,9 +139,18 @@ func ScanDefaultPrivilege(conn *sqlx.DB, objectType, granteeId, targetRoleId, da
 	return c, nil
 }
 
+// Converts a list of DefaultPrivilegeParamss into a map
+// list of DefaultPrivilegeParamss would become
+// map[string][]string
+//
+//	{
+//		"TYPE|p||":         {"USAGE", "INSERT"},
+//		"CLUSTER|s2|u3|u8": {"USAGE"},
+//	}
 func MapDefaultGrantPrivileges(privileges []DefaultPrivilegeParams) (map[string][]string, error) {
 	mapping := make(map[string][]string)
 	for _, p := range privileges {
+		// Construct compund grant key
 		key := p.ObjectType.String + "|" + p.GranteeId.String + "|" + p.DatabaseId.String + "|" + p.SchemaId.String
 		parsedPrivileges := []string{}
 		for _, rp := range strings.Split(p.Privileges.String, "") {

--- a/pkg/materialize/privilege_system_privilege.go
+++ b/pkg/materialize/privilege_system_privilege.go
@@ -1,9 +1,7 @@
 package materialize
 
 import (
-	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -37,7 +35,7 @@ func (b *SystemPrivilegeBuilder) GrantKey(roleId, privilege string) string {
 }
 
 type SytemPrivilegeParams struct {
-	Privileges sql.NullString `db:"privileges"`
+	Privileges string `db:"privileges"`
 }
 
 var systemPrivilegeQuery = `SELECT privileges FROM mz_system_privileges`
@@ -49,25 +47,4 @@ func ScanSystemPrivileges(conn *sqlx.DB) ([]SytemPrivilegeParams, error) {
 	}
 
 	return c, nil
-}
-
-func ParseSystemPrivileges(privileges []SytemPrivilegeParams) (map[string][]string, error) {
-	mapping := make(map[string][]string)
-
-	for _, p := range privileges {
-		s := strings.Split(p.Privileges.String, "=")
-
-		rId := s[0]
-		rPrivileges := strings.Split(s[1], "/")[0]
-
-		parsedPrivileges := []string{}
-		for _, rp := range strings.Split(rPrivileges, "") {
-			v := Permissions[rp]
-			parsedPrivileges = append(parsedPrivileges, v)
-		}
-
-		mapping[rId] = parsedPrivileges
-	}
-
-	return mapping, nil
 }

--- a/pkg/materialize/privilege_system_privilege_test.go
+++ b/pkg/materialize/privilege_system_privilege_test.go
@@ -1,35 +1,12 @@
 package materialize
 
 import (
-	"database/sql"
-	"reflect"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
 	"github.com/jmoiron/sqlx"
 )
-
-func TestParseSystemPrivileges(t *testing.T) {
-	input := []SytemPrivilegeParams{
-		{Privileges: sql.NullString{String: "s1=RBN/s1", Valid: true}},
-		{Privileges: sql.NullString{String: "u6=B/s1", Valid: true}},
-	}
-
-	output, err := ParseSystemPrivileges(input)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := map[string][]string{
-		"s1": {"CREATEROLE", "CREATEDB", "CREATECLUSTER"},
-		"u6": {"CREATEDB"},
-	}
-
-	if !reflect.DeepEqual(output, expected) {
-		t.Fatal("ouptut does not equal expected")
-	}
-}
 
 func TestSystemPrivilegeGrant(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
@@ -62,7 +39,7 @@ func TestScanSystemPrivileges(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if p[0].Privileges.String != "s1=RBN/s1" {
+		if p[0].Privileges != "s1=RBN/s1" {
 			t.Fatalf("unexpected privileges")
 		}
 	})

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -9,27 +9,43 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func TestParsePrivileges(t *testing.T) {
-	o := ParsePrivileges("{u2=r/u18,u3=r/u18,u18=arwd/u18}")
-	e := map[string][]string{
-		"u2":  {"SELECT"},
-		"u3":  {"SELECT"},
-		"u18": {"INSERT", "SELECT", "UPDATE", "DELETE"},
+func TestPrivilegeName(t *testing.T) {
+	p, err := PrivilegeName("r")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(o, e) {
-		t.Fatalf("unexpected privilege mapping")
+	if p != "SELECT" {
+		t.Fatal("unexpected privilege name mapping")
 	}
 }
 
-func TestHasPrivilege(t *testing.T) {
-	p := []string{"SELECT", "INSERT", "UPDATE"}
-
-	if !HasPrivilege(p, "INSERT") {
-		t.Fatalf("expected priviledge %s to contain 'INSERT'", p)
+func TestParseMzCatalogPrivileges(t *testing.T) {
+	o := ParseMzCatalogPrivileges("u18=arwd/s1")
+	e := MzCatalogPrivilege{
+		Grantee:    "u18",
+		Privileges: []string{"INSERT", "SELECT", "UPDATE", "DELETE"},
+		Grantor:    "s1",
 	}
+	if !reflect.DeepEqual(o, e) {
+		t.Log(o)
+		t.Log(e)
+		t.Fatalf("could not parse into expected MzCatalogPrivilege")
+	}
+}
 
-	if HasPrivilege(p, "DELETE") {
-		t.Fatalf("expected priviledge %s to not contain 'DELETE", p)
+func TestMapGrantPrivileges(t *testing.T) {
+	o, err := MapGrantPrivileges([]string{"s1=arwd/s1", "u3=wd/s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := map[string][]string{
+		"s1": {"INSERT", "SELECT", "UPDATE", "DELETE"},
+		"u3": {"UPDATE", "DELETE"},
+	}
+	if !reflect.DeepEqual(o, e) {
+		t.Log(o)
+		t.Log(e)
+		t.Fatalf("could not parse into expected mapping")
 	}
 }
 
@@ -71,13 +87,14 @@ func TestScanPrivileges(t *testing.T) {
 		ip := `WHERE mz_databases.id = 'u1'`
 		testhelpers.MockDatabaseScan(mock, ip)
 
-		p, err := ScanPrivileges(db, "DATABASE", "u1")
+		o, err := ScanPrivileges(db, "DATABASE", "u1")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if p != "{u1=UC/u18}" {
-			t.Fatalf("unexpected privileges %s", p)
+		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
+		if !reflect.DeepEqual(o, e) {
+			t.Fatalf("unexpected privileges %s", o)
 		}
 	})
 }

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -20,8 +20,8 @@ func TestPrivilegeName(t *testing.T) {
 }
 
 func TestParseMzCatalogPrivileges(t *testing.T) {
-	o := ParseMzCatalogPrivileges("u18=arwd/s1")
-	e := MzCatalogPrivilege{
+	o := ParseMzAclString("u18=arwd/s1")
+	e := MzAclItem{
 		Grantee:    "u18",
 		Privileges: []string{"INSERT", "SELECT", "UPDATE", "DELETE"},
 		Grantor:    "s1",

--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 // DDL
@@ -43,7 +44,7 @@ type SchemaParams struct {
 	DatabaseName sql.NullString `db:"database_name"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var schemaQuery = NewBaseQuery(`

--- a/pkg/materialize/secret.go
+++ b/pkg/materialize/secret.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 // DDL
@@ -62,7 +63,7 @@ type SecretParams struct {
 	DatabaseName sql.NullString `db:"database_name"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var secretQuery = NewBaseQuery(`

--- a/pkg/materialize/source.go
+++ b/pkg/materialize/source.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type TableStruct struct {
@@ -109,7 +110,7 @@ type SourceParams struct {
 	ClusterName    sql.NullString `db:"cluster_name"`
 	Comment        sql.NullString `db:"comment"`
 	OwnerName      sql.NullString `db:"owner_name"`
-	Privileges     sql.NullString `db:"privileges"`
+	Privileges     pq.StringArray `db:"privileges"`
 }
 
 var sourceQuery = NewBaseQuery(`

--- a/pkg/materialize/table.go
+++ b/pkg/materialize/table.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type TableColumn struct {
@@ -94,7 +95,7 @@ type TableParams struct {
 	DatabaseName sql.NullString `db:"database_name"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var tableQuery = NewBaseQuery(`

--- a/pkg/materialize/type.go
+++ b/pkg/materialize/type.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 type ListProperties struct {
@@ -114,7 +115,7 @@ type TypeParams struct {
 	Category     sql.NullString `db:"category"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var typeQuery = NewBaseQuery(`

--- a/pkg/materialize/view.go
+++ b/pkg/materialize/view.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 )
 
 // DDL
@@ -57,7 +58,7 @@ type ViewParams struct {
 	DatabaseName sql.NullString `db:"database_name"`
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
-	Privileges   sql.NullString `db:"privileges"`
+	Privileges   pq.StringArray `db:"privileges"`
 }
 
 var viewQuery = NewBaseQuery(`

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"slices"
 	"testing"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/exp/slices"
 )
 
 func TestProvider(t *testing.T) {

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -39,6 +39,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 
 	key, err := parsePrivilegeKey(i)
 	if err != nil {
+		d.SetId("")
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/exp/slices"
 )
 
 type GrantPrivilegeKey struct {
@@ -41,7 +42,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 
-	privileges, err := materialize.ScanPrivileges(meta.(*sqlx.DB), key.objectType, key.objectId)
+	p, err := materialize.ScanPrivileges(meta.(*sqlx.DB), key.objectType, key.objectId)
 	if err == sql.ErrNoRows {
 		d.SetId("")
 		return nil
@@ -49,10 +50,11 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 
-	priviledgeMap := materialize.ParsePrivileges(privileges)
+	privilegeMap, err := materialize.MapGrantPrivileges(p)
 	privilege := d.Get("privilege").(string)
 
-	if !materialize.HasPrivilege(priviledgeMap[key.roleId], privilege) {
+	if !slices.Contains(privilegeMap[key.roleId], privilege) {
+		log.Printf("[DEBUG] privilege map %s", privilegeMap)
 		log.Printf("[DEBUG] %s: object does not contain privilege: %s", i, privilege)
 		// Remove id from state
 		d.SetId("")

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -57,21 +57,11 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// Check if default privilege has expected privilege
-	mapping, _ := materialize.ParseDefaultPrivileges(privileges)
+	privilegeMap, _ := materialize.MapDefaultGrantPrivileges(privileges)
+	mapKey := strings.ToLower(key.objectType) + "|" + key.granteeId + "|" + key.databaseId + "|" + key.schemaId
 
-	mapKey := materialize.DefaultPrivilegeMapKey{
-		ObjectType: strings.ToLower(key.objectType), GranteeId: key.granteeId,
-	}
-
-	if key.databaseId != "" {
-		mapKey.DatabaseId = key.databaseId
-	}
-
-	if key.schemaId != "" {
-		mapKey.SchemaId = key.schemaId
-	}
-
-	if !slices.Contains(mapping[mapKey], key.privilege) {
+	if !slices.Contains(privilegeMap[mapKey], key.privilege) {
+		log.Printf("[DEBUG] privilege map %s", privilegeMap)
 		log.Printf("[DEBUG] %s: object does not contain privilege: %s", i, key.privilege)
 		// Remove id from state
 		d.SetId("")

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -27,7 +27,7 @@ func parseDefaultPrivilegeKey(id string) (DefaultPrivilegeKey, error) {
 	ie := strings.Split(id, "|")
 
 	if len(ie) != 7 {
-		return DefaultPrivilegeKey{}, fmt.Errorf("%s cannot be parsed correctly", id)
+		return DefaultPrivilegeKey{}, fmt.Errorf("%s: cannot be parsed correctly", id)
 	}
 
 	return DefaultPrivilegeKey{
@@ -45,6 +45,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 
 	key, err := parseDefaultPrivilegeKey(i)
 	if err != nil {
+		d.SetId("")
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_grant_default_privilege_test.go
+++ b/pkg/resources/resource_grant_default_privilege_test.go
@@ -47,3 +47,17 @@ func TestParseDefaultPrivilegeIdComplex(t *testing.T) {
 		t.Fatalf("schema id %s: expected to u4", i.schemaId)
 	}
 }
+
+func TestParseDefaultPrivilegeIdError(t *testing.T) {
+	_, err := parseDefaultPrivilegeKey("incorrect|key|string")
+	if err.Error() != "incorrect|key|string: cannot be parsed correctly" {
+		t.Fatalf("error not handled")
+	}
+}
+
+func TestParseDefaultPrivilegeIdErrorEmpty(t *testing.T) {
+	_, err := parseDefaultPrivilegeKey("")
+	if err.Error() != ": cannot be parsed correctly" {
+		t.Fatal(err)
+	}
+}

--- a/pkg/resources/resource_grant_materialized_view_test.go
+++ b/pkg/resources/resource_grant_materialized_view_test.go
@@ -16,7 +16,7 @@ func TestResourceGrantMaterializedViewCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":              "joe",
-		"privilege":              "SELECT",
+		"privilege":              "USAGE",
 		"materialized_view_name": "mview",
 		"schema_name":            "schema",
 		"database_name":          "database",
@@ -27,7 +27,7 @@ func TestResourceGrantMaterializedViewCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`GRANT SELECT ON TABLE "database"."schema"."mview" TO "joe";`,
+			`GRANT USAGE ON TABLE "database"."schema"."mview" TO "joe";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Role Id
@@ -46,7 +46,7 @@ func TestResourceGrantMaterializedViewCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if d.Id() != "GRANT|MATERIALIZED VIEW|u1|u1|SELECT" {
+		if d.Id() != "GRANT|MATERIALIZED VIEW|u1|u1|USAGE" {
 			t.Fatalf("unexpected id of %s", d.Id())
 		}
 	})
@@ -57,7 +57,7 @@ func TestResourceGrantMaterializedViewDelete(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":              "joe",
-		"privilege":              "SELECT",
+		"privilege":              "USAGE",
 		"materialized_view_name": "mview",
 		"schema_name":            "schema",
 		"database_name":          "database",
@@ -66,7 +66,7 @@ func TestResourceGrantMaterializedViewDelete(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`REVOKE SELECT ON TABLE "database"."schema"."mview" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`REVOKE USAGE ON TABLE "database"."schema"."mview" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		if err := grantMaterializedViewDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_source_test.go
+++ b/pkg/resources/resource_grant_source_test.go
@@ -16,7 +16,7 @@ func TestResourceGrantSourceCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "SELECT",
+		"privilege":     "USAGE",
 		"source_name":   "source",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -27,7 +27,7 @@ func TestResourceGrantSourceCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`GRANT SELECT ON TABLE "database"."schema"."source" TO "joe";`,
+			`GRANT USAGE ON TABLE "database"."schema"."source" TO "joe";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Role Id
@@ -46,7 +46,7 @@ func TestResourceGrantSourceCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if d.Id() != "GRANT|SOURCE|u1|u1|SELECT" {
+		if d.Id() != "GRANT|SOURCE|u1|u1|USAGE" {
 			t.Fatalf("unexpected id of %s", d.Id())
 		}
 	})
@@ -57,7 +57,7 @@ func TestResourceGrantSourceDelete(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "SELECT",
+		"privilege":     "USAGE",
 		"source_name":   "source",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -66,7 +66,7 @@ func TestResourceGrantSourceDelete(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`REVOKE SELECT ON TABLE "database"."schema"."source" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`REVOKE USAGE ON TABLE "database"."schema"."source" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		if err := grantSourceDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -61,6 +61,7 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	key, err := parseSystemPrivilegeKey(i)
 	if err != nil {
+		d.SetId("")
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_grant_table_test.go
+++ b/pkg/resources/resource_grant_table_test.go
@@ -16,7 +16,7 @@ func TestResourceGrantTableCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "INSERT",
+		"privilege":     "USAGE",
 		"table_name":    "table",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -27,7 +27,7 @@ func TestResourceGrantTableCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`GRANT INSERT ON TABLE "database"."schema"."table" TO "joe";`,
+			`GRANT USAGE ON TABLE "database"."schema"."table" TO "joe";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Role Id
@@ -46,7 +46,7 @@ func TestResourceGrantTableCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if d.Id() != "GRANT|TABLE|u1|u1|INSERT" {
+		if d.Id() != "GRANT|TABLE|u1|u1|USAGE" {
 			t.Fatalf("unexpected id of %s", d.Id())
 		}
 	})
@@ -57,7 +57,7 @@ func TestResourceGrantTableDelete(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "INSERT",
+		"privilege":     "USAGE",
 		"table_name":    "table",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -66,7 +66,7 @@ func TestResourceGrantTableDelete(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`REVOKE INSERT ON TABLE "database"."schema"."table" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`REVOKE USAGE ON TABLE "database"."schema"."table" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		if err := grantTableDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_view_grant_test.go
+++ b/pkg/resources/resource_view_grant_test.go
@@ -16,7 +16,7 @@ func TestResourceGrantViewCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "SELECT",
+		"privilege":     "USAGE",
 		"view_name":     "view",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -27,7 +27,7 @@ func TestResourceGrantViewCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`GRANT SELECT ON TABLE "database"."schema"."view" TO "joe";`,
+			`GRANT USAGE ON TABLE "database"."schema"."view" TO "joe";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Role Id
@@ -46,7 +46,7 @@ func TestResourceGrantViewCreate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if d.Id() != "GRANT|VIEW|u1|u1|SELECT" {
+		if d.Id() != "GRANT|VIEW|u1|u1|USAGE" {
 			t.Fatalf("unexpected id of %s", d.Id())
 		}
 	})
@@ -57,7 +57,7 @@ func TestResourceGrantViewDelete(t *testing.T) {
 
 	in := map[string]interface{}{
 		"role_name":     "joe",
-		"privilege":     "SELECT",
+		"privilege":     "USAGE",
 		"view_name":     "view",
 		"schema_name":   "schema",
 		"database_name": "database",
@@ -66,7 +66,7 @@ func TestResourceGrantViewDelete(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`REVOKE SELECT ON TABLE "database"."schema"."view" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`REVOKE USAGE ON TABLE "database"."schema"."view" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		if err := grantViewDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -201,7 +201,9 @@ func MockDefaultPrivilegeScan(mock sqlmock.Sqlmock, predicate, objectType string
 	q := mockQueryBuilder(b, predicate, "")
 
 	ir := mock.NewRows([]string{"object_type", "grantee_id", "grantee_name", "target_id", "target_name", "database_id", "schema_id", "privileges"}).
-		AddRow(objectType, "u1", "grantee", "u1", "target", nil, nil, "Ur")
+		AddRow(objectType, "u2", "grantee", "u4", "target", "u1", "u3", "U").
+		AddRow(objectType, "u1", "grantee", "u1", "target", nil, nil, "Ur").
+		AddRow(objectType, "u3", "grantee", "u6", "target", "u2", nil, "rw")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -353,6 +355,7 @@ func MockRoleGrantScan(mock sqlmock.Sqlmock) {
 	FROM mz_role_members`
 
 	ir := mock.NewRows([]string{"role_id", "member", "grantor"}).
+		AddRow("u2", "u3", "u3").
 		AddRow("u1", "u1", "s1")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
@@ -540,7 +543,8 @@ func MockTableColumnScan(mock sqlmock.Sqlmock, predicate string) {
 
 func MockSystemGrantScan(mock sqlmock.Sqlmock) {
 	q := `SELECT privileges FROM mz_system_privileges`
-	ir := mock.NewRows([]string{"privileges"}).AddRow("u1=B/s1")
+	ir := mock.NewRows([]string{"privileges"}).
+		AddRow("u1=B/s1").AddRow("u9=RBN/s1").AddRow("u5=B/s1")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
 )
+
+var defaultPrivilege = pq.StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
 
 func mockQueryBuilder(query, predicate, order string) string {
 	q := strings.Builder{}
@@ -74,7 +77,7 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "managed", "size", "replication_factor", "disk", "comment", "owner_name", "privileges"}).
-		AddRow("u1", "cluster", true, "small", 2, true, "comment", "joe", "{u1=UC/u18}")
+		AddRow("u1", "cluster", true, "small", 2, true, "comment", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -105,7 +108,7 @@ func MockConnectionScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "connection_name", "schema_name", "database_name", "connection_type", "owner_name", "privileges"}).
-		AddRow("u1", "connection", "schema", "database", "kafka", "joe", "{u1=U/u18}")
+		AddRow("u1", "connection", "schema", "database", "kafka", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -196,8 +199,9 @@ func MockDefaultPrivilegeScan(mock sqlmock.Sqlmock, predicate, objectType string
 		ON mz_default_privileges.database_id = mz_databases.id`
 
 	q := mockQueryBuilder(b, predicate, "")
+
 	ir := mock.NewRows([]string{"object_type", "grantee_id", "grantee_name", "target_id", "target_name", "database_id", "schema_id", "privileges"}).
-		AddRow(objectType, "u1", "grantee", "u1", "target", nil, nil, "{u1=UC/u18}")
+		AddRow(objectType, "u1", "grantee", "u1", "target", nil, nil, "Ur")
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -221,7 +225,7 @@ func MockDatabaseScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "database_name", "owner_name", "privileges"}).
-		AddRow("u1", "database", "joe", "{u1=UC/u18}")
+		AddRow("u1", "database", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -308,7 +312,7 @@ func MockMaterializeViewScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "materialized_view_name", "schema_name", "database_name", "cluster_name", "owner_name", "privileges"}).
-		AddRow("u1", "view", "schema", "database", "cluster", "joe", "{u1=r/u18}")
+		AddRow("u1", "view", "schema", "database", "cluster", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -375,7 +379,7 @@ func MockSchemaScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "schema_name", "database_name", "owner_name", "privileges"}).
-		AddRow("u1", "schema", "database", "joe", "{u1=UC/u18}")
+		AddRow("u1", "schema", "database", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -405,7 +409,7 @@ func MockSecretScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "owner_name", "privileges"}).
-		AddRow("u1", "secret", "schema", "database", "joe", "{u1=U/u18}")
+		AddRow("u1", "secret", "schema", "database", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -482,7 +486,7 @@ func MockSourceScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "source_type", "size", "envelope_type", "connection_name", "cluster_name", "owner_name", "privileges"}).
-		AddRow("u1", "source", "schema", "database", "kafka", "small", "BYTES", "conn", "cluster", "joe", "{u1=r/u18}")
+		AddRow("u1", "source", "schema", "database", "kafka", "small", "BYTES", "conn", "cluster", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -567,7 +571,7 @@ func MockTableScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "comment", "owner_name", "privileges"}).
-		AddRow("u1", "table", "schema", "database", "comment", "materialize", "{u1=arwd/u18}")
+		AddRow("u1", "table", "schema", "database", "comment", "materialize", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -598,7 +602,7 @@ func MockTypeScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := mock.NewRows([]string{"id", "name", "schema_name", "database_name", "category", "owner_name", "privileges"}).
-		AddRow("u1", "type", "schema", "database", "category", "joe", "{u1=U/u18}")
+		AddRow("u1", "type", "schema", "database", "category", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
@@ -628,6 +632,6 @@ func MockViewScan(mock sqlmock.Sqlmock, predicate string) {
 
 	q := mockQueryBuilder(b, predicate, "")
 	ir := sqlmock.NewRows([]string{"id", "name", "schema_name", "database_name", "owner_name", "privileges"}).
-		AddRow("u1", "view", "schema", "database", "joe", "{u1=r/u18}")
+		AddRow("u1", "view", "schema", "database", "joe", defaultPrivilege)
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }


### PR DESCRIPTION
Cleaning up the grant code which can lead to cryptic errors. Part of this was handling the privileges column from the system catalog as a string (now using `pq.StringArray`). Issues can come from attempting to generate the compound key that makes up grants and parsing out the compound key in order to correctly query the mz catalog.
```
panic: runtime error: index out of range [0] with length 0
```
If any issues arise with the parsing the key, the provider will set the key to `""` so the grant can be recreated rather than erroring.

Make the grant parsing functions more consistent and simple:
* `PrivilegeName`
* `ParseMzAclString`
* `MapGrantPrivileges`
* `MapDefaultGrantPrivileges`