### PR TITLE
.*: Rename "default" cluster to "quickstart"

### DIFF
--- a/docs/resources/materialized_view.md
+++ b/docs/resources/materialized_view.md
@@ -47,7 +47,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
 
 ### Optional
 
-- `cluster_name` (String) The cluster to maintain the materialized view. If not specified, defaults to the default cluster.
+- `cluster_name` (String) The cluster to maintain the materialized view. If not specified, defaults to the quickstart cluster.
 - `comment` (String) **Private Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the materialized view database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `not_null_assertion` (List of String) **Private Preview** A list of columns for which to create non-null assertions.

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -48,4 +48,4 @@ resource "materialize_cluster" "managed_cluster" {
 
 data "materialize_cluster" "all" {}
 
-data "materialize_current_cluster" "default" {}
+data "materialize_current_cluster" "quickstart" {}

--- a/integration/index.tf
+++ b/integration/index.tf
@@ -17,7 +17,7 @@ resource "materialize_index" "loadgen_index" {
 
 resource "materialize_index" "materialized_view_index" {
   name         = "simple"
-  cluster_name = "default"
+  cluster_name = "quickstart"
 
   obj_name {
     name          = materialize_materialized_view.simple_materialized_view.name

--- a/integration/materialized_view.tf
+++ b/integration/materialized_view.tf
@@ -3,7 +3,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
   schema_name   = materialize_schema.schema.name
   database_name = materialize_database.database.name
   comment       = "materialize view comment"
-  cluster_name  = "default"
+  cluster_name  = "quickstart"
 
   statement = <<SQL
 SELECT
@@ -15,7 +15,7 @@ resource "materialize_materialized_view" "materialized_view_assertions" {
   name               = "materialized_view_assertions"
   schema_name        = materialize_schema.schema.name
   database_name      = materialize_database.database.name
-  cluster_name       = "default"
+  cluster_name       = "quickstart"
   not_null_assertion = ["id"]
 
   statement = <<SQL

--- a/pkg/datasources/datasource_current_cluster_test.go
+++ b/pkg/datasources/datasource_current_cluster_test.go
@@ -20,7 +20,7 @@ func TestCurrentClusterDatasource(t *testing.T) {
 	r.NotNil(d)
 
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		ir := mock.NewRows([]string{"cluster"}).AddRow("default")
+		ir := mock.NewRows([]string{"cluster"}).AddRow("quickstart")
 		mock.ExpectQuery(`SHOW CLUSTER;`).WillReturnRows(ir)
 
 		if err := currentClusterRead(context.TODO(), d, db); err != nil {

--- a/pkg/provider/acceptance_datasource_materialized_view_test.go
+++ b/pkg/provider/acceptance_datasource_materialized_view_test.go
@@ -80,7 +80,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		comment       = "some comment"
 	  
 		statement = <<SQL
@@ -93,7 +93,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
 		schema_name   = materialize_schema.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 	  
 		statement = <<SQL
 	  SELECT
@@ -105,7 +105,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
 		schema_name   = materialize_schema.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		comment       = "some comment"
 	  
 		statement = <<SQL
@@ -117,7 +117,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 	  
 		statement = <<SQL
 	  SELECT
@@ -128,7 +128,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 	  
 		statement = <<SQL
 	  SELECT

--- a/pkg/provider/acceptance_datasource_source_test.go
+++ b/pkg/provider/acceptance_datasource_source_test.go
@@ -58,7 +58,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
 
@@ -66,7 +66,7 @@ func testAccDatasourceSource(nameSpace string) string {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
 		schema_name   = materialize_schema.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
 
@@ -74,21 +74,21 @@ func testAccDatasourceSource(nameSpace string) string {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
 		schema_name   = materialize_schema.test.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
 
 	resource "materialize_source_load_generator" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
 
 	resource "materialize_source_load_generator" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
-		cluster_name  = "default"
+		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
 

--- a/pkg/provider/acceptance_index_test.go
+++ b/pkg/provider/acceptance_index_test.go
@@ -110,7 +110,7 @@ func testAccIndexResource(viewName, indexName string) string {
 
 	resource "materialize_index" "test" {
 		name = "%[2]s"
-		cluster_name = "default"
+		cluster_name = "quickstart"
 
 		obj_name {
 			name = materialize_view.test.name
@@ -138,7 +138,7 @@ func testAccIndexWithComment(viewName, indexName, comment string) string {
 
 	resource "materialize_index" "test" {
 		name = "%[2]s"
-		cluster_name = "default"
+		cluster_name = "quickstart"
 		comment = "%[3]s"
 
 		obj_name {

--- a/pkg/provider/acceptance_materialized_view_grant_test.go
+++ b/pkg/provider/acceptance_materialized_view_grant_test.go
@@ -93,7 +93,7 @@ resource "materialize_materialized_view" "test" {
 	name = "%s"
 	schema_name = materialize_schema.test.name
 	database_name = materialize_database.test.name
-	cluster_name = "default"
+	cluster_name = "quickstart"
   
 	statement = <<SQL
   SELECT

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -122,14 +122,14 @@ func testAccMaterializedViewResource(roleName, materializeViewName, materializeV
 	resource "materialize_materialized_view" "test" {
 		name = "%[2]s"
 		statement = "SELECT 1 AS id"
-		cluster_name = "default"
+		cluster_name = "quickstart"
 		not_null_assertion = ["id"]
 	}
 
 	resource "materialize_materialized_view" "test_role" {
 		name = "%[3]s"
 		statement = "SELECT 1 AS id"
-		cluster_name = "default"
+		cluster_name = "quickstart"
 		ownership_role = "%[4]s"
 		comment = "%[5]s"
 

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -23,7 +23,7 @@ var materializedViewSchema = map[string]*schema.Schema{
 	"qualified_sql_name": QualifiedNameSchema("materialized view"),
 	"comment":            CommentSchema(false),
 	"cluster_name": {
-		Description: "The cluster to maintain the materialized view. If not specified, defaults to the default cluster.",
+		Description: "The cluster to maintain the materialized view. If not specified, defaults to the quickstart cluster.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,


### PR DESCRIPTION
Part of a larger change to rename the "default" cluster to "quickstart" for new customers. See https://github.com/MaterializeInc/materialize/issues/22351 for more info