### PR TITLE
Allow `replication_factor` 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### BugFixes
 * Fix `expose_progress` in `materialize_source_postgres` and `materialize_source_kafka` [#374](https://github.com/MaterializeInc/terraform-provider-materialize/pull/374)
 * Fix `start_offset` in `materialize_source_kafka` [#374](https://github.com/MaterializeInc/terraform-provider-materialize/pull/374)
+* Allow `replication_factor` of 0 for `materialize_cluster` [#390](https://github.com/MaterializeInc/terraform-provider-materialize/pull/390)
 
 ### Misc
 * Set `replication_factor` as computed in `materialize_cluster` [#374](https://github.com/MaterializeInc/terraform-provider-materialize/pull/374)

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -12,6 +12,12 @@ resource "materialize_cluster" "cluster_sink" {
   size = "3xsmall"
 }
 
+resource "materialize_cluster" "no_replication" {
+  name               = "no_replication"
+  size               = "3xsmall"
+  replication_factor = 0
+}
+
 resource "materialize_cluster_grant" "cluster_grant_usage" {
   role_name    = materialize_role.role_1.name
   privilege    = "USAGE"

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -13,7 +13,7 @@ import (
 type ClusterBuilder struct {
 	ddl                        Builder
 	clusterName                string
-	replicationFactor          int
+	replicationFactor          *int
 	size                       string
 	disk                       bool
 	availabilityZones          []string
@@ -33,7 +33,7 @@ func (b *ClusterBuilder) QualifiedName() string {
 	return QualifiedName(b.clusterName)
 }
 
-func (b *ClusterBuilder) ReplicationFactor(r int) *ClusterBuilder {
+func (b *ClusterBuilder) ReplicationFactor(r *int) *ClusterBuilder {
 	b.replicationFactor = r
 	return b
 }
@@ -72,7 +72,7 @@ func (b *ClusterBuilder) Create() error {
 	q := strings.Builder{}
 
 	q.WriteString(fmt.Sprintf(`CREATE CLUSTER %s`, b.QualifiedName()))
-	// Only create empty clusters, manage replicas with separate resource if replication factor is not set
+	// Only create empty clusters, manage replicas with separate resource if size is not set
 	if b.size != "" {
 		q.WriteString(fmt.Sprintf(` SIZE %s`, QuoteString(b.size)))
 
@@ -83,8 +83,8 @@ func (b *ClusterBuilder) Create() error {
 			p = append(p, i)
 		}
 
-		if b.replicationFactor > 0 {
-			i := fmt.Sprintf(` REPLICATION FACTOR %d`, b.replicationFactor)
+		if b.replicationFactor != nil {
+			i := fmt.Sprintf(` REPLICATION FACTOR %v`, *b.replicationFactor)
 			p = append(p, i)
 		}
 

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -38,11 +38,11 @@ func TestClusterManagedCreate(t *testing.T) {
 func TestClusterManagedReplicationFactorCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`CREATE CLUSTER "cluster" SIZE 'xsmall', REPLICATION FACTOR 3;`).WillReturnResult(sqlmock.NewResult(1, 1))
-
 		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
-		b.ReplicationFactor(3)
+		r := 3
+		b.ReplicationFactor(&r)
 		if err := b.Create(); err != nil {
 			t.Fatal(err)
 		}
@@ -78,7 +78,8 @@ func TestClusterManagedAllCreate(t *testing.T) {
 		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
-		b.ReplicationFactor(2)
+		r := 2
+		b.ReplicationFactor(&r)
 		b.AvailabilityZones([]string{"us-east-1"})
 		b.IntrospectionInterval("1s")
 		b.IntrospectionDebugging()

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -80,6 +80,32 @@ func TestAccClusterManagedNoReplication_basic(t *testing.T) {
 	})
 }
 
+func TestAccClusterManagedZeroReplication_basic(t *testing.T) {
+	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterManagedZeroReplicationResource(clusterName, "3xsmall"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists("materialize_cluster.test"),
+					resource.TestCheckResourceAttr("materialize_cluster.test", "name", clusterName),
+					resource.TestCheckResourceAttr("materialize_cluster.test", "size", "3xsmall"),
+					resource.TestCheckResourceAttr("materialize_cluster.test", "replication_factor", "0"),
+				),
+			},
+			{
+				ResourceName:            "materialize_cluster.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"introspection_debugging", "introspection_interval"},
+			},
+		},
+	})
+}
+
 func TestAccCluster_update(t *testing.T) {
 	slug := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	oldClusterName := fmt.Sprintf("old_%s", slug)
@@ -295,6 +321,17 @@ func testAccClusterManagedNoReplicationResource(clusterName, clusterSize string)
 	resource "materialize_cluster" "test" {
 		name = "%[1]s"
 		size = "%[2]s"
+	}
+	`,
+		clusterName, clusterSize)
+}
+
+func testAccClusterManagedZeroReplicationResource(clusterName, clusterSize string) string {
+	return fmt.Sprintf(`
+	resource "materialize_cluster" "test" {
+		name = "%[1]s"
+		size = "%[2]s"
+		replication_factor = 0
 	}
 	`,
 		clusterName, clusterSize)

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -103,8 +103,9 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 	if size, ok := d.GetOk("size"); ok {
 		b.Size(size.(string))
 
-		if v, ok := d.GetOk("replication_factor"); ok {
-			b.ReplicationFactor(v.(int))
+		if v, ok := d.GetOkExists("replication_factor"); ok {
+			r := v.(int)
+			b.ReplicationFactor(&r)
 		}
 
 		if v, ok := d.GetOk("disk"); ok {


### PR DESCRIPTION
Users are currently unable to create `materialize_clusters` with a `replication_factor` of 0.