### PR TITLE
Change the user of the scheduled tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -6,7 +6,7 @@ on:
       - main.go
       - go.mod
   schedule:
-    - cron: 0 11 * * 0
+    - cron: 1 11 * * 0
 
 jobs:
   acceptance:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ on:
       - main.go
       - go.mod
   schedule:
-    - cron: 0 11 * * 0
+    - cron: 1 11 * * 0
 
 jobs:
   integration:


### PR DESCRIPTION
We noticed that the scheduled tests were running as `dehume` as he was the one who set those up initially. Making a minor change to the scheduled time, based on this discussion [here](https://github.com/MaterializeInc/terraform-provider-materialize/pull/423) so that the workflows would run as my user instead:

> Notifications for scheduled workflows are sent to the user who initially created the workflow. If a different user updates the cron syntax in the workflow file, subsequent notifications will be sent to that user instead. If a scheduled workflow is disabled and then re-enabled, notifications will be sent to the user who re-enabled the workflow rather than the user who last modified the cron syntax.


