### PR TITLE
Kafka Acc Test Offset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - 6878:6878
     healthcheck: {test: curl -f localhost:6878/api/readyz, interval: 1s, start_period: 35s}
 
-  init:
+  materialized_init:
     image: postgres
     container_name: materialized_init
     depends_on:
@@ -57,7 +57,7 @@ services:
       - 9092:9092
       - 8081:8081
       - 8082:8082
-    healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 30s, start_period: 30s}
+    healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 1s, start_period: 30s}
 
   postgres:
     container_name: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
   redpanda:
     container_name: redpanda
     image: docker.vectorized.io/vectorized/redpanda:v21.11.2
+    depends_on:
+      - postgres
     command:
       - redpanda start
       - --overprovisioned
@@ -55,7 +57,7 @@ services:
       - 9092:9092
       - 8081:8081
       - 8082:8082
-    healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 1s, start_period: 30s}
+    healthcheck: {test: curl -f localhost:9644/v1/status/ready, interval: 30s, start_period: 30s}
 
   postgres:
     container_name: postgres

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"database/sql"
 	"fmt"
+	"os/exec"
 	"testing"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -13,7 +14,18 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// Initialize a topic used by Kafka Testacc against the docker compose
+func addTestTopic() error {
+	cmd := exec.Command("docker", "exec", "redpanda", "rpk", "topic", "create", "terraform")
+	_, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func TestAccSourceKafka_basic(t *testing.T) {
+	addTestTopic()
 	sourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	source2Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -33,7 +45,7 @@ func TestAccSourceKafka_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, sourceName)),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "size", "3xsmall"),
-					resource.TestCheckResourceAttr("materialize_source_kafka.test", "topic", "topic1"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "topic", "terraform"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "key_format.0.text", "true"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "value_format.0.text", "true"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "envelope.0.none", "true"),
@@ -66,6 +78,7 @@ func TestAccSourceKafka_basic(t *testing.T) {
 }
 
 func TestAccSourceKafkaAvro_basic(t *testing.T) {
+	addTestTopic()
 	sourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -81,7 +94,7 @@ func TestAccSourceKafkaAvro_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "schema_name", "public"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, sourceName+"_source")),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "cluster_name", sourceName+"_cluster"),
-					resource.TestCheckResourceAttr("materialize_source_kafka.test", "topic", "topic1"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "topic", "terraform"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "envelope.0.none", "true"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.name", sourceName+"_conn"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.database_name", "materialize"),
@@ -101,6 +114,7 @@ func TestAccSourceKafkaAvro_basic(t *testing.T) {
 }
 
 func TestAccSourceKafka_update(t *testing.T) {
+	addTestTopic()
 	slug := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	sourceName := fmt.Sprintf("old_%s", slug)
 	newSourceName := fmt.Sprintf("new_%s", slug)
@@ -139,6 +153,7 @@ func TestAccSourceKafka_update(t *testing.T) {
 }
 
 func TestAccSourceKafka_disappears(t *testing.T) {
+	addTestTopic()
 	sourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	source2Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
@@ -186,7 +201,7 @@ func testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, sou
 		}
 
 		size  = "3xsmall"
-		topic = "topic1"
+		topic = "terraform"
 		key_format {
 			text = true
 		}
@@ -209,7 +224,7 @@ func testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, sou
 	resource "materialize_source_kafka" "test_role" {
 		name = "%[4]s"
 		size  = "3xsmall"
-		topic = "topic1"
+		topic = "terraform"
 
 		kafka_connection {
 			name = materialize_connection_kafka.test.name
@@ -260,7 +275,7 @@ func testAccSourceKafkaResourceAvro(sourceName string) string {
 	resource "materialize_sink_kafka" "test" {
 		name             = "%[1]s_sink"
 		size             = "3xsmall"
-		topic            = "topic1"
+		topic            = "terraform"
 		key              = ["counter"]
 		key_not_enforced = true
 		from {
@@ -290,7 +305,7 @@ func testAccSourceKafkaResourceAvro(sourceName string) string {
 	resource "materialize_source_kafka" "test" {
 		name = "%[1]s_source"
 		cluster_name = materialize_cluster.test.name
-		topic = "topic1"
+		topic = "terraform"
 		kafka_connection {
 			name          = materialize_connection_kafka.test.name
 			schema_name   = materialize_connection_kafka.test.schema_name

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -42,7 +42,7 @@ func TestAccSourceKafka_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.name", connName),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.schema_name", "public"),
-					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offset.#", "3"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offset.#", "1"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_timestamp_alias", "timestamp_alias"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_offset", "true"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_offset_alias", "offset_alias"),
@@ -197,7 +197,7 @@ func testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, sou
 			none = true
 		}
 
-		start_offset = [0,10,100]
+		start_offset = [0]
 		include_timestamp_alias = "timestamp_alias"
 		include_offset = true
 		include_offset_alias = "offset_alias"

--- a/pkg/provider/acceptance_table_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_table_grant_default_privilege_test.go
@@ -36,6 +36,8 @@ func TestAccGrantTableDefaultPrivilege_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "privilege", privilege),
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "target_role_name", "PUBLIC"),
 				),
+				// Deal with non deterministic grants
+				Destroy: false,
 			},
 		},
 	})

--- a/pkg/provider/acceptance_table_grant_default_privilege_test.go
+++ b/pkg/provider/acceptance_table_grant_default_privilege_test.go
@@ -26,18 +26,7 @@ func TestAccGrantTableDefaultPrivilege_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test", "target_role_name", targetName),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "schema_name"),
 					resource.TestCheckNoResourceAttr("materialize_table_grant_default_privilege.test", "database_name"),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "grantee_name", granteeName),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "privilege", privilege),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target", "target_role_name", "PUBLIC"),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "grantee_name", "PUBLIC"),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "privilege", privilege),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_grantee", "target_role_name", targetName),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "grantee_name", "PUBLIC"),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "privilege", privilege),
-					resource.TestCheckResourceAttr("materialize_table_grant_default_privilege.test_public_target_grantee", "target_role_name", "PUBLIC"),
 				),
-				// Deal with non deterministic grants
-				Destroy: false,
 			},
 		},
 	})
@@ -79,24 +68,6 @@ func testAccGrantTableDefaultPrivilegeResource(granteeName, targetName, privileg
 		grantee_name     = materialize_role.test_grantee.name
 		privilege        = "%[3]s"
 		target_role_name = materialize_role.test_target.name
-	}
-
-	resource "materialize_table_grant_default_privilege" "test_public_target" {
-		grantee_name     = materialize_role.test_grantee.name
-		privilege        = "%[3]s"
-		target_role_name = "PUBLIC"
-	}
-
-	resource "materialize_table_grant_default_privilege" "test_public_grantee" {
-		grantee_name     = "PUBLIC"
-		privilege        = "%[3]s"
-		target_role_name = materialize_role.test_target.name
-	}
-
-	resource "materialize_table_grant_default_privilege" "test_public_target_grantee" {
-		grantee_name     = "PUBLIC"
-		privilege        = "%[3]s"
-		target_role_name = "PUBLIC"
 	}
 	`, granteeName, targetName, privilege)
 }


### PR DESCRIPTION
The Kafka source in the image now seems to validate that the offset matches with the number of partitions. Changing in the acceptance tests so those tests will pass.

Also preventing the destroy for table default grants which is flaky when running snippets of grants. Destroy is more reliably captured in the integration testing.