### PR TITLE
Add new cc sizes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: materialize/materialized:latest
     container_name: materialized
     command:
-      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "100cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
+      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
       - --bootstrap-default-cluster-replica-size=3xsmall
       - --bootstrap-builtin-cluster-replica-size=3xsmall
       - --availability-zone=test1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: materialize/materialized:latest
     container_name: materialized
     command:
-      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
+      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "100cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
       - --bootstrap-default-cluster-replica-size=3xsmall
       - --bootstrap-builtin-cluster-replica-size=3xsmall
       - --availability-zone=test1

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -14,7 +14,7 @@ resource "materialize_cluster" "cluster_sink" {
 
 resource "materialize_cluster" "no_replication" {
   name               = "no_replication"
-  size               = "50cc"
+  size               = "25cc"
   replication_factor = 0
 }
 
@@ -39,7 +39,7 @@ resource "materialize_cluster_grant_default_privilege" "example" {
 resource "materialize_cluster" "managed_cluster" {
   name                          = "managed_cluster"
   replication_factor            = 2
-  size                          = "50cc"
+  size                          = "25cc"
   introspection_interval        = "1s"
   introspection_debugging       = true
   idle_arrangement_merge_effort = 2

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -14,7 +14,7 @@ resource "materialize_cluster" "cluster_sink" {
 
 resource "materialize_cluster" "no_replication" {
   name               = "no_replication"
-  size               = "3xsmall"
+  size               = "50cc"
   replication_factor = 0
 }
 
@@ -39,7 +39,7 @@ resource "materialize_cluster_grant_default_privilege" "example" {
 resource "materialize_cluster" "managed_cluster" {
   name                          = "managed_cluster"
   replication_factor            = 2
-  size                          = "3xsmall"
+  size                          = "50cc"
   introspection_interval        = "1s"
   introspection_debugging       = true
   idle_arrangement_merge_effort = 2

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -55,6 +55,39 @@ func TestAccCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccClusterCCSize_basic(t *testing.T) {
+	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	cluster2Name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "50cc", "1", "1s", "true", "2", "true", "Comment"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "name", clusterName+"_managed"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "ownership_role", "mz_system"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "size", "50cc"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "1"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "1s"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "true"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "idle_arrangement_merge_effort", "2"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "disk", "true"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "comment", "Comment"),
+				),
+			},
+			{
+				ResourceName:            "materialize_cluster.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"introspection_debugging", "introspection_interval"},
+			},
+		},
+	})
+}
+
 func TestAccClusterManagedNoReplication_basic(t *testing.T) {
 	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.ParallelTest(t, resource.TestCase{

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -65,11 +65,11 @@ func TestAccClusterCCSize_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "50cc", "1", "1s", "true", "2", "true", "Comment"),
+				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "25cc", "1", "1s", "true", "2", "true", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "name", clusterName+"_managed"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "ownership_role", "mz_system"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "size", "50cc"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "size", "25cc"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "1"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "1s"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "true"),

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -28,7 +28,7 @@ func TestAccSourcePostgres_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "database_name", nameSpace+"_database"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schema_name", nameSpace+"_schema"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "qualified_sql_name", fmt.Sprintf(`"%[1]s_database"."%[1]s_schema"."%[1]s_source"`, nameSpace)),
-					resource.TestCheckResourceAttr("materialize_source_postgres.test", "size", "50cc"),
+					resource.TestCheckResourceAttr("materialize_source_postgres.test", "size", "25cc"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "text_columns.#", "1"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "table.#", "2"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "table.0.name", "table1"),
@@ -195,7 +195,7 @@ func testAccSourcePostgresBasicResource(nameSpace string) string {
 
 	resource "materialize_cluster" "test" {
 		name = "%[1]s_cluster"
-		size = "50cc"
+		size = "25cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {
@@ -267,7 +267,7 @@ func testAccSourcePostgresResource(roleName, secretName, connName, sourceName, s
 
 	resource "materialize_cluster" "test" {
 		name = "%[3]s"
-		size = "50cc"
+		size = "25cc"
 	}
 
 	resource "materialize_source_postgres" "test" {
@@ -326,7 +326,7 @@ func testAccSourcePostgresResourceUpdate(roleName, secretName, connName, sourceN
 
 	resource "materialize_cluster" "test" {
 		name = "%[3]s"
-		size = "50cc"
+		size = "25cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {
@@ -396,7 +396,7 @@ func testAccSourcePostgresResourceSchema(sourceName string) string {
 
 	resource "materialize_cluster" "test" {
 		name = "%[1]s_cluster"
-		size = "50cc"
+		size = "25cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -28,7 +28,7 @@ func TestAccSourcePostgres_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "database_name", nameSpace+"_database"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "schema_name", nameSpace+"_schema"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "qualified_sql_name", fmt.Sprintf(`"%[1]s_database"."%[1]s_schema"."%[1]s_source"`, nameSpace)),
-					resource.TestCheckResourceAttr("materialize_source_postgres.test", "size", "3xsmall"),
+					resource.TestCheckResourceAttr("materialize_source_postgres.test", "size", "50cc"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "text_columns.#", "1"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "table.#", "2"),
 					resource.TestCheckResourceAttr("materialize_source_postgres.test", "table.0.name", "table1"),
@@ -195,7 +195,7 @@ func testAccSourcePostgresBasicResource(nameSpace string) string {
 
 	resource "materialize_cluster" "test" {
 		name = "%[1]s_cluster"
-		size = "3xsmall"
+		size = "50cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {
@@ -267,7 +267,7 @@ func testAccSourcePostgresResource(roleName, secretName, connName, sourceName, s
 
 	resource "materialize_cluster" "test" {
 		name = "%[3]s"
-		size = "3xsmall"
+		size = "50cc"
 	}
 
 	resource "materialize_source_postgres" "test" {
@@ -326,7 +326,7 @@ func testAccSourcePostgresResourceUpdate(roleName, secretName, connName, sourceN
 
 	resource "materialize_cluster" "test" {
 		name = "%[3]s"
-		size = "3xsmall"
+		size = "50cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {
@@ -396,7 +396,7 @@ func testAccSourcePostgresResourceSchema(sourceName string) string {
 
 	resource "materialize_cluster" "test" {
 		name = "%[1]s_cluster"
-		size = "3xsmall"
+		size = "50cc"
 	}
 
 	resource "materialize_connection_postgres" "test" {

--- a/pkg/resources/config.go
+++ b/pkg/resources/config.go
@@ -21,6 +21,21 @@ var replicaSizes = []string{
 	"4xlarge",
 	"5xlarge",
 	"6xlarge",
+	"25cc",
+	"50cc",
+	"100cc",
+	"200cc",
+	"300cc",
+	"400cc",
+	"600cc",
+	"800cc",
+	"1200cc",
+	"1600cc",
+	"3200cc",
+	"6400cc",
+	"128C",
+	"256C",
+	"512C",
 }
 
 var saslMechanisms = []string{

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -121,6 +121,7 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		// DISK option not supported for cluster sizes ending in cc or C because disk is always enabled
 		if strings.HasSuffix(size.(string), "cc") || strings.HasSuffix(size.(string), "C") {
+			log.Printf("[WARN] disk option not supported for cluster size %s, disk is always enabled", size)
 			d.Set("disk", true)
 		} else {
 			if v, ok := d.GetOk("disk"); ok {
@@ -215,7 +216,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 			// DISK option not supported for cluster sizes ending in cc or C because disk is always enabled
 			size := d.Get("size").(string)
 			if strings.HasSuffix(size, "cc") || strings.HasSuffix(size, "C") {
-				// Warn user that disk is always enabled for this cluster size
 				log.Printf("[WARN] disk option not supported for cluster size %s, disk is always enabled", size)
 				d.Set("disk", true)
 			} else {

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -496,6 +496,7 @@ func DiskSchema(forceNew bool) *schema.Schema {
 		Optional:    true,
 		ForceNew:    forceNew,
 		Deprecated:  "Disk replicas are deprecated and will be removed in a future release. The `disk` attribute will be enabled by default for 'cc' clusters",
+		Computed:    true,
 	}
 }
 


### PR DESCRIPTION
Adding the new cc sizes to the allowed configuration options.

The `disk` option is already marked as deprecated and should push people towards using the new sizes before we fully disable it. As of the time being this PR allows users to use both the old sizes and the new sizes.