### PR TITLE
Update CODEOWNERS to use new "console" team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bobbyiliev @MaterializeInc/frontend
+* @bobbyiliev @MaterializeInc/console


### PR DESCRIPTION
Do not merge until the team is renamed by a github admin.