### PR TITLE
Update Changelog for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+## 0.6.0 - 2024-01-23
+
+### Breaking Changes
+* Drop `SIZE` support for sources and sinks [#438](https://github.com/MaterializeInc/terraform-provider-materialize/pull/438)
+
+### Features
+* Make `cluster_name` parameter required for `materialized_view` and `index` resources [#435](https://github.com/MaterializeInc/terraform-provider-materialize/pull/435)
+* Include `create_sql` for `view` and `materialized_view` [#436](https://github.com/MaterializeInc/terraform-provider-materialize/pull/436)
+* New resources: [#442](https://github.com/MaterializeInc/terraform-provider-materialize/pull/442)
+  * `materialize_sso_config`: Manages [SSO configuration](https://materialize.com/docs/manage/access-control/sso/) details
+  * `materialize_sso_default_roles`: Manages SSO default roles
+  * `materialize_sso_domain`: Manages SSO domains
+  * `materialize_sso_group_mappings`: Manages SSO group mappings
+* New data sources:
+  * `materialize_scim_configs`: Fetches SCIM configuration details
+  * `materialize_scim_groups`: Fetches SCIM group details
+  * `materialize_sso_config`: Fetches SSO configuration details
+
+### Misc
+* Add Tests for `INCLUDE KEY AS` for kafka sources [#439](https://github.com/MaterializeInc/terraform-provider-materialize/pull/439)
+* Mark comments as public preview [#440](https://github.com/MaterializeInc/terraform-provider-materialize/pull/440)
+* Dependabot updates: [#441](https://github.com/MaterializeInc/terraform-provider-materialize/pull/441), [#443](https://github.com/MaterializeInc/terraform-provider-materialize/pull/443)
+
 ## 0.5.0 - 2024-01-10
 
 ### Features


### PR DESCRIPTION
In the upcoming release of Materialize, we are dropping support for the `size` option for [sources and sinks](https://github.com/MaterializeInc/materialize/pull/24161).

To align with these changes, we are updating the Materialize Terraform provider to version `v0.6.0` which will include:

### What you need to know:

- **Provider Update Required:** Please upgrade to version `v0.6.0` of the Materialize Terraform provider.
- **Configuration Adjustments:** In your Terraform configurations, you will need to comment out or remove the `size` parameter for all your sources and sinks as this parameter will no longer be used.
- **New Source and Sink**: When you create a new source or sink, the `cluster_name` parameter will now be required.

### Important Notes:

- **Potential for Cluster Leaks:** Be aware that removing sources or sinks, that were created using the `size` parameter, from your Terraform configuration may not automatically delete the associated clusters. This could lead to "leaked" clusters which you will have to manually delete.
- Any sources or sinks created with `cluster_name` will continue to work as expected.
