### PR TITLE
Remove SIZE from documentation examples

### DIFF
--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -14,9 +14,9 @@ A Kafka sink establishes a link to a Kafka cluster that you want Materialize to 
 
 ```terraform
 resource "materialize_sink_kafka" "example_sink_kafka" {
-  name        = "sink_kafka"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "sink_kafka"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
   from {
     name = "table"
   }

--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -14,9 +14,9 @@ A Kafka source describes a Kafka cluster you want Materialize to read data from.
 
 ```terraform
 resource "materialize_source_kafka" "example_source_kafka" {
-  name        = "source_kafka"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "source_kafka"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
   kafka_connection {
     name          = "kafka_connection"
     database_name = "database"

--- a/docs/resources/source_load_generator.md
+++ b/docs/resources/source_load_generator.md
@@ -14,9 +14,9 @@ A load generator source produces synthetic data for use in demos and performance
 
 ```terraform
 resource "materialize_source_load_generator" "example_source_load_generator" {
-  name        = "source_load_generator"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "source_load_generator"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
 
   load_generator_type = "COUNTER"
 

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -14,10 +14,10 @@ A Postgres source describes a PostgreSQL instance you want Materialize to read d
 
 ```terraform
 resource "materialize_source_postgres" "example_source_postgres" {
-  name        = "source_postgres"
-  schema_name = "schema"
-  size        = "3xsmall"
-  publication = "mz_source"
+  name         = "source_postgres"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
+  publication  = "mz_source"
 
   postgres_connection {
     name = "pg_connection"

--- a/examples/resources/materialize_sink_kafka/resource.tf
+++ b/examples/resources/materialize_sink_kafka/resource.tf
@@ -1,7 +1,7 @@
 resource "materialize_sink_kafka" "example_sink_kafka" {
-  name        = "sink_kafka"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "sink_kafka"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
   from {
     name = "table"
   }

--- a/examples/resources/materialize_source_kafka/resource.tf
+++ b/examples/resources/materialize_source_kafka/resource.tf
@@ -1,7 +1,7 @@
 resource "materialize_source_kafka" "example_source_kafka" {
-  name        = "source_kafka"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "source_kafka"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
   kafka_connection {
     name          = "kafka_connection"
     database_name = "database"

--- a/examples/resources/materialize_source_load_generator/resource.tf
+++ b/examples/resources/materialize_source_load_generator/resource.tf
@@ -1,7 +1,7 @@
 resource "materialize_source_load_generator" "example_source_load_generator" {
-  name        = "source_load_generator"
-  schema_name = "schema"
-  size        = "3xsmall"
+  name         = "source_load_generator"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
 
   load_generator_type = "COUNTER"
 

--- a/examples/resources/materialize_source_postgres/resource.tf
+++ b/examples/resources/materialize_source_postgres/resource.tf
@@ -1,8 +1,8 @@
 resource "materialize_source_postgres" "example_source_postgres" {
-  name        = "source_postgres"
-  schema_name = "schema"
-  size        = "3xsmall"
-  publication = "mz_source"
+  name         = "source_postgres"
+  schema_name  = "schema"
+  cluster_name = "quickstart"
+  publication  = "mz_source"
 
   postgres_connection {
     name = "pg_connection"


### PR DESCRIPTION
Just realized that a couple of docs example files slipped in #438 