### PR TITLE
Allow schema rename

### DIFF
--- a/pkg/materialize/schema.go
+++ b/pkg/materialize/schema.go
@@ -32,6 +32,12 @@ func (b *SchemaBuilder) Create() error {
 	return b.ddl.exec(q)
 }
 
+func (b *SchemaBuilder) Rename(newName string) error {
+	old := b.QualifiedName()
+	new := QualifiedName(newName)
+	return b.ddl.rename(old, new)
+}
+
 func (b *SchemaBuilder) Drop() error {
 	qn := b.QualifiedName()
 	return b.ddl.drop(qn)

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -13,7 +13,7 @@ import (
 )
 
 var schemaSchema = map[string]*schema.Schema{
-	"name":               ObjectNameSchema("schema", true, true),
+	"name":               ObjectNameSchema("schema", true, false),
 	"database_name":      DatabaseNameSchema("schema", false),
 	"qualified_sql_name": QualifiedNameSchema("schema"),
 	"comment":            CommentSchema(false),
@@ -149,6 +149,15 @@ func schemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		b := materialize.NewCommentBuilder(metaDb, o)
 
 		if err := b.Object(newComment.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.MaterializeObject{ObjectType: "SCHEMA", Name: oldName.(string), DatabaseName: databaseName}
+		b := materialize.NewSchemaBuilder(metaDb, o)
+		if err := b.Rename(newName.(string)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -28,7 +28,7 @@ func SchemaNameSchema(resource string, required bool) *schema.Schema {
 		Description: fmt.Sprintf("The identifier for the %s schema. Defaults to `public`.", resource),
 		Required:    required,
 		Optional:    !required,
-		ForceNew:    false,
+		ForceNew:    true,
 		Default:     defaultSchema,
 	}
 }

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -28,7 +28,7 @@ func SchemaNameSchema(resource string, required bool) *schema.Schema {
 		Description: fmt.Sprintf("The identifier for the %s schema. Defaults to `public`.", resource),
 		Required:    required,
 		Optional:    !required,
-		ForceNew:    true,
+		ForceNew:    false,
 		Default:     defaultSchema,
 	}
 }


### PR DESCRIPTION
Implementing the schema rename by itself is straight forward, the challenging part is all of the handling of all of the dependant resources, eg all resources that use the `SchemaNameSchema`.

Closes #334 