### PR TITLE
Allow `PUBLIC` for `grantee` with Default Grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 * Add `ssh_tunnel` as a broker level attribute for `materialize_connection_kafka`. `ssh_tunnel` can be applied as a top level attribute (the default for all brokers) or both the individual broker level [#366](https://github.com/MaterializeInc/terraform-provider-materialize/pull/366)
 
+### BugFixes
+* Allow `PUBLIC` as `grantee` for default grant resources [#397](https://github.com/MaterializeInc/terraform-provider-materialize/issues/397)
+
 ## 0.3.3 - 2023-11-30
 
 ### Features

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -69,6 +69,21 @@ variable "database_grants" {
       privilege : "USAGE",
       target_role : "target_2",
     },
+    public_usage_t2 = {
+      grantee : "PUBLIC",
+      privilege : "USAGE",
+      target_role : "target_2",
+    },
+    de_usage_t2_public = {
+      grantee : "de",
+      privilege : "USAGE",
+      target_role : "PUBLIC",
+    },
+    public_usage_t2_public = {
+      grantee : "PUBLIC",
+      privilege : "USAGE",
+      target_role : "PUBLIC",
+    },
   }
 }
 

--- a/pkg/materialize/privilege_default_privilege.go
+++ b/pkg/materialize/privilege_default_privilege.go
@@ -65,9 +65,14 @@ func (b *DefaultPrivilegeBuilder) baseQuery(action string) error {
 		grantDirection = "FROM"
 	}
 
-	q.WriteString(fmt.Sprintf(` %[1]s %[2]s ON %[3]sS %[4]s %[5]s`, action, b.privilege, b.objectType, grantDirection, b.granteeRole.QualifiedName()))
+	q.WriteString(fmt.Sprintf(` %[1]s %[2]s ON %[3]sS %[4]s`, action, b.privilege, b.objectType, grantDirection))
 
-	q.WriteString(`;`)
+	if b.granteeRole.name == "PUBLIC" {
+		q.WriteString(" PUBLIC")
+	} else {
+		q.WriteString(fmt.Sprintf(` %[1]s`, b.granteeRole.QualifiedName()))
+	}
+
 	return b.ddl.exec(q.String())
 }
 

--- a/pkg/materialize/privilege_default_privilege_test.go
+++ b/pkg/materialize/privilege_default_privilege_test.go
@@ -103,7 +103,7 @@ func TestDefaultPrivilegeRevokeSimple(t *testing.T) {
 	})
 }
 
-func TestDefaultPrivilegeGrantAllRoles(t *testing.T) {
+func TestDefaultPrivilegeGrantPublicTarget(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`
 			ALTER DEFAULT PRIVILEGES FOR ALL ROLES
@@ -111,6 +111,20 @@ func TestDefaultPrivilegeGrantAllRoles(t *testing.T) {
 		`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		b := NewDefaultPrivilegeBuilder(db, "TABLE", "managers", "PUBLIC", "SELECT")
+		if err := b.Grant(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDefaultPrivilegeGrantPublicGrantee(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`
+			ALTER DEFAULT PRIVILEGES FOR ROLE "managers"
+			GRANT SELECT ON TABLES TO PUBLIC;
+		`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		b := NewDefaultPrivilegeBuilder(db, "TABLE", "PUBLIC", "managers", "SELECT")
 		if err := b.Grant(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/provider/acceptance_table_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_table_grant_default_privilege_test.go
@@ -25,6 +25,15 @@ func TestAccGrantTableDefaultPrivilege_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "target_role_name", targetName),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "schema_name"),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "database_name"),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "grantee_name", granteeName),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "privilege", privilege),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "target_role_name", "PUBLIC"),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "grantee_name", "PUBLIC"),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "privilege", privilege),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "target_role_name", targetName),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "grantee_name", "PUBLIC"),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "privilege", privilege),
+					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "target_role_name", "PUBLIC"),
 				),
 			},
 		},
@@ -55,18 +64,36 @@ func TestAccGrantTableDefaultPrivilege_disappears(t *testing.T) {
 
 func testAccGrantTableDefaultPrivilegeResource(granteeName, targetName, privilege string) string {
 	return fmt.Sprintf(`
-resource "materialize_role" "test_grantee" {
-	name = "%[1]s"
-}
+	resource "materialize_role" "test_grantee" {
+		name = "%[1]s"
+	}
 
-resource "materialize_role" "test_target" {
-	name = "%[2]s"
-}
+	resource "materialize_role" "test_target" {
+		name = "%[2]s"
+	}
 
-resource "materialize_table_grant_default_privilege" "test" {
-	grantee_name     = materialize_role.test_grantee.name
-	privilege        = "%[3]s"
-	target_role_name = materialize_role.test_target.name
-}
-`, granteeName, targetName, privilege)
+	resource "materialize_table_grant_default_privilege" "test" {
+		grantee_name     = materialize_role.test_grantee.name
+		privilege        = "%[3]s"
+		target_role_name = materialize_role.test_target.name
+	}
+
+	resource "materialize_table_grant_default_privilege" "test_public_target" {
+		grantee_name     = materialize_role.test_grantee.name
+		privilege        = "%[3]s"
+		target_role_name = "PUBLIC"
+	}
+
+	resource "materialize_table_grant_default_privilege" "test_public_grantee" {
+		grantee_name     = "PUBLIC"
+		privilege        = "%[3]s"
+		target_role_name = materialize_role.test_target.name
+	}
+
+	resource "materialize_table_grant_default_privilege" "test_public_target_grantee" {
+		grantee_name     = "PUBLIC"
+		privilege        = "%[3]s"
+		target_role_name = "PUBLIC"
+	}
+	`, granteeName, targetName, privilege)
 }


### PR DESCRIPTION
The documentation indicates that `PUBLIC` can be used for both `target_role` and `grantee` for default grant resources. However this was only true for `target_role`. Supporting `grantee` as well.