### PR TITLE
[WIP] Rename Singular Attributes

### DIFF
--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -74,7 +74,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 - `ownership_role` (String) The owernship role of the object.
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
 - `size` (String) The size of the source. If not specified, the `cluster_name` option must be specified.
-- `start_offset` (List of Number) Read partitions from the specified offset.
+- `start_offsets` (List of Number) Read partitions from the specified offset.
 - `start_timestamp` (Number) Use the specified value to set `START OFFSET` based on the Kafka timestamp.
 - `value_format` (Block List, Max: 1) Set the value format explicitly. (see [below for nested schema](#nestedblock--value_format))
 

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -59,8 +59,8 @@ resource "materialize_source_postgres" "example_source_postgres" {
 - `database_name` (String) The identifier for the source database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (Block List, Max: 1) The name of the progress subsource for the source. If this is not specified, the subsource will be named `<src_name>_progress`. (see [below for nested schema](#nestedblock--expose_progress))
 - `ownership_role` (String) The owernship role of the object.
-- `schema` (List of String) Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES
 - `schema_name` (String) The identifier for the source schema. Defaults to `public`.
+- `schemas` (List of String) Creates subsources for specific schemas. If neither table or schema is specified, will default to ALL TABLES
 - `size` (String) The size of the source. If not specified, the `cluster_name` option must be specified.
 - `table` (Block List) Creates subsources for specific tables. If neither table or schema is specified, will default to ALL TABLES (see [below for nested schema](#nestedblock--table))
 - `text_columns` (List of String) Decode data as text for specific columns that contain PostgreSQL types that are unsupported in Materialize. Can only be updated in place when also updating a corresponding `table` attribute.

--- a/integration/source.tf
+++ b/integration/source.tf
@@ -91,7 +91,7 @@ resource "materialize_source_postgres" "example_source_postgres_schema" {
   name        = "source_postgres_schema"
   size        = "3xsmall"
   publication = "mz_source"
-  schema      = ["PUBLIC"]
+  schemas     = ["PUBLIC"]
 
   postgres_connection {
     name          = materialize_connection_postgres.postgres_connection.name

--- a/pkg/provider/acceptance_source_kafka_migration_test.go
+++ b/pkg/provider/acceptance_source_kafka_migration_test.go
@@ -1,0 +1,111 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSourceKafkaMigration_basic(t *testing.T) {
+	addTestTopic()
+	sourceName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"materialize": {
+						VersionConstraint: "0.4.1",
+						Source:            "MaterializeInc/materialize",
+					},
+				},
+				Config: testAccSourceKafkaMigrationV0Resource(sourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSourceKafkaExists("materialize_source_kafka.test"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offset.#", "1"),
+				),
+			},
+			{
+				ProviderFactories: testAccProviderFactories,
+				Config:            testAccSourceKafkaMigrationV1Resource(sourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSourceKafkaExists("materialize_source_kafka.test"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offsets.#", "1"),
+				),
+			},
+			{
+				ProviderFactories: testAccProviderFactories,
+				ResourceName:      "materialize_source_kafka.test",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccSourceKafkaMigrationV0Resource(sourceName string) string {
+	return fmt.Sprintf(`
+	resource "materialize_connection_kafka" "test" {
+		name = "%[1]s"
+		kafka_broker {
+			broker = "redpanda:9092"
+		}
+		security_protocol = "PLAINTEXT"
+	}
+
+	resource "materialize_source_kafka" "test" {
+		name = "%[1]s"
+		kafka_connection {
+			name = materialize_connection_kafka.test.name
+		}
+
+		size  = "3xsmall"
+		topic = "terraform"
+		key_format {
+			text = true
+		}
+		value_format {
+			text = true
+		}
+		envelope {
+			none = true
+		}
+		start_offset = [0]
+	}
+`, sourceName)
+}
+
+func testAccSourceKafkaMigrationV1Resource(sourceName string) string {
+	return fmt.Sprintf(`
+	resource "materialize_connection_kafka" "test" {
+		name = "%[1]s"
+		kafka_broker {
+			broker = "redpanda:9092"
+		}
+		security_protocol = "PLAINTEXT"
+	}
+
+	resource "materialize_source_kafka" "test" {
+		name = "%[1]s"
+		kafka_connection {
+			name = materialize_connection_kafka.test.name
+		}
+
+		size  = "3xsmall"
+		topic = "terraform"
+		key_format {
+			text = true
+		}
+		value_format {
+			text = true
+		}
+		envelope {
+			none = true
+		}
+		start_offset = [0]
+	}
+`, sourceName)
+}

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -54,7 +54,7 @@ func TestAccSourceKafka_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.name", connName),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.database_name", "materialize"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "kafka_connection.0.schema_name", "public"),
-					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offset.#", "1"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test", "start_offsets.#", "1"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_timestamp_alias", "timestamp_alias"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_offset", "true"),
 					resource.TestCheckResourceAttr("materialize_source_kafka.test", "include_offset_alias", "offset_alias"),
@@ -212,7 +212,7 @@ func testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, sou
 			none = true
 		}
 
-		start_offset = [0]
+		start_offsets = [0]
 		include_timestamp_alias = "timestamp_alias"
 		include_offset = true
 		include_offset_alias = "offset_alias"

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -75,8 +75,8 @@ func TestAccSourcePostgresSchema_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, sourceName+"_source")),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "cluster_name", sourceName+"_cluster"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "publication", "mz_source"),
-					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schema.#", "1"),
-					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schema.0", "PUBLIC"),
+					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schemas.#", "1"),
+					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schemas.0", "PUBLIC"),
 				),
 			},
 			{
@@ -353,7 +353,7 @@ func testAccSourcePostgresResourceSchema(sourceName string) string {
 			database_name = materialize_connection_postgres.test.database_name
 		}
 		publication = "mz_source"
-		schema      = ["PUBLIC"]
+		schemas     = ["PUBLIC"]
 	}
 	`, sourceName)
 }

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -48,7 +48,7 @@ var inSourceKafka = map[string]interface{}{
 		},
 	},
 	"envelope":        []interface{}{map[string]interface{}{"upsert": true}},
-	"start_offset":    []interface{}{1, 2, 3},
+	"start_offsets":   []interface{}{1, 2, 3},
 	"start_timestamp": -1000,
 }
 

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -73,7 +73,7 @@ func sourcePostgresSchemaV0() *schema.Resource {
 	}
 }
 
-var sourcePostgresSchemaV1 = map[string]*schema.Schema{
+var sourcePostgresSchema = map[string]*schema.Schema{
 	"name":                ObjectNameSchema("source", true, false),
 	"schema_name":         SchemaNameSchema("source", false),
 	"database_name":       DatabaseNameSchema("source", false),
@@ -129,7 +129,7 @@ var sourcePostgresSchemaV1 = map[string]*schema.Schema{
 	"ownership_role":  OwnershipRoleSchema(),
 }
 
-func postgresSourceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+func sourcePostgresStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	if rawState == nil {
 		return nil, fmt.Errorf("SourcePostgres resource state upgrade failed, state is nil")
 	}
@@ -150,13 +150,13 @@ func SourcePostgres() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema:        sourcePostgresSchemaV1,
+		Schema:        sourcePostgresSchema,
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
 				Type:    sourcePostgresSchemaV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: postgresSourceStateUpgradeV0,
+				Upgrade: sourcePostgresStateUpgradeV0,
 			},
 		},
 	}

--- a/pkg/resources/resource_source_postgres_test.go
+++ b/pkg/resources/resource_source_postgres_test.go
@@ -75,7 +75,7 @@ var inSourcePostgresSchema = map[string]interface{}{
 	},
 	"publication":  "mz_source",
 	"text_columns": []interface{}{"table.unsupported_type_1"},
-	"schema":       []interface{}{"schema1", "schema2"},
+	"schemas":      []interface{}{"schema1", "schema2"},
 }
 
 func TestResourceSourcePostgresCreateSchema(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/terraform-provider-materialize/issues/391

Implement two attribute name changes for 2 `schema.TypeList` that are singular that should be plural. Including `StateUpgraders` to and make this as easy as possible for existing resources.

| Resource | Old Attribute | New Attribute |
| --- | --- | --- |
| source kafka | `start_offset` | `start_offsets` |
| source postgres | `schema` | `schemas` |