### PR TITLE
Set Security Protocol

### DIFF
--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -89,7 +89,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 - `sasl_password` (Block List, Max: 1) The SASL password for the Kafka broker. (see [below for nested schema](#nestedblock--sasl_password))
 - `sasl_username` (Block List, Max: 1) The SASL username for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--sasl_username))
 - `schema_name` (String) The identifier for the connection schema. Defaults to `public`.
-- `security_protocol` (String) **Private Preview** The security protocol to use.
+- `security_protocol` (String) The security protocol to use: `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.
 - `ssh_tunnel` (Block List, Max: 1) The SSH tunnel configuration for the Kafka broker. (see [below for nested schema](#nestedblock--ssh_tunnel))
 - `ssl_certificate` (Block List, Max: 1) The client certificate for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--ssl_certificate))
 - `ssl_certificate_authority` (Block List, Max: 1) The CA certificate for the Kafka broker.. Can be supplied as either free text using `text` or reference to a secret object using `secret`. (see [below for nested schema](#nestedblock--ssl_certificate_authority))

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -1,6 +1,7 @@
 resource "materialize_connection_kafka" "kafka_connection" {
-  name    = "kafka_connection"
-  comment = "connection kafka comment"
+  name              = "kafka_connection"
+  comment           = "connection kafka comment"
+  security_protocol = "PLAINTEXT"
 
   kafka_broker {
     broker = "redpanda:9092"
@@ -40,11 +41,10 @@ resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
     database_name = materialize_secret.kafka_password.database_name
     schema_name   = materialize_secret.kafka_password.schema_name
   }
-  # TODO: Enable when image supports
-  # security_protocol = "SASL_PLAINTEXT"
-  sasl_mechanisms = "SCRAM-SHA-256"
-  progress_topic  = "progress_topic"
-  validate        = false
+  security_protocol = "SASL_PLAINTEXT"
+  sasl_mechanisms   = "SCRAM-SHA-256"
+  progress_topic    = "progress_topic"
+  validate          = false
 }
 
 resource "materialize_connection_postgres" "postgres_connection" {

--- a/pkg/provider/acceptance_connection_grant_test.go
+++ b/pkg/provider/acceptance_connection_grant_test.go
@@ -97,6 +97,7 @@ resource "materialize_connection_kafka" "test" {
 	kafka_broker {
 	  broker = "redpanda:9092"
 	}
+	security_protocol = "PLAINTEXT"
 }
 
 resource "materialize_connection_grant" "connection_grant" {

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -113,6 +113,7 @@ resource "materialize_connection_kafka" "test" {
 	kafka_broker {
 		broker = "redpanda:9092"
 	}
+	security_protocol = "PLAINTEXT"
 }
 
 resource "materialize_connection_kafka" "test_role" {
@@ -120,6 +121,7 @@ resource "materialize_connection_kafka" "test_role" {
 	kafka_broker {
 		broker = "redpanda:9092"
 	}
+	security_protocol = "PLAINTEXT"
 	ownership_role = "%[4]s"
 
 	depends_on = [materialize_role.test]

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -123,6 +123,7 @@ resource "materialize_connection_kafka" "test" {
 	kafka_broker {
 		broker = "redpanda:9092"
 	}
+	security_protocol = "PLAINTEXT"
 }
 
 resource "materialize_table" "test" {

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -126,6 +126,7 @@ resource "materialize_connection_kafka" "test" {
 	kafka_broker {
 		broker = "redpanda:9092"
 	}
+	security_protocol = "PLAINTEXT"
 }
 
 resource "materialize_source_kafka" "test" {

--- a/pkg/provider/acceptance_table_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_table_grant_default_privilege_test.go
@@ -25,9 +25,6 @@ func TestAccGrantTableDefaultPrivilege_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "target_role_name", targetName),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "schema_name"),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "database_name"),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_all", "grantee_name", granteeName),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_all", "privilege", privilege),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_all", "target_role_name", "PUBLIC"),
 				),
 			},
 		},
@@ -70,12 +67,6 @@ resource "materialize_table_grant_default_privilege" "test" {
 	grantee_name     = materialize_role.test_grantee.name
 	privilege        = "%[3]s"
 	target_role_name = materialize_role.test_target.name
-}
-
-resource "materialize_table_grant_default_privilege" "test_all" {
-	grantee_name     = materialize_role.test_grantee.name
-	privilege        = "%[3]s"
-	target_role_name = "PUBLIC"
 }
 `, granteeName, targetName, privilege)
 }

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -47,7 +47,7 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 		},
 	},
 	"security_protocol": {
-		Description:  "**Private Preview** The security protocol to use.",
+		Description:  "The security protocol to use: `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.",
 		Type:         schema.TypeString,
 		Optional:     true,
 		ForceNew:     true,


### PR DESCRIPTION
Now that `security protocol` is enabled, setting so the integration and acceptance tests will pass. Also updating the flakey table grant acceptance test.