### PR TITLE
Include query with view and materialized_view

### DIFF
--- a/docs/resources/materialized_view.md
+++ b/docs/resources/materialized_view.md
@@ -57,6 +57,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
 
 ### Read-Only
 
+- `create_sql` (String) The SQL statement used to create the materialized view.
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the materialized view.
 

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -55,6 +55,7 @@ resource "materialize_view" "simple_view" {
 
 ### Read-Only
 
+- `create_sql` (String) The SQL statement used to create the view.
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the view.
 

--- a/pkg/materialize/materialized_view.go
+++ b/pkg/materialize/materialized_view.go
@@ -89,6 +89,7 @@ type MaterializedViewParams struct {
 	Comment              sql.NullString `db:"comment"`
 	OwnerName            sql.NullString `db:"owner_name"`
 	Privileges           pq.StringArray `db:"privileges"`
+	CreateSQL            sql.NullString `db:"create_sql"`
 }
 
 var materializedViewQuery = NewBaseQuery(`
@@ -100,6 +101,7 @@ var materializedViewQuery = NewBaseQuery(`
 		mz_clusters.name AS cluster_name,
 		comments.comment AS comment,
 		mz_roles.name AS owner_name,
+		mz_materialized_views.create_sql,
 		mz_materialized_views.privileges
 	FROM mz_materialized_views
 	JOIN mz_schemas

--- a/pkg/materialize/view.go
+++ b/pkg/materialize/view.go
@@ -60,6 +60,7 @@ type ViewParams struct {
 	Comment      sql.NullString `db:"comment"`
 	OwnerName    sql.NullString `db:"owner_name"`
 	Privileges   pq.StringArray `db:"privileges"`
+	CreateSQL    sql.NullString `db:"create_sql"`
 }
 
 var viewQuery = NewBaseQuery(`
@@ -70,6 +71,7 @@ var viewQuery = NewBaseQuery(`
 		mz_databases.name AS database_name,
 		comments.comment AS comment,
 		mz_roles.name AS owner_name,
+		mz_views.create_sql,
 		mz_views.privileges
 	FROM mz_views
 	JOIN mz_schemas

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -32,6 +32,7 @@ func TestAccMaterializedView_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, viewName)),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "statement", "SELECT 1 AS id"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "ownership_role", "mz_system"),
+					resource.TestCheckResourceAttr("materialize_materialized_view.test", "create_sql", fmt.Sprintf(`CREATE MATERIALIZED VIEW "materialize"."public"."%s" IN CLUSTER [u1] WITH (ASSERT NOT NULL = "id", REFRESH = ON COMMIT) AS SELECT 1 AS "id"`, viewName)),
 					testAccCheckMaterializedViewExists("materialize_materialized_view.test_role"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test_role", "name", view2Name),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test_role", "ownership_role", roleName),

--- a/pkg/provider/acceptance_view_test.go
+++ b/pkg/provider/acceptance_view_test.go
@@ -32,6 +32,7 @@ func TestAccView_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_view.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, viewName)),
 					resource.TestCheckResourceAttr("materialize_view.test", "statement", "SELECT 1 AS id"),
 					resource.TestCheckResourceAttr("materialize_view.test", "ownership_role", "mz_system"),
+					resource.TestCheckResourceAttr("materialize_view.test", "create_sql", fmt.Sprintf(`CREATE VIEW "materialize"."public"."%s" AS SELECT 1 AS "id"`, viewName)),
 					testAccCheckViewExists("materialize_view.test_role"),
 					resource.TestCheckResourceAttr("materialize_view.test_role", "name", view2Name),
 					resource.TestCheckResourceAttr("materialize_view.test_role", "ownership_role", roleName),

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -40,6 +40,11 @@ var materializedViewSchema = map[string]*schema.Schema{
 		Required:    true,
 		ForceNew:    true,
 	},
+	"create_sql": {
+		Description: "The SQL statement used to create the materialized view.",
+		Type:        schema.TypeString,
+		Computed:    true,
+	},
 	"ownership_role": OwnershipRoleSchema(),
 	"region":         RegionSchema(),
 }
@@ -104,6 +109,10 @@ func materializedViewRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("comment", s.Comment.String); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("create_sql", s.CreateSQL.String); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -24,6 +24,11 @@ var viewSchema = map[string]*schema.Schema{
 		Required:    true,
 		ForceNew:    true,
 	},
+	"create_sql": {
+		Description: "The SQL statement used to create the view.",
+		Type:        schema.TypeString,
+		Computed:    true,
+	},
 	"ownership_role": OwnershipRoleSchema(),
 	"region":         RegionSchema(),
 }
@@ -84,6 +89,10 @@ func viewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	}
 
 	if err := d.Set("comment", s.Comment.String); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("create_sql", s.CreateSQL.String); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -295,6 +295,7 @@ func MockMaterializeViewScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_clusters.name AS cluster_name,
 		comments.comment AS comment,
 		mz_roles.name AS owner_name,
+		mz_materialized_views.create_sql,
 		mz_materialized_views.privileges
 	FROM mz_materialized_views
 	JOIN mz_schemas
@@ -620,6 +621,7 @@ func MockViewScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_databases.name AS database_name,
 		comments.comment AS comment,
 		mz_roles.name AS owner_name,
+		mz_views.create_sql,
 		mz_views.privileges
 	FROM mz_views
 	JOIN mz_schemas


### PR DESCRIPTION
The query that reads view and materialized_view did not include the query statement.

Since the mz catalog has now added `create_sql`, updating the read query to include that for both view and materialized_view.

Closes #122