### PR TITLE
Add acceptance tests for SSO Config resource

### DIFF
--- a/mocks/frontegg/mock_server.go
+++ b/mocks/frontegg/mock_server.go
@@ -48,7 +48,7 @@ type Domain struct {
 	ID          string `json:"id"`
 	Domain      string `json:"domain"`
 	Validated   bool   `json:"validated"`
-	SsoConfigId string `json:"sso_config_id"`
+	SsoConfigId string `json:"ssoConfigId"`
 }
 
 type GroupMapping struct {

--- a/pkg/frontegg/sso_config.go
+++ b/pkg/frontegg/sso_config.go
@@ -38,7 +38,7 @@ type Domain struct {
 	ID          string `json:"id"`
 	Domain      string `json:"domain"`
 	Validated   bool   `json:"validated"`
-	SsoConfigId string `json:"sso_config_id"`
+	SsoConfigId string `json:"ssoConfigId"`
 }
 
 type SSOConfigurationsResponse []SSOConfig

--- a/pkg/frontegg/sso_config.go
+++ b/pkg/frontegg/sso_config.go
@@ -1,0 +1,205 @@
+package frontegg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
+)
+
+const (
+	SSOConfigurationsApiPathV1 = "/frontegg/team/resources/sso/v1/configurations"
+)
+
+// SSOConfig represents the structure for SSO configuration.
+type SSOConfig struct {
+	Id                string    `json:"id"`
+	Enabled           bool      `json:"enabled"`
+	SsoEndpoint       string    `json:"ssoEndpoint"`
+	PublicCertificate string    `json:"publicCertificate"`
+	SignRequest       bool      `json:"signRequest"`
+	AcsUrl            string    `json:"acsUrl"`
+	SpEntityId        string    `json:"spEntityId"`
+	Type              string    `json:"type"`
+	OidcClientId      string    `json:"oidcClientId"`
+	OidcSecret        string    `json:"oidcSecret"`
+	CreatedAt         time.Time `json:"createdAt"`
+	Domains           []Domain
+}
+
+// Domain represents the structure for SSO domain.
+type Domain struct {
+	ID          string `json:"id"`
+	Domain      string `json:"domain"`
+	Validated   bool   `json:"validated"`
+	SsoConfigId string `json:"sso_config_id"`
+}
+
+type SSOConfigurationsResponse []SSOConfig
+
+// Helper function to flatten the SSO configurations data
+func FlattenSSOConfigurations(configurations SSOConfigurationsResponse) []interface{} {
+	var flattenedConfigurations []interface{}
+	for _, config := range configurations {
+		flattenedConfig := map[string]interface{}{
+			"id":                 config.Id,
+			"enabled":            config.Enabled,
+			"sso_endpoint":       config.SsoEndpoint,
+			"public_certificate": config.PublicCertificate,
+			"sign_request":       config.SignRequest,
+			"acs_url":            config.AcsUrl,
+			"sp_entity_id":       config.SpEntityId,
+			"type":               config.Type,
+			"oidc_client_id":     config.OidcClientId,
+			"oidc_secret":        config.OidcSecret,
+			"created_at":         config.CreatedAt.Format(time.RFC3339),
+		}
+		flattenedConfigurations = append(flattenedConfigurations, flattenedConfig)
+	}
+	return flattenedConfigurations
+}
+
+// FetchSSOConfigurations fetches the SSO configurations
+func FetchSSOConfigurations(ctx context.Context, client *clients.FronteggClient) (SSOConfigurationsResponse, error) {
+	endpoint := fmt.Sprintf("%s%s", client.Endpoint, SSOConfigurationsApiPathV1)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.Token)
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var sb strings.Builder
+		_, err = io.Copy(&sb, resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error reading SSO configurations: status %d, response: %s", resp.StatusCode, sb.String())
+	}
+
+	var configurations SSOConfigurationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&configurations); err != nil {
+		return nil, err
+	}
+
+	return configurations, nil
+}
+
+// CreateSSOConfiguration creates a new SSO configuration
+func CreateSSOConfiguration(ctx context.Context, client *clients.FronteggClient, ssoConfig SSOConfig) (*SSOConfig, error) {
+	requestBody, err := json.Marshal(ssoConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s%s", client.Endpoint, SSOConfigurationsApiPathV1)
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.Token)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		var sb strings.Builder
+		_, err = io.Copy(&sb, resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error creating SSO configuration: status %d, response: %s", resp.StatusCode, sb.String())
+	}
+
+	var newConfig SSOConfig
+	if err := json.NewDecoder(resp.Body).Decode(&newConfig); err != nil {
+		return nil, err
+	}
+
+	return &newConfig, nil
+}
+
+// UpdateSSOConfiguration updates an existing SSO configuration
+func UpdateSSOConfiguration(ctx context.Context, client *clients.FronteggClient, ssoConfig SSOConfig) (*SSOConfig, error) {
+	requestBody, err := json.Marshal(ssoConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s%s/%s", client.Endpoint, SSOConfigurationsApiPathV1, ssoConfig.Id)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", endpoint, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.Token)
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var sb strings.Builder
+		_, err = io.Copy(&sb, resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error updating SSO configuration: status %d, response: %s", resp.StatusCode, sb.String())
+	}
+
+	var updatedConfig SSOConfig
+	if err := json.NewDecoder(resp.Body).Decode(&updatedConfig); err != nil {
+		return nil, err
+	}
+
+	return &updatedConfig, nil
+}
+
+// DeleteSSOConfiguration deletes an existing SSO configuration
+func DeleteSSOConfiguration(ctx context.Context, client *clients.FronteggClient, configId string) error {
+	endpoint := fmt.Sprintf("%s%s/%s", client.Endpoint, SSOConfigurationsApiPathV1, configId)
+	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+client.Token)
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var sb strings.Builder
+		_, err = io.Copy(&sb, resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("error deleting SSO configuration: status %d, response: %s", resp.StatusCode, sb.String())
+	}
+
+	return nil
+}

--- a/pkg/frontegg/sso_config_test.go
+++ b/pkg/frontegg/sso_config_test.go
@@ -1,0 +1,115 @@
+package frontegg
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchSSOConfigurationsSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":"test-id","enabled":true,"ssoEndpoint":"test-endpoint","publicCertificate":"test-cert","signRequest":true,"type":"saml"}]`))
+	}))
+	defer mockServer.Close()
+
+	client := &clients.FronteggClient{
+		Endpoint:   mockServer.URL,
+		HTTPClient: mockServer.Client(),
+	}
+
+	configurations, err := FetchSSOConfigurations(context.Background(), client)
+	assert.NoError(err)
+	assert.Len(configurations, 1)
+	assert.Equal("test-id", configurations[0].Id)
+	assert.True(configurations[0].Enabled)
+	assert.Equal("test-endpoint", configurations[0].SsoEndpoint)
+	assert.Equal("test-cert", configurations[0].PublicCertificate)
+	assert.True(configurations[0].SignRequest)
+	assert.Equal("saml", configurations[0].Type)
+	assert.Empty(configurations[0].Domains)
+}
+
+func TestCreateSSOConfigurationSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":"test-id","enabled":true,"ssoEndpoint":"test-endpoint","publicCertificate":"test-cert","signRequest":true,"type":"saml"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &clients.FronteggClient{
+		Endpoint:   mockServer.URL,
+		HTTPClient: mockServer.Client(),
+	}
+
+	ssoConfig := SSOConfig{
+		Enabled:           true,
+		SsoEndpoint:       "test-endpoint",
+		PublicCertificate: "test-cert",
+		SignRequest:       true,
+		Type:              "saml",
+	}
+
+	newConfig, err := CreateSSOConfiguration(context.Background(), client, ssoConfig)
+	assert.NoError(err)
+	assert.Equal("test-id", newConfig.Id)
+	assert.True(newConfig.Enabled)
+	assert.Equal("test-endpoint", newConfig.SsoEndpoint)
+	assert.Equal("test-cert", newConfig.PublicCertificate)
+	assert.True(newConfig.SignRequest)
+	assert.Equal("saml", newConfig.Type)
+	assert.Empty(newConfig.Domains)
+}
+
+func TestUpdateSSOConfigurationSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"test-id","enabled":true,"ssoEndpoint":"updated-endpoint","publicCertificate":"test-cert","signRequest":true,"type":"saml"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &clients.FronteggClient{
+		Endpoint:   mockServer.URL,
+		HTTPClient: mockServer.Client(),
+	}
+
+	ssoConfig := SSOConfig{
+		Id:                "test-id",
+		Enabled:           true,
+		SsoEndpoint:       "updated-endpoint",
+		PublicCertificate: "test-cert",
+		SignRequest:       true,
+		Type:              "saml",
+	}
+
+	updatedConfig, err := UpdateSSOConfiguration(context.Background(), client, ssoConfig)
+	assert.NoError(err)
+	assert.Equal("updated-endpoint", updatedConfig.SsoEndpoint)
+}
+
+func TestDeleteSSOConfigurationSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	client := &clients.FronteggClient{
+		Endpoint:   mockServer.URL,
+		HTTPClient: mockServer.Client(),
+	}
+
+	err := DeleteSSOConfiguration(context.Background(), client, "test-id")
+	assert.NoError(err)
+}

--- a/pkg/provider/acceptance_sso_config_test.go
+++ b/pkg/provider/acceptance_sso_config_test.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/frontegg"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccSSOConfiguration_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOConfigBasicConfig(true, true, "https://example.com/sso", "test-certificate", "saml", "client-id", "secret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSSOConfigExists("materialize_sso_config.example"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "enabled", "true"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sso_endpoint", "https://example.com/sso"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "public_certificate", "test-certificate"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sign_request", "true"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "type", "saml"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_client_id", "client-id"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_secret", "secret"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSOConfiguration_update(t *testing.T) {
+	initialSSOEndpoint := "https://example.com/sso"
+	updatedSSOEndpoint := "https://updated.example.com/sso"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOConfigBasicConfig(true, true, initialSSOEndpoint, "test-certificate", "saml", "client-id", "secret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSSOConfigExists("materialize_sso_config.example"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sso_endpoint", initialSSOEndpoint),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "public_certificate", "test-certificate"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sign_request", "true"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "type", "saml"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_client_id", "client-id"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_secret", "secret"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccSSOConfigBasicConfig(true, true, updatedSSOEndpoint, "test-certificate2", "saml", "client-id", "secret2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSSOConfigExists("materialize_sso_config.example"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sso_endpoint", updatedSSOEndpoint),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "public_certificate", "test-certificate2"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "sign_request", "true"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "type", "saml"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_client_id", "client-id"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "oidc_secret", "secret2"),
+					resource.TestCheckResourceAttr("materialize_sso_config.example", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSSOConfiguration_disappears(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSOConfigBasicConfig(true, true, "https://example.com/sso", "test-certificate", "saml", "client-id", "secret"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSSOConfigExists("materialize_sso_config.example"),
+					testAccCheckSSOConfigDisappears("materialize_sso_config.example"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccSSOConfigBasicConfig(enabled, signRequest bool, ssoEndpoint, publicCertificate, ssoType, oidcClientId, oidcSecret string) string {
+	// Return a Terraform configuration for an example SSO Configuration
+	return fmt.Sprintf(`
+resource "materialize_sso_config" "example" {
+  enabled             = %t
+  sign_request        = %t
+  sso_endpoint        = "%s"
+  public_certificate  = "%s"
+  type                = "%s"
+  oidc_client_id      = "%s"
+  oidc_secret         = "%s"
+}
+`, enabled, signRequest, ssoEndpoint, publicCertificate, ssoType, oidcClientId, oidcSecret)
+}
+
+func testAccCheckSSOConfigExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SSO Configuration ID is set")
+		}
+
+		meta := testAccProvider.Meta()
+		providerMeta, _ := utils.GetProviderMeta(meta)
+		client := providerMeta.Frontegg
+
+		configurations, err := frontegg.FetchSSOConfigurations(context.Background(), client)
+		if err != nil {
+			return err
+		}
+
+		var foundConfig *frontegg.SSOConfig
+		for _, config := range configurations {
+			if config.Id == rs.Primary.ID {
+				foundConfig = &config
+				break
+			}
+		}
+
+		if foundConfig == nil {
+			return fmt.Errorf("SSO Configuration not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSSOConfigNotExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		meta := testAccProvider.Meta()
+		providerMeta, _ := utils.GetProviderMeta(meta)
+		client := providerMeta.Frontegg
+
+		configurations, err := frontegg.FetchSSOConfigurations(context.Background(), client)
+		if err != nil {
+			return fmt.Errorf("Error fetching SSO configurations: %s", err)
+		}
+
+		for _, config := range configurations {
+			if config.Id == rs.Primary.ID {
+				return fmt.Errorf("SSO configuration %s still exists", rs.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSSOConfigDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		meta := testAccProvider.Meta()
+		providerMeta, _ := utils.GetProviderMeta(meta)
+		client := providerMeta.Frontegg
+
+		err := frontegg.DeleteSSOConfiguration(context.Background(), client, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error deleting SSO configuration: %s", err)
+		}
+
+		return nil
+	}
+}

--- a/pkg/resources/resource_sso_domain.go
+++ b/pkg/resources/resource_sso_domain.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/frontegg"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -32,14 +33,6 @@ var SSODomainSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "Indicates whether the domain has been validated.",
 	},
-}
-
-// Domain represents the structure for SSO domain.
-type Domain struct {
-	ID          string `json:"id"`
-	Domain      string `json:"domain"`
-	Validated   bool   `json:"validated"`
-	SsoConfigId string `json:"sso_config_id"`
 }
 
 func SSODomain() *schema.Resource {
@@ -106,7 +99,7 @@ func ssoDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 		return diag.Errorf("error reading SSO configurations: status %d, response: %s", resp.StatusCode, string(responseData))
 	}
 
-	var configs []SSOConfig
+	var configs []frontegg.SSOConfig
 	if err := json.NewDecoder(resp.Body).Decode(&configs); err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -385,12 +385,16 @@ func handleSSOConfigAndDomainRequests(w http.ResponseWriter, req *http.Request) 
 		if req.Method == http.MethodPatch {
 			// Parse the request body to get the updated SSO configuration data
 			var updatedSSOConfig SSOConfig
+			updatedSSOConfig.Id = ssoConfigID
 			err := json.NewDecoder(req.Body).Decode(&updatedSSOConfig)
 			if err != nil {
 				http.Error(w, "Failed to decode request body", http.StatusBadRequest)
 				return
 			}
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(updatedSSOConfig)
+			return
 		}
 		if req.Method == http.MethodDelete {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -45,7 +45,7 @@ type Domain struct {
 	ID          string `json:"id"`
 	Domain      string `json:"domain"`
 	Validated   bool   `json:"validated"`
-	SsoConfigId string `json:"sso_config_id"`
+	SsoConfigId string `json:"ssoConfigId"`
 }
 
 type GroupMapping struct {


### PR DESCRIPTION
As part of #454 refactoring the SSO config resource to abstract the Frontegg logic to the Frontegg package and also adding acceptance tests.