### PR TITLE
Acceptance Id Tests

### DIFF
--- a/pkg/provider/acceptance_cluster_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_cluster_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantClusterDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantClusterDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_cluster_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_cluster_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_cluster_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_cluster_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_cluster_grant_test.go
+++ b/pkg/provider/acceptance_cluster_grant_test.go
@@ -26,6 +26,7 @@ func TestAccGrantCluster_basic(t *testing.T) {
 							ObjectType: "CLUSTER",
 							Name:       clusterName,
 						}, "materialize_cluster_grant.cluster_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_cluster_grant.cluster_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_cluster_grant.cluster_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_cluster_grant.cluster_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_cluster_grant.cluster_grant", "cluster_name", clusterName),

--- a/pkg/provider/acceptance_cluster_replica_test.go
+++ b/pkg/provider/acceptance_cluster_replica_test.go
@@ -25,6 +25,7 @@ func TestAccClusterReplica_basic(t *testing.T) {
 				Config: testAccClusterReplicaResource(clusterName, replicaName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterReplicaExists("materialize_cluster_replica.test"),
+					resource.TestMatchResourceAttr("materialize_cluster_replica.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "cluster_name", clusterName),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "name", replicaName),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "size", "3xsmall"),

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -26,6 +26,7 @@ func TestAccCluster_basic(t *testing.T) {
 				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "3xsmall", "1", "1s", "true", "2", "true", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
+					resource.TestMatchResourceAttr("materialize_cluster.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "name", clusterName),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "ownership_role", "mz_system"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "size", ""),

--- a/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
+++ b/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
@@ -26,6 +26,7 @@ func TestAccConnConfluentSchemaRegistry_basic(t *testing.T) {
 				Config: testAccConnConfluentSchemaRegistryResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnConfluentSchemaRegistryExists("materialize_connection_confluent_schema_registry.test"),
+					resource.TestMatchResourceAttr("materialize_connection_confluent_schema_registry.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_confluent_schema_registry.test", "name", connectionName),
 					resource.TestCheckResourceAttr("materialize_connection_confluent_schema_registry.test", "url", "http://redpanda:8081"),
 					resource.TestCheckResourceAttr("materialize_connection_confluent_schema_registry.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_connection_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_connection_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantConnectionDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantConnectionDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_connection_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_connection_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_connection_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_connection_grant_test.go
+++ b/pkg/provider/acceptance_connection_grant_test.go
@@ -31,6 +31,7 @@ func TestAccGrantConnection_basic(t *testing.T) {
 							DatabaseName: databaseName,
 						},
 						"materialize_connection_grant.connection_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_connection_grant.connection_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_grant.connection_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_connection_grant.connection_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_connection_grant.connection_grant", "connection_name", connectionName),

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -26,6 +26,7 @@ func TestAccConnKafka_basic(t *testing.T) {
 				Config: testAccConnKafkaResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnKafkaExists("materialize_connection_kafka.test"),
+					resource.TestMatchResourceAttr("materialize_connection_kafka.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_kafka.test", "name", connectionName),
 					resource.TestCheckResourceAttr("materialize_connection_kafka.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_connection_kafka.test", "schema_name", "public"),

--- a/pkg/provider/acceptance_connection_postgres_test.go
+++ b/pkg/provider/acceptance_connection_postgres_test.go
@@ -27,6 +27,7 @@ func TestAccConnPostgres_basic(t *testing.T) {
 				Config: testAccConnPostgresResource(roleName, secretName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnPostgresExists("materialize_connection_postgres.test"),
+					resource.TestMatchResourceAttr("materialize_connection_postgres.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_postgres.test", "name", connectionName),
 					resource.TestCheckResourceAttr("materialize_connection_postgres.test", "user.#", "1"),
 					resource.TestCheckResourceAttr("materialize_connection_postgres.test", "user.0.text", "postgres"),

--- a/pkg/provider/acceptance_connection_ssh_tunnel_test.go
+++ b/pkg/provider/acceptance_connection_ssh_tunnel_test.go
@@ -26,6 +26,7 @@ func TestAccConnSshTunnel_basic(t *testing.T) {
 				Config: testAccConnSshTunnelResource(roleName, connectionName, connection2Name, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConnSshTunnelExists("materialize_connection_ssh_tunnel.test"),
+					resource.TestMatchResourceAttr("materialize_connection_ssh_tunnel.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_connection_ssh_tunnel.test", "name", connectionName),
 					resource.TestCheckResourceAttr("materialize_connection_ssh_tunnel.test", "host", "ssh_host"),
 					resource.TestCheckResourceAttr("materialize_connection_ssh_tunnel.test", "user", "ssh_user"),

--- a/pkg/provider/acceptance_database_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_database_grant_default_privilege_test.go
@@ -24,6 +24,7 @@ func TestAccGrantDatabaseDefaultPrivilege_basic(t *testing.T) {
 					{
 						Config: testAccGrantDatabaseDefaultPrivilegeResource(granteeName, targetName, privilege),
 						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("materialize_database_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 							resource.TestCheckResourceAttr("materialize_database_grant_default_privilege.test", "grantee_name", granteeName),
 							resource.TestCheckResourceAttr("materialize_database_grant_default_privilege.test", "privilege", privilege),
 							resource.TestCheckResourceAttr("materialize_database_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_database_grant_test.go
+++ b/pkg/provider/acceptance_database_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantDatabase_basic(t *testing.T) {
 									ObjectType: "DATABASE",
 									Name:       databaseName,
 								}, "materialize_database_grant.database_grant", roleName, privilege),
+							resource.TestMatchResourceAttr("materialize_database_grant.test", "id", terraformGrantIdRegex),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "role_name", roleName),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "privilege", privilege),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "database_name", databaseName),

--- a/pkg/provider/acceptance_database_grant_test.go
+++ b/pkg/provider/acceptance_database_grant_test.go
@@ -30,7 +30,7 @@ func TestAccGrantDatabase_basic(t *testing.T) {
 									ObjectType: "DATABASE",
 									Name:       databaseName,
 								}, "materialize_database_grant.database_grant", roleName, privilege),
-							resource.TestMatchResourceAttr("materialize_database_grant.test", "id", terraformGrantIdRegex),
+							resource.TestMatchResourceAttr("materialize_database_grant.database_grant", "id", terraformGrantIdRegex),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "role_name", roleName),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "privilege", privilege),
 							resource.TestCheckResourceAttr("materialize_database_grant.database_grant", "database_name", databaseName),

--- a/pkg/provider/acceptance_database_test.go
+++ b/pkg/provider/acceptance_database_test.go
@@ -30,7 +30,7 @@ func TestAccDatabase_basic(t *testing.T) {
 						Config: testAccDatabaseResource(roleName, databaseName, database2Name, roleName, "Comment"),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckDatabaseExists("materialize_database.test"),
-							testAccCheckDatabaseExists("materialize_database.test_role"),
+							resource.TestMatchResourceAttr("materialize_database.test", "id", terraformObjectIdRegex),
 							resource.TestCheckResourceAttr("materialize_database.test", "name", databaseName),
 							resource.TestCheckResourceAttr("materialize_database.test", "ownership_role", "mz_system"),
 							testAccCheckDatabaseExists("materialize_database.test_role"),

--- a/pkg/provider/acceptance_grant_system_privilege_test.go
+++ b/pkg/provider/acceptance_grant_system_privilege_test.go
@@ -25,6 +25,7 @@ func TestAccGrantSystemPrivilege_basic(t *testing.T) {
 					{
 						Config: testAccGrantSystemPrivilegeResource(roleName),
 						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("materialize_grant_system_privilege.test", "id", terraformGrantSystemIdRegex),
 							resource.TestCheckResourceAttr("materialize_grant_system_privilege.test", "role_name", roleName),
 							resource.TestCheckResourceAttr("materialize_grant_system_privilege.test", "privilege", "CREATEDB"),
 						),

--- a/pkg/provider/acceptance_index_test.go
+++ b/pkg/provider/acceptance_index_test.go
@@ -25,6 +25,7 @@ func TestAccIndex_basic(t *testing.T) {
 				Config: testAccIndexResource(viewName, indexName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists("materialize_index.test"),
+					resource.TestMatchResourceAttr("materialize_index.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_index.test", "name", indexName),
 					resource.TestCheckResourceAttr("materialize_index.test", "method", "ARRANGEMENT"),
 					resource.TestCheckResourceAttr("materialize_index.test", "obj_name.#", "1"),

--- a/pkg/provider/acceptance_materialized_view_grant_test.go
+++ b/pkg/provider/acceptance_materialized_view_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantMaterializedView_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_materialized_view_grant.materialized_view_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_materialized_view_grant.materialized_view_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_materialized_view_grant.materialized_view_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_materialized_view_grant.materialized_view_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_materialized_view_grant.materialized_view_grant", "materialized_view_name", materializedViewName),

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -26,6 +26,7 @@ func TestAccMaterializedView_basic(t *testing.T) {
 				Config: testAccMaterializedViewResource(roleName, viewName, view2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMaterializedViewExists("materialize_materialized_view.test"),
+					resource.TestMatchResourceAttr("materialize_materialized_view.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "name", viewName),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_role_grant_test.go
+++ b/pkg/provider/acceptance_role_grant_test.go
@@ -33,6 +33,7 @@ func TestAccGrantRole_basic(t *testing.T) {
 					{
 						Config: testAccGrantRoleResource(r["roleName"], r["granteeName"]),
 						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("materialize_role_grant.test", "id", terraformGrantRoleIdRegex),
 							resource.TestCheckResourceAttr("materialize_role_grant.test", "role_name", r["roleName"]),
 							resource.TestCheckResourceAttr("materialize_role_grant.test", "member_name", r["granteeName"]),
 						),

--- a/pkg/provider/acceptance_role_test.go
+++ b/pkg/provider/acceptance_role_test.go
@@ -24,6 +24,7 @@ func TestAccRole_basic(t *testing.T) {
 				Config: testAccRoleResource(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists("materialize_role.test"),
+					resource.TestMatchResourceAttr("materialize_role.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_role.test", "name", roleName),
 					resource.TestCheckResourceAttr("materialize_role.test", "inherit", "true"),
 				),

--- a/pkg/provider/acceptance_schema_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_schema_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantSchemaDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantSchemaDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_schema_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_schema_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_schema_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_schema_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_schema_grant_test.go
+++ b/pkg/provider/acceptance_schema_grant_test.go
@@ -27,6 +27,7 @@ func TestAccGrantSchema_basic(t *testing.T) {
 						Name:         schemaName,
 						DatabaseName: databaseName,
 					}, "materialize_schema_grant.schema_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_schema_grant.schema_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_schema_grant.schema_grant", "schema_name", schemaName),

--- a/pkg/provider/acceptance_schema_test.go
+++ b/pkg/provider/acceptance_schema_test.go
@@ -26,6 +26,7 @@ func TestAccSchema_basic(t *testing.T) {
 				Config: testAccSchemaResource(roleName, schemaName, schema2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchemaExists("materialize_schema.test"),
+					resource.TestMatchResourceAttr("materialize_schema.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_schema.test", "name", schemaName),
 					resource.TestCheckResourceAttr("materialize_schema.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_schema.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."%s"`, schemaName)),

--- a/pkg/provider/acceptance_secret_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_secret_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantSecretDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantSecretDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_secret_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_secret_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_secret_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_secret_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_secret_grant_test.go
+++ b/pkg/provider/acceptance_secret_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantSecret_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_secret_grant.secret_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_secret_grant.secret_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_secret_grant.secret_grant", "secret_name", secretName),

--- a/pkg/provider/acceptance_secret_test.go
+++ b/pkg/provider/acceptance_secret_test.go
@@ -26,6 +26,7 @@ func TestAccSecret_basic(t *testing.T) {
 				Config: testAccSecretResource(roleName, secretName, "sekret", secret2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretExists("materialize_secret.test"),
+					resource.TestMatchResourceAttr("materialize_secret.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_secret.test", "name", secretName),
 					resource.TestCheckResourceAttr("materialize_secret.test", "value", "sekret"),
 					resource.TestCheckResourceAttr("materialize_secret.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -28,6 +28,7 @@ func TestAccSinkKafka_basic(t *testing.T) {
 				Config: testAccSinkKafkaResource(roleName, connName, tableName, sinkName, sink2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkKafkaExists("materialize_sink_kafka.test"),
+					resource.TestMatchResourceAttr("materialize_sink_kafka.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_sink_kafka.test", "name", sinkName),
 					resource.TestCheckResourceAttr("materialize_sink_kafka.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_sink_kafka.test", "schema_name", "public"),

--- a/pkg/provider/acceptance_source_grant_test.go
+++ b/pkg/provider/acceptance_source_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantSource_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_source_grant.source_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_source_grant.source_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_grant.source_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_source_grant.source_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_source_grant.source_grant", "source_name", sourceName),

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -27,6 +27,7 @@ func TestAccSourceKafka_basic(t *testing.T) {
 				Config: testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceKafkaExists("materialize_source_kafka.test"),
+					resource.TestMatchResourceAttr("materialize_source_kafka.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "schema_name", "public"),

--- a/pkg/provider/acceptance_source_load_generator_test.go
+++ b/pkg/provider/acceptance_source_load_generator_test.go
@@ -26,6 +26,7 @@ func TestAccSourceLoadGeneratorCounter_basic(t *testing.T) {
 				Config: testAccSourceLoadGeneratorResource(roleName, sourceName, source2Name, "3xsmall", roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceLoadGeneratorExists("materialize_source_load_generator.test"),
+					resource.TestMatchResourceAttr("materialize_source_load_generator.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_load_generator.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_load_generator.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_source_load_generator.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -28,6 +28,7 @@ func TestAccSourcePostgres_basic(t *testing.T) {
 				Config: testAccSourcePostgresResource(roleName, secretName, connName, sourceName, source2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourcePostgresExists("materialize_source_postgres.test"),
+					resource.TestMatchResourceAttr("materialize_source_postgres.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schema_name", "public"),

--- a/pkg/provider/acceptance_source_webhook_test.go
+++ b/pkg/provider/acceptance_source_webhook_test.go
@@ -27,6 +27,7 @@ func TestAccSourceWebhook_basic(t *testing.T) {
 				Config: testAccSourceWebhookResource(roleName, secretName, clusterName, sourceName, "mz_system", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceWebhookExists("materialize_source_webhook.test"),
+					resource.TestMatchResourceAttr("materialize_source_webhook.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "cluster_name", clusterName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "body_format", "json"),
@@ -64,6 +65,7 @@ func TestAccSourceWebhookSegment_basic(t *testing.T) {
 				Config: testAccSourceWebhookSegmentResource(sourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceWebhookExists("materialize_source_webhook.test"),
+					resource.TestMatchResourceAttr("materialize_source_webhook.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "cluster_name", "segment_cluster"),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "body_format", "json"),
@@ -97,6 +99,7 @@ func TestAccSourceWebhookRudderstack_basic(t *testing.T) {
 				Config: testAccSourceWebhookRudderstackResource(sourceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSourceWebhookExists("materialize_source_webhook.test"),
+					resource.TestMatchResourceAttr("materialize_source_webhook.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "name", sourceName),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "cluster_name", "rudderstack_cluster"),
 					resource.TestCheckResourceAttr("materialize_source_webhook.test", "body_format", "json"),

--- a/pkg/provider/acceptance_table_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_table_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantTableDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantTableDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_table_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_table_grant_test.go
+++ b/pkg/provider/acceptance_table_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantTable_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_table_grant.table_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_table_grant.table_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_table_grant.table_grant", "table_name", tableName),

--- a/pkg/provider/acceptance_table_test.go
+++ b/pkg/provider/acceptance_table_test.go
@@ -26,6 +26,7 @@ func TestAccTable_basic(t *testing.T) {
 				Config: testAccTableResource(roleName, tableName, tableRoleName, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTableExists("materialize_table.test"),
+					resource.TestMatchResourceAttr("materialize_table.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_table.test", "name", tableName),
 					resource.TestCheckResourceAttr("materialize_table.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_table.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_type_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_type_grant_default_privilege_test.go
@@ -20,6 +20,7 @@ func TestAccGrantTypeDefaultPrivilege_basic(t *testing.T) {
 			{
 				Config: testAccGrantTypeDefaultPrivilegeResource(granteeName, targetName, privilege),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("materialize_type_grant_default_privilege.test", "id", terraformGrantDefaultIdRegex),
 					resource.TestCheckResourceAttr("materialize_type_grant_default_privilege.test", "grantee_name", granteeName),
 					resource.TestCheckResourceAttr("materialize_type_grant_default_privilege.test", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_type_grant_default_privilege.test", "target_role_name", targetName),

--- a/pkg/provider/acceptance_type_grant_test.go
+++ b/pkg/provider/acceptance_type_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantType_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_type_grant.type_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_type_grant.type_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_type_grant.type_grant", "type_name", typeName),

--- a/pkg/provider/acceptance_type_test.go
+++ b/pkg/provider/acceptance_type_test.go
@@ -26,6 +26,7 @@ func TestAccTypeList_basic(t *testing.T) {
 				Config: testAccTypeResource(roleName, typeName, type2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTypeExists("materialize_type.test"),
+					resource.TestMatchResourceAttr("materialize_type.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_type.test", "name", typeName),
 					resource.TestCheckResourceAttr("materialize_type.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_type.test", "database_name", "materialize"),

--- a/pkg/provider/acceptance_view_grant_test.go
+++ b/pkg/provider/acceptance_view_grant_test.go
@@ -30,6 +30,7 @@ func TestAccGrantView_basic(t *testing.T) {
 							SchemaName:   schemaName,
 							DatabaseName: databaseName,
 						}, "materialize_view_grant.view_grant", roleName, privilege),
+					resource.TestMatchResourceAttr("materialize_view_grant.view_grant", "id", terraformGrantIdRegex),
 					resource.TestCheckResourceAttr("materialize_view_grant.view_grant", "role_name", roleName),
 					resource.TestCheckResourceAttr("materialize_view_grant.view_grant", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_view_grant.view_grant", "view_name", viewName),

--- a/pkg/provider/acceptance_view_test.go
+++ b/pkg/provider/acceptance_view_test.go
@@ -26,6 +26,7 @@ func TestAccView_basic(t *testing.T) {
 				Config: testAccViewResource(roleName, viewName, view2Name, roleName, "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckViewExists("materialize_view.test"),
+					resource.TestMatchResourceAttr("materialize_view.test", "id", terraformObjectIdRegex),
 					resource.TestCheckResourceAttr("materialize_view.test", "name", viewName),
 					resource.TestCheckResourceAttr("materialize_view.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_view.test", "database_name", "materialize"),

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -10,6 +11,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/exp/slices"
+)
+
+var (
+	terraformObjectIdRegex       = regexp.MustCompile("^aws/us-east-1:")
+	terraformGrantIdRegex        = regexp.MustCompile("^aws/us-east-1:GRANT|")
+	terraformGrantDefaultIdRegex = regexp.MustCompile("^aws/us-east-1:GRANT DEFAULT|")
+	terraformGrantSystemIdRegex  = regexp.MustCompile("^aws/us-east-1:GRANT ROLE|")
+	terraformGrantRoleIdRegex    = regexp.MustCompile("^aws/us-east-1:GRANT SYSTEM|")
 )
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
Include tests for id in all acceptance tests. Because we do not know the system ids until they are generated, using `TestMatchResourceAttr` to ensure they match the expected regex for the 5 main id types:
```
var (
	terraformObjectIdRegex       = regexp.MustCompile("^aws/us-east-1:")
	terraformGrantIdRegex        = regexp.MustCompile("^aws/us-east-1:GRANT|")
	terraformGrantDefaultIdRegex = regexp.MustCompile("^aws/us-east-1:GRANT DEFAULT|")
	terraformGrantSystemIdRegex  = regexp.MustCompile("^aws/us-east-1:GRANT ROLE|")
	terraformGrantRoleIdRegex    = regexp.MustCompile("^aws/us-east-1:GRANT SYSTEM|")
)
```