### PR TITLE
Default Grant Read Unnecessary `Set`

### DIFF
--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -49,7 +49,7 @@ resource "materialize_role" "target_2" {
 variable "database_grants" {
   type = map(any)
   default = {
-    bi_usage = {
+    bi_usage_t1 = {
       grantee : "bi",
       privilege : "USAGE",
       target_role : "target_1",
@@ -64,7 +64,7 @@ variable "database_grants" {
       privilege : "CREATE",
       target_role : "target_2",
     },
-    de_usage = {
+    de_usage_t2 = {
       grantee : "de",
       privilege : "USAGE",
       target_role : "target_2",
@@ -107,7 +107,7 @@ variable "schema_grants" {
       privilege : "USAGE",
       database : "db2",
     },
-    bi_usage = {
+    bi_usage_nodb = {
       grantee : "bi",
       privilege : "USAGE",
       database : "",
@@ -138,47 +138,53 @@ resource "materialize_schema_grant_default_privilege" "complex" {
 variable "table_grants" {
   type = map(any)
   default = {
-    bi_select = {
+    bi_select_db1_s1 = {
       grantee : "bi",
       privilege : "SELECT",
       database : "db1",
       schema : "schema1"
     },
-    bi_insert = {
+    bi_insert_db1_s2 = {
       grantee : "bi",
       privilege : "INSERT",
       database : "db1",
       schema : "schema1"
     },
-    ds_select = {
+    ds_select_db2_s3 = {
       grantee : "ds",
       privilege : "SELECT",
       database : "db1",
       schema : "schema2"
     },
-    de_select = {
+    de_select_db1_s3 = {
       grantee : "de",
       privilege : "SELECT",
       database : "db2",
       schema : "schema3"
     },
-    de_update = {
+    de_update_db1_s1 = {
       grantee : "de",
       privilege : "UPDATE",
       database : "db1",
       schema : "schema1",
     },
-    de_update_db1 = {
+    de_update_db1_nos = {
       grantee : "de",
       privilege : "UPDATE",
       database : "db1",
       schema : "",
     },
-    de_update_db2 = {
+    de_update_nodb_nos = {
       grantee : "de",
       privilege : "UPDATE",
-      database : "db2",
+      database : "",
       schema : "",
+    },
+    de_update_db1_public = {
+      grantee : "de",
+      privilege : "UPDATE",
+      database : "db1",
+      schema : "public",
     },
   }
 }

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -52,22 +52,22 @@ variable "database_grants" {
     bi_usage = {
       grantee : "bi",
       privilege : "USAGE",
-      target_role: "target_1",
+      target_role : "target_1",
     },
     bi_create_t1 = {
       grantee : "bi",
       privilege : "CREATE",
-      target_role: "target_1",
+      target_role : "target_1",
     },
     bi_create_t2 = {
       grantee : "bi",
       privilege : "CREATE",
-      target_role: "target_2",
+      target_role : "target_2",
     },
     de_usage = {
       grantee : "de",
       privilege : "USAGE",
-      target_role: "target_2",
+      target_role : "target_2",
     },
   }
 }

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -1,27 +1,29 @@
-variable "teams" {
-  type = map(any)
-  default = {
-    bi_select = {
-      grantee : "bi",
-      privilege : "SELECT",
-    },
-    "bi_insert" = {
-      grantee : "bi",
-      privilege : "INSERT",
-    },
-    "ds_select" = {
-      grantee : "ds",
-      privilege : "SELECT",
-    },
-    "de_select" = {
-      grantee : "de",
-      privilege : "SELECT",
-    },
-    "de_update" = {
-      grantee : "de",
-      privilege : "UPDATE",
-    },
-  }
+resource "materialize_database" "db1" {
+  name = "db1"
+}
+
+resource "materialize_database" "db2" {
+  name = "db2"
+}
+
+resource "materialize_schema" "schema1" {
+  name          = "schema1"
+  database_name = materialize_database.db1.name
+}
+
+resource "materialize_schema" "schema2" {
+  name          = "schema2"
+  database_name = materialize_database.db1.name
+}
+
+resource "materialize_schema" "schema3" {
+  name          = "schema3"
+  database_name = materialize_database.db2.name
+}
+
+resource "materialize_schema" "schema4" {
+  name          = "schema4"
+  database_name = materialize_database.db2.name
 }
 
 resource "materialize_role" "bi" {
@@ -36,15 +38,170 @@ resource "materialize_role" "de" {
   name = "de"
 }
 
-resource "materialize_table_grant_default_privilege" "complex" {
-  for_each         = var.teams
+resource "materialize_role" "target_1" {
+  name = "target_1"
+}
+
+resource "materialize_role" "target_2" {
+  name = "target_2"
+}
+
+variable "database_grants" {
+  type = map(any)
+  default = {
+    bi_usage = {
+      grantee : "bi",
+      privilege : "USAGE",
+      target_role: "target_1",
+    },
+    bi_create_t1 = {
+      grantee : "bi",
+      privilege : "CREATE",
+      target_role: "target_1",
+    },
+    bi_create_t2 = {
+      grantee : "bi",
+      privilege : "CREATE",
+      target_role: "target_2",
+    },
+    de_usage = {
+      grantee : "de",
+      privilege : "USAGE",
+      target_role: "target_2",
+    },
+  }
+}
+
+resource "materialize_database_grant_default_privilege" "complex" {
+  for_each         = var.database_grants
+  privilege        = each.value.privilege
+  grantee_name     = each.value.grantee
+  target_role_name = each.value.target_role
+
+  depends_on = [
+    materialize_role.bi,
+    materialize_role.ds,
+    materialize_role.de,
+    materialize_role.target_1,
+    materialize_role.target_2,
+    materialize_database.db1,
+    materialize_database.db2,
+  ]
+}
+
+variable "schema_grants" {
+  type = map(any)
+  default = {
+    bi_usage_db1 = {
+      grantee : "bi",
+      privilege : "USAGE",
+      database : "db1",
+    },
+    bi_usage_db2 = {
+      grantee : "bi",
+      privilege : "USAGE",
+      database : "db2",
+    },
+    de_usage_db1 = {
+      grantee : "de",
+      privilege : "USAGE",
+      database : "db2",
+    },
+    bi_usage = {
+      grantee : "bi",
+      privilege : "USAGE",
+      database : "",
+    },
+  }
+}
+
+resource "materialize_schema_grant_default_privilege" "complex" {
+  for_each         = var.schema_grants
   privilege        = each.value.privilege
   grantee_name     = each.value.grantee
   target_role_name = materialize_role.target.name
-  database_name    = materialize_database.database.name
-  schema_name      = materialize_schema.schema.name
+  database_name    = each.value.database
 
-  depends_on = [materialize_role.bi, materialize_role.ds, materialize_role.de]
+  depends_on = [
+    materialize_role.bi,
+    materialize_role.ds,
+    materialize_role.de,
+    materialize_database.db1,
+    materialize_database.db2,
+    materialize_schema.schema1,
+    materialize_schema.schema2,
+    materialize_schema.schema3,
+    materialize_schema.schema4,
+  ]
+}
+
+variable "table_grants" {
+  type = map(any)
+  default = {
+    bi_select = {
+      grantee : "bi",
+      privilege : "SELECT",
+      database : "db1",
+      schema : "schema1"
+    },
+    bi_insert = {
+      grantee : "bi",
+      privilege : "INSERT",
+      database : "db1",
+      schema : "schema1"
+    },
+    ds_select = {
+      grantee : "ds",
+      privilege : "SELECT",
+      database : "db1",
+      schema : "schema2"
+    },
+    de_select = {
+      grantee : "de",
+      privilege : "SELECT",
+      database : "db2",
+      schema : "schema3"
+    },
+    de_update = {
+      grantee : "de",
+      privilege : "UPDATE",
+      database : "db1",
+      schema : "schema1",
+    },
+    de_update_db1 = {
+      grantee : "de",
+      privilege : "UPDATE",
+      database : "db1",
+      schema : "",
+    },
+    de_update_db2 = {
+      grantee : "de",
+      privilege : "UPDATE",
+      database : "db2",
+      schema : "",
+    },
+  }
+}
+
+resource "materialize_table_grant_default_privilege" "complex" {
+  for_each         = var.table_grants
+  privilege        = each.value.privilege
+  grantee_name     = each.value.grantee
+  target_role_name = materialize_role.target.name
+  database_name    = each.value.database
+  schema_name      = each.value.schema
+
+  depends_on = [
+    materialize_role.bi,
+    materialize_role.ds,
+    materialize_role.de,
+    materialize_database.db1,
+    materialize_database.db2,
+    materialize_schema.schema1,
+    materialize_schema.schema2,
+    materialize_schema.schema3,
+    materialize_schema.schema4,
+  ]
 }
 
 resource "materialize_role" "op" {
@@ -52,7 +209,15 @@ resource "materialize_role" "op" {
 }
 
 # Non-deterministic grants
-resource "materialize_table_grant_default_privilege" "base" {
+resource "materialize_table_grant_default_privilege" "base_insert" {
+  privilege        = "INSERT"
+  grantee_name     = materialize_role.de.name
+  target_role_name = materialize_role.target.name
+  database_name    = materialize_database.database.name
+  schema_name      = materialize_schema.schema.name
+}
+
+resource "materialize_table_grant_default_privilege" "base_update" {
   privilege        = "UPDATE"
   grantee_name     = materialize_role.de.name
   target_role_name = materialize_role.target.name
@@ -60,7 +225,7 @@ resource "materialize_table_grant_default_privilege" "base" {
   schema_name      = materialize_schema.schema.name
 }
 
-resource "materialize_table_grant_default_privilege" "duplicate" {
+resource "materialize_table_grant_default_privilege" "duplicate_udpate" {
   privilege        = "UPDATE"
   grantee_name     = materialize_role.de.name
   target_role_name = materialize_role.target.name

--- a/pkg/materialize/privilege_default_privilege.go
+++ b/pkg/materialize/privilege_default_privilege.go
@@ -144,14 +144,14 @@ func ScanDefaultPrivilege(conn *sqlx.DB, objectType, granteeId, targetRoleId, da
 // map[string][]string
 //
 //	{
-//		"TYPE|p||":         {"USAGE", "INSERT"},
-//		"CLUSTER|s2|u3|u8": {"USAGE"},
+//		"TYPE|p|s1||":         {"USAGE", "INSERT"},
+//		"CLUSTER|s2|s1|u3|u8": {"USAGE"},
 //	}
 func MapDefaultGrantPrivileges(privileges []DefaultPrivilegeParams) (map[string][]string, error) {
 	mapping := make(map[string][]string)
 	for _, p := range privileges {
 		// Construct compund grant key
-		key := p.ObjectType.String + "|" + p.GranteeId.String + "|" + p.DatabaseId.String + "|" + p.SchemaId.String
+		key := p.ObjectType.String + "|" + p.GranteeId.String + "|" + p.TargetId.String + "|" + p.DatabaseId.String + "|" + p.SchemaId.String
 		parsedPrivileges := []string{}
 		for _, rp := range strings.Split(p.Privileges.String, "") {
 			pName, _ := PrivilegeName(rp)

--- a/pkg/materialize/privilege_default_privilege_test.go
+++ b/pkg/materialize/privilege_default_privilege_test.go
@@ -15,21 +15,25 @@ func TestParseDefaultPrivileges(t *testing.T) {
 		{
 			ObjectType: sql.NullString{String: "TYPE", Valid: true},
 			GranteeId:  sql.NullString{String: "p", Valid: true},
+			TargetId:   sql.NullString{String: "s1", Valid: true},
 			Privileges: sql.NullString{String: "U", Valid: true},
 		},
 		{
 			ObjectType: sql.NullString{String: "CLUSTER", Valid: true},
 			GranteeId:  sql.NullString{String: "s2", Valid: true},
+			TargetId:   sql.NullString{String: "s1", Valid: true},
 			Privileges: sql.NullString{String: "U", Valid: true},
 		},
 		{
 			ObjectType: sql.NullString{String: "TABLE", Valid: true},
 			GranteeId:  sql.NullString{String: "u9", Valid: true},
+			TargetId:   sql.NullString{String: "s2", Valid: true},
 			Privileges: sql.NullString{String: "ar", Valid: true},
 		},
 		{
 			ObjectType: sql.NullString{String: "TABLE", Valid: true},
 			GranteeId:  sql.NullString{String: "u9", Valid: true},
+			TargetId:   sql.NullString{String: "s3", Valid: true},
 			Privileges: sql.NullString{String: "w", Valid: true},
 			DatabaseId: sql.NullString{String: "u3", Valid: true},
 			SchemaId:   sql.NullString{String: "u9", Valid: true},
@@ -42,10 +46,10 @@ func TestParseDefaultPrivileges(t *testing.T) {
 	}
 
 	e := map[string][]string{
-		"TYPE|p||":       {"USAGE"},
-		"CLUSTER|s2||":   {"USAGE"},
-		"TABLE|u9||":     {"INSERT", "SELECT"},
-		"TABLE|u9|u3|u9": {"UPDATE"},
+		"TYPE|p|s1||":       {"USAGE"},
+		"CLUSTER|s2|s1||":   {"USAGE"},
+		"TABLE|u9|s2||":     {"INSERT", "SELECT"},
+		"TABLE|u9|s3|u3|u9": {"UPDATE"},
 	}
 
 	if !reflect.DeepEqual(o, e) {

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -55,12 +55,10 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 
 	privilegeMap, err := materialize.MapGrantPrivileges(p)
 	privilege := d.Get("privilege").(string)
-
 	if !slices.Contains(privilegeMap[key.roleId], privilege) {
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, privilege)
 		// Remove id from state
 		d.SetId("")
 	}
-
 	return nil
 }

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -61,19 +61,12 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 
 	// Check if default privilege has expected privilege
 	privilegeMap, _ := materialize.MapDefaultGrantPrivileges(privileges)
-	mapKey := strings.ToLower(key.objectType) + "|" + key.granteeId + "|" + key.databaseId + "|" + key.schemaId
+	mapKey := strings.ToLower(key.objectType) + "|" + key.granteeId + "|" + key.targetRoleId + "|" + key.databaseId + "|" + key.schemaId
 
 	if !slices.Contains(privilegeMap[mapKey], key.privilege) {
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, key.privilege)
 		// Remove id from state
 		d.SetId("")
 	}
-
-	d.SetId(i)
-
-	if err := d.Set("target_role_name", privileges[0].TargetName.String); err != nil {
-		return diag.FromErr(err)
-	}
-
 	return nil
 }

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -86,9 +86,6 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 		// Remove id from state
 		d.SetId("")
 	}
-
-	d.SetId(i)
-
 	return nil
 }
 


### PR DESCRIPTION
Remove unnecessary `d.Set` from `grantDefaultPrivilegeRead`. Reads for grants never need to set any attributes, it just needs to confirm that the query can be preformed based on the compound key and that the privilege is present in the returned result. Removing this part prevents an error in the provider if the query returns no rows. 

Updating the RBAC integration tests to be a more complex matrix to more throughly test.