### PR TITLE
Top level privatelink for kafka

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
       echo "Waiting for materialized to start..." &&
       sleep 15 &&
       psql -h materialized -U mz_system -d materialize -p 6877 -c "ALTER SYSTEM SET max_clusters = 100;" &&
-      psql -h materialized -U mz_system -d materialize -p 6877 -c "ALTER SYSTEM SET max_sources = 100;"
+      psql -h materialized -U mz_system -d materialize -p 6877 -c "ALTER SYSTEM SET max_sources = 100;" &&
+      psql -h materialized -U mz_system -d materialize -p 6877 -c "ALTER SYSTEM SET max_aws_privatelink_connections = 10;" &&
+      psql -h materialized -U mz_system -d materialize -p 6877 -c "CREATE CONNECTION \"materialize\".\"public\".\"privatelink_conn\" TO AWS PRIVATELINK (AVAILABILITY ZONES = ('\''use1-az2'\'', '\''use1-az6'\''), SERVICE NAME = '\''com.amazonaws.us-east-1.materialize.example'\'');"
       '
 
   redpanda:

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -76,13 +76,14 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 ### Required
 
-- `kafka_broker` (Block List, Min: 1) The Kafka brokers configuration. (see [below for nested schema](#nestedblock--kafka_broker))
 - `name` (String) The identifier for the connection.
 
 ### Optional
 
+- `aws_privatelink` (Block List, Max: 1) AWS PrivateLink configuration. This is an alternative to `kafka_broker`. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
+- `kafka_broker` (Block List) The Kafka brokers configuration. (see [below for nested schema](#nestedblock--kafka_broker))
 - `ownership_role` (String) The owernship role of the object.
 - `progress_topic` (String) The name of a topic that Kafka sinks can use to track internal consistency metadata.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
@@ -101,6 +102,31 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the connection.
+
+<a id="nestedblock--aws_privatelink"></a>
+### Nested Schema for `aws_privatelink`
+
+Required:
+
+- `privatelink_connection_port` (Number) The port of the AWS PrivateLink connection.
+
+Optional:
+
+- `privatelink_connection` (Block List, Max: 1) The AWS PrivateLink connection name in Materialize. (see [below for nested schema](#nestedblock--aws_privatelink--privatelink_connection))
+
+<a id="nestedblock--aws_privatelink--privatelink_connection"></a>
+### Nested Schema for `aws_privatelink.privatelink_connection`
+
+Required:
+
+- `name` (String) The privatelink_connection name.
+
+Optional:
+
+- `database_name` (String) The privatelink_connection database name. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
+- `schema_name` (String) The privatelink_connection schema name. Defaults to `public`.
+
+
 
 <a id="nestedblock--kafka_broker"></a>
 ### Nested Schema for `kafka_broker`

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -80,7 +80,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 ### Optional
 
-- `aws_privatelink` (Block List, Max: 1) AWS PrivateLink configuration. This is an alternative to `kafka_broker`. (see [below for nested schema](#nestedblock--aws_privatelink))
+- `aws_privatelink` (Block List, Max: 1) AWS PrivateLink configuration. Conflicts with `kafka_broker`. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `kafka_broker` (Block List) The Kafka brokers configuration. (see [below for nested schema](#nestedblock--kafka_broker))
@@ -108,11 +108,8 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 Required:
 
+- `privatelink_connection` (Block List, Min: 1, Max: 1) The AWS PrivateLink connection name in Materialize. (see [below for nested schema](#nestedblock--aws_privatelink--privatelink_connection))
 - `privatelink_connection_port` (Number) The port of the AWS PrivateLink connection.
-
-Optional:
-
-- `privatelink_connection` (Block List, Max: 1) The AWS PrivateLink connection name in Materialize. (see [below for nested schema](#nestedblock--aws_privatelink--privatelink_connection))
 
 <a id="nestedblock--aws_privatelink--privatelink_connection"></a>
 ### Nested Schema for `aws_privatelink.privatelink_connection`

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -83,7 +83,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 - `aws_privatelink` (Block List, Max: 1) AWS PrivateLink configuration. Conflicts with `kafka_broker`. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `kafka_broker` (Block List) The Kafka brokers configuration. (see [below for nested schema](#nestedblock--kafka_broker))
+- `kafka_broker` (Block List) The Kafka broker's configuration. (see [below for nested schema](#nestedblock--kafka_broker))
 - `ownership_role` (String) The owernship role of the object.
 - `progress_topic` (String) The name of a topic that Kafka sinks can use to track internal consistency metadata.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -108,6 +108,50 @@ resource "materialize_connection_kafka" "kafka_conn_multiple_brokers" {
   validate          = false
 }
 
+resource "materialize_connection_kafka" "kafka_top_level_privatelink" {
+  name = "kafka_top_level_privatelink"
+  # The Privatelink connection is created during the docker-compose setup
+  # As if you were to drop the privatelink connection, the container would crash
+  aws_privatelink {
+    privatelink_connection {
+      name          = "privatelink_conn"
+      database_name = "materialize"
+      schema_name   = "public"
+    }
+    privatelink_connection_port = 9092
+  }
+
+  security_protocol = "SASL_SSL"
+
+ sasl_mechanisms = "SCRAM-SHA-256"
+
+  sasl_username {
+    text = "sasl_username"
+  }
+
+  sasl_password {
+    name          = materialize_secret.kafka_password.name
+    database_name = materialize_secret.kafka_password.database_name
+    schema_name   = materialize_secret.kafka_password.schema_name
+  }
+
+  ssl_certificate {
+    text = "ssl_certificate_content"
+  }
+
+  ssl_key {
+    name          = materialize_secret.kafka_password.name
+    database_name = materialize_secret.kafka_password.database_name
+    schema_name   = materialize_secret.kafka_password.schema_name
+  }
+
+  ssl_certificate_authority {
+    text = "ssl_ca_content"
+  }
+
+  validate = false
+}
+
 resource "materialize_connection_confluent_schema_registry" "schema_registry" {
   name    = "schema_registry_connection"
   comment = "connection schema registry comment"

--- a/integration/connection.tf
+++ b/integration/connection.tf
@@ -122,8 +122,7 @@ resource "materialize_connection_kafka" "kafka_top_level_privatelink" {
   }
 
   security_protocol = "SASL_SSL"
-
- sasl_mechanisms = "SCRAM-SHA-256"
+  sasl_mechanisms   = "SCRAM-SHA-256"
 
   sasl_username {
     text = "sasl_username"

--- a/pkg/materialize/connection_kafka.go
+++ b/pkg/materialize/connection_kafka.go
@@ -48,24 +48,19 @@ func GetAwsPrivateLinkConnectionStruct(v interface{}) awsPrivateLinkConnection {
 		return awsPrivateLinkConnection{}
 	}
 
-	plMap, ok := v.([]interface{})[0].(map[string]interface{})
+	b, ok := v.([]interface{})[0].(map[string]interface{})
 	if !ok {
 		return awsPrivateLinkConnection{}
 	}
 
 	privatelinkConnection := IdentifierSchemaStruct{}
-	if plMap["privatelink_connection"] != nil && len(plMap["privatelink_connection"].([]interface{})) > 0 {
-		privatelinkConnection = GetIdentifierSchemaStruct(plMap["privatelink_connection"].([]interface{}))
-	}
-
-	privatelinkPort, ok := plMap["privatelink_connection_port"].(int)
-	if !ok {
-		return awsPrivateLinkConnection{}
+	if b["privatelink_connection"] != nil && len(b["privatelink_connection"].([]interface{})) > 0 {
+		privatelinkConnection = GetIdentifierSchemaStruct(b["privatelink_connection"].([]interface{}))
 	}
 
 	return awsPrivateLinkConnection{
+		PrivateLinkPort:       b["privatelink_connection_port"].(int),
 		PrivateLinkConnection: privatelinkConnection,
-		PrivateLinkPort:       privatelinkPort,
 	}
 }
 

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -32,7 +32,7 @@ func TestAccMaterializedView_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, viewName)),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "statement", "SELECT 1 AS id"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test", "ownership_role", "mz_system"),
-					resource.TestCheckResourceAttr("materialize_materialized_view.test", "create_sql", fmt.Sprintf(`CREATE MATERIALIZED VIEW "materialize"."public"."%s" IN CLUSTER [u1] WITH (ASSERT NOT NULL = "id", REFRESH = ON COMMIT) AS SELECT 1 AS "id"`, viewName)),
+					resource.TestCheckResourceAttr("materialize_materialized_view.test", "create_sql", fmt.Sprintf(`CREATE MATERIALIZED VIEW "materialize"."public"."%s" IN CLUSTER [u1] WITH (ASSERT NOT NULL = "id", REFRESH = ON COMMIT) AS SELECT 1 AS "id" AS OF 0`, viewName)),
 					testAccCheckMaterializedViewExists("materialize_materialized_view.test_role"),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test_role", "name", view2Name),
 					resource.TestCheckResourceAttr("materialize_materialized_view.test_role", "ownership_role", roleName),

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -50,7 +50,7 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 		},
 	},
 	"aws_privatelink": {
-		Description:   "AWS PrivateLink configuration. This is an alternative to `kafka_broker`.",
+		Description:   "AWS PrivateLink configuration. Conflicts with `kafka_broker`.",
 		Type:          schema.TypeList,
 		Optional:      true,
 		ConflictsWith: []string{"kafka_broker"},
@@ -60,7 +60,7 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 		ForceNew:      true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"privatelink_connection": IdentifierSchema("privatelink_connection", "The AWS PrivateLink connection name in Materialize.", false),
+				"privatelink_connection": IdentifierSchema("privatelink_connection", "The AWS PrivateLink connection name in Materialize.", true),
 				"privatelink_connection_port": {
 					Description: "The port of the AWS PrivateLink connection.",
 					Type:        schema.TypeInt,

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -20,7 +20,7 @@ var connectionKafkaSchema = map[string]*schema.Schema{
 	"qualified_sql_name": QualifiedNameSchema("connection"),
 	"comment":            CommentSchema(false),
 	"kafka_broker": {
-		Description:   "The Kafka brokers configuration.",
+		Description:   "The Kafka broker's configuration.",
 		Type:          schema.TypeList,
 		ConflictsWith: []string{"aws_privatelink"},
 		AtLeastOneOf:  []string{"kafka_broker", "aws_privatelink"},

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -21,11 +21,11 @@ var inKafka = map[string]interface{}{
 		"broker":                 "b-1.hostname-1:9096",
 		"target_group_port":      9001,
 		"availability_zone":      "use1-az1",
-		"privatelink_connection": []interface{}{map[string]interface{}{"name": "cert"}},
+		"privatelink_connection": []interface{}{map[string]interface{}{"name": "pl_conn"}},
 		"ssh_tunnel":             []interface{}{map[string]interface{}{"name": "ssh"}},
 	}},
 	"aws_privatelink": []interface{}{map[string]interface{}{
-		"privatelink_connection":      []interface{}{map[string]interface{}{"name": "cert"}},
+		"privatelink_connection":      []interface{}{map[string]interface{}{"name": "pl_conn"}},
 		"privatelink_connection_port": 9001,
 	}},
 	"security_protocol":         "SASL_PLAINTEXT",
@@ -53,9 +53,9 @@ func TestResourceConnectionKafkaCreate(t *testing.T) {
 			TO KAFKA \(BROKERS
 				\('b-1.hostname-1:9096'
 				USING SSH TUNNEL "materialize"."public"."ssh"
-				USING AWS PRIVATELINK "materialize"."public"."cert" 
+				USING AWS PRIVATELINK "materialize"."public"."pl_conn"
 				\(PORT 9001, AVAILABILITY ZONE 'use1-az1'\)\)
-			AWS PRIVATELINK "materialize"."public"."cert" \(PORT 9001\),
+			AWS PRIVATELINK "materialize"."public"."pl_conn" \(PORT 9001\),
 			SSH TUNNEL "materialize"."public"."tunnel",
 			SECURITY PROTOCOL = 'SASL_PLAINTEXT', PROGRESS TOPIC 'topic',
 			SSL CERTIFICATE AUTHORITY = 'key',

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -24,6 +24,10 @@ var inKafka = map[string]interface{}{
 		"privatelink_connection": []interface{}{map[string]interface{}{"name": "cert"}},
 		"ssh_tunnel":             []interface{}{map[string]interface{}{"name": "ssh"}},
 	}},
+	"aws_privatelink": []interface{}{map[string]interface{}{
+		"privatelink_connection":      []interface{}{map[string]interface{}{"name": "cert"}},
+		"privatelink_connection_port": 9001,
+	}},
 	"security_protocol":         "SASL_PLAINTEXT",
 	"progress_topic":            "topic",
 	"ssl_certificate_authority": []interface{}{map[string]interface{}{"text": "key"}},
@@ -50,7 +54,8 @@ func TestResourceConnectionKafkaCreate(t *testing.T) {
 				\('b-1.hostname-1:9096'
 				USING SSH TUNNEL "materialize"."public"."ssh"
 				USING AWS PRIVATELINK "materialize"."public"."cert" 
-				\(PORT 9001, AVAILABILITY ZONE 'use1-az1'\)\),
+				\(PORT 9001, AVAILABILITY ZONE 'use1-az1'\)\)
+			AWS PRIVATELINK "materialize"."public"."cert" \(PORT 9001\),
 			SSH TUNNEL "materialize"."public"."tunnel",
 			SECURITY PROTOCOL = 'SASL_PLAINTEXT', PROGRESS TOPIC 'topic',
 			SSL CERTIFICATE AUTHORITY = 'key',


### PR DESCRIPTION
Adding support for the new top level Privatelink for Kafka connections, eg:

```sql
CREATE CONNECTION <redpanda_cloud> TO KAFKA (
    AWS PRIVATELINK rp_privatleink (PORT 30292)
    SASL MECHANISMS = 'SCRAM-SHA-256',
    SASL USERNAME = SECRET redpanda_username,
    SASL PASSWORD = SECRET redpanda_password,
    SSL CERTIFICATE AUTHORITY = SECRET redpanda_ca_cert
);
```

Closes #470 