### PR TITLE
Grant Id Set Read

### DIFF
--- a/pkg/resources/resource_connection_aws_privatelink_test.go
+++ b/pkg/resources/resource_connection_aws_privatelink_test.go
@@ -47,6 +47,31 @@ func TestResourceConnectionAwsPrivatelinkCreate(t *testing.T) {
 
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceConnectionAwsPrivatelinkReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, ConnectionAwsPrivatelink().Schema, inAwsPrivatelink)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_connections.id = 'u1'`
+		testhelpers.MockConnectionAwsPrivatelinkScan(mock, pp)
+
+		if err := connectionAwsPrivatelinkRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+
+}
+
 func TestResourceConnectionAwsPrivatelinkUpdate(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, ConnectionAwsPrivatelink().Schema, inAwsPrivatelink)

--- a/pkg/resources/resource_connection_test.go
+++ b/pkg/resources/resource_connection_test.go
@@ -6,6 +6,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,8 @@ var inConnection = map[string]interface{}{
 	"database_name": "database",
 }
 
+// All connections (other than AWS Privatelink and SSH Tunnel)
+// share the same update function
 func TestResourceConnectionUpdate(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inConnection)
@@ -39,6 +42,34 @@ func TestResourceConnectionUpdate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+// All connections (other than AWS Privatelink and SSH Tunnel)
+// share the same read function
+func TestResourceConnectionReadIdMigration(t *testing.T) {
+	utils.SetRegionFromHostname("localhost")
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inConnection)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		p := `WHERE mz_connections.id = 'u1'`
+		testhelpers.MockConnectionScan(mock, p)
+
+		if err := connectionRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
+// All connections share the same delete function
 func TestResourceConnectionDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_database_test.go
+++ b/pkg/resources/resource_database_test.go
@@ -41,6 +41,33 @@ func TestResourceDatabaseCreate(t *testing.T) {
 	})
 }
 
+func TestResourceDatabaseReadIdMigration(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name": "database",
+	}
+	d := schema.TestResourceDataRaw(t, Database().Schema, in)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_databases.id = 'u1'`
+		testhelpers.MockDatabaseScan(mock, pp)
+
+		if err := databaseRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceDatabaseDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
@@ -60,5 +61,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		// Remove id from state
 		d.SetId("")
 	}
+
+	d.SetId(utils.TransformIdWithRegion(i))
 	return nil
 }

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmoiron/sqlx"
@@ -68,5 +69,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 		// Remove id from state
 		d.SetId("")
 	}
+
+	d.SetId(utils.TransformIdWithRegion(i))
 	return nil
 }

--- a/pkg/resources/resource_grant_role.go
+++ b/pkg/resources/resource_grant_role.go
@@ -85,8 +85,7 @@ func grantRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 		return diag.Errorf("role does contain member %s", key.memberId)
 	}
 
-	d.SetId(i)
-
+	d.SetId(utils.TransformIdWithRegion(i))
 	return nil
 }
 

--- a/pkg/resources/resource_grant_role_test.go
+++ b/pkg/resources/resource_grant_role_test.go
@@ -50,6 +50,35 @@ func TestResourceGrantRolePrivilegeCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceGrantRolePrivilegeReadIdMigration(t *testing.T) {
+	utils.SetRegionFromHostname("localhost")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":   "role",
+		"member_name": "member",
+	}
+	d := schema.TestResourceDataRaw(t, GrantRole().Schema, in)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("ROLE MEMBER|u1|u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		testhelpers.MockRoleGrantScan(mock)
+
+		if err := grantRoleRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:ROLE MEMBER|u1|u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceGrantRolePrivilegeDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -87,6 +87,8 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 		// Remove id from state
 		d.SetId("")
 	}
+
+	d.SetId(utils.TransformIdWithRegion(i))
 	return nil
 }
 

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -1,0 +1,45 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+// Confirm id is updated with region for 0.4.0
+// All resources share the same read function
+func TestResourceGrantPrivilegeReadIdMigration(t *testing.T) {
+	utils.SetRegionFromHostname("localhost")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "CREATE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("GRANT|CLUSTER|u1|u1|CREATE")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_clusters.id = 'u1'`
+		testhelpers.MockClusterScan(mock, pp)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:GRANT|CLUSTER|u1|u1|CREATE" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}

--- a/pkg/resources/resource_materialized_view_test.go
+++ b/pkg/resources/resource_materialized_view_test.go
@@ -46,6 +46,30 @@ func TestResourceMaterializedViewCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceMaterializedViewReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, MaterializedView().Schema, inMaterializedView)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_materialized_views.id = 'u1'`
+		testhelpers.MockMaterializeViewScan(mock, pp)
+
+		if err := materializedViewRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceMaterializedViewUpdate(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, MaterializedView().Schema, inMaterializedView)

--- a/pkg/resources/resource_role_test.go
+++ b/pkg/resources/resource_role_test.go
@@ -42,6 +42,30 @@ func TestResourceRoleCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceRoleReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, Role().Schema, inRole)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_roles.id = 'u1'`
+		testhelpers.MockRoleScan(mock, pp)
+
+		if err := roleRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceRoleDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_schema_test.go
+++ b/pkg/resources/resource_schema_test.go
@@ -42,6 +42,34 @@ func TestResourceSchemaCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceSchemaReadIdMigration(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name": "schema",
+	}
+	d := schema.TestResourceDataRaw(t, Schema().Schema, in)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_schemas.id = 'u1'`
+		testhelpers.MockSchemaScan(mock, pp)
+
+		if err := schemaRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceSchemaDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_sink_test.go
+++ b/pkg/resources/resource_sink_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceSinkReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, SinkKafka().Schema, inSinkKafka)
+	r.NotNil(d)
+
+	// Set current state
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_sinks.id = 'u1'`
+		testhelpers.MockSinkScan(mock, pp)
+
+		if err := sinkRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceSinkUpdate(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, SinkKafka().Schema, inSinkKafka)

--- a/pkg/resources/resource_type_test.go
+++ b/pkg/resources/resource_type_test.go
@@ -42,6 +42,30 @@ func TestResourceTypeCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceTypeReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, Type().Schema, inType)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_types.id = 'u1'`
+		testhelpers.MockTypeScan(mock, pp)
+
+		if err := typeRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceTypeDelete(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/resource_view_test.go
+++ b/pkg/resources/resource_view_test.go
@@ -42,6 +42,30 @@ func TestResourceViewCreate(t *testing.T) {
 	})
 }
 
+// Confirm id is updated with region for 0.4.0
+func TestResourceViewReadIdMigration(t *testing.T) {
+	r := require.New(t)
+	d := schema.TestResourceDataRaw(t, View().Schema, inView)
+	r.NotNil(d)
+
+	// Set id before migration
+	d.SetId("u1")
+
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_views.id = 'u1'`
+		testhelpers.MockViewScan(mock, pp)
+
+		if err := viewRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:u1" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceViewUpdate(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, View().Schema, inView)


### PR DESCRIPTION
The grant read functions was not setting the new id value which would mean that existing grants would not be properly updated after the migration to `0.4.0`. Including `TransformIdWithRegion` in the `SetId` on all of the read functions. Also while including the unit tests for the grant read functions, including a similar migration id unit test for all other resources.