### PR TITLE
Make `cluster_name` parameter required

### DIFF
--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -42,9 +42,9 @@ var indexSchema = map[string]*schema.Schema{
 	"comment":            CommentSchema(false),
 	"obj_name":           IdentifierSchema("obj_name", "The name of the source, view, or materialized view on which you want to create an index.", true),
 	"cluster_name": {
-		Description: "The cluster to maintain this index. If not specified, defaults to the active cluster.",
+		Description: "The cluster to maintain this index.",
 		Type:        schema.TypeString,
-		Optional:    true,
+		Required:    true,
 		ForceNew:    true,
 	},
 	"method": {

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -22,10 +22,9 @@ var materializedViewSchema = map[string]*schema.Schema{
 	"qualified_sql_name": QualifiedNameSchema("materialized view"),
 	"comment":            CommentSchema(false),
 	"cluster_name": {
-		Description: "The cluster to maintain the materialized view. If not specified, defaults to the quickstart cluster.",
+		Description: "The cluster to maintain the materialized view.",
 		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
+		Required:    true,
 	},
 	"not_null_assertion": {
 		Description: "**Private Preview** A list of columns for which to create non-null assertions.",


### PR DESCRIPTION
As discussed in #434 making the `cluster_name` parameter required for materialized views and indexes.

For sinks and sources the user is already required to either specify the size of the source/sink or if they don't specify the `size`, they have to specify a `cluster_name`, eg:

https://github.com/MaterializeInc/terraform-provider-materialize/blob/a6a57bb15f132f892169a521eda672e6d3d9ead3/pkg/resources/schema.go#L387-L397