### PR TITLE
Add public psuedo role to resource grant

### DIFF
--- a/integration/role.tf
+++ b/integration/role.tf
@@ -32,6 +32,12 @@ resource "materialize_grant_system_privilege" "role_1_system_createcluster" {
   privilege = "CREATECLUSTER"
 }
 
+resource "materialize_cluster_grant" "cluster_grant_public" {
+  role_name    = "PUBLIC"
+  privilege    = "USAGE"
+  cluster_name = materialize_cluster.cluster.name
+}
+
 output "qualified_role" {
   value = materialize_role.role_1.qualified_sql_name
 }

--- a/pkg/materialize/privilege.go
+++ b/pkg/materialize/privilege.go
@@ -131,6 +131,10 @@ type MaterializeRole struct {
 }
 
 func (b *MaterializeRole) QualifiedName() string {
+	// If role name is PUBLIC, it should not be quoted as it is a pseudo-role
+	if b.name == "PUBLIC" {
+		return b.name
+	}
 	return QualifiedName(b.name)
 }
 

--- a/pkg/resources/resource_grant_cluster_test.go
+++ b/pkg/resources/resource_grant_cluster_test.go
@@ -51,6 +51,42 @@ func TestResourceGrantClusterCreate(t *testing.T) {
 	})
 }
 
+func TestResourceGrantClusterCreateP(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "PUBLIC",
+		"privilege":    "CREATE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`GRANT CREATE ON CLUSTER "materialize" TO PUBLIC;`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Grant Id
+		gp := `WHERE mz_clusters.name = 'materialize'`
+		testhelpers.MockClusterScan(mock, gp)
+
+		// Query Params
+		pp := `WHERE mz_clusters.id = 'u1'`
+		testhelpers.MockClusterScan(mock, pp)
+
+		if err := grantClusterCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:GRANT|CLUSTER|u1|p|CREATE" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceGrantClusterDelete(t *testing.T) {
 	r := require.New(t)
 
@@ -64,6 +100,26 @@ func TestResourceGrantClusterDelete(t *testing.T) {
 
 	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(`REVOKE CREATE ON CLUSTER "materialize" FROM "joe";`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		if err := grantClusterDelete(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestResourceGrantClusterDeletePublic(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "PUBLIC",
+		"privilege":    "CREATE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`REVOKE CREATE ON CLUSTER "materialize" FROM PUBLIC;`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		if err := grantClusterDelete(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_grant_table_test.go
+++ b/pkg/resources/resource_grant_table_test.go
@@ -53,6 +53,44 @@ func TestResourceGrantTableCreate(t *testing.T) {
 	})
 }
 
+func TestResourceGrantTableCreatePublic(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":     "PUBLIC",
+		"privilege":     "USAGE",
+		"table_name":    "table",
+		"schema_name":   "schema",
+		"database_name": "database",
+	}
+	d := schema.TestResourceDataRaw(t, GrantTable().Schema, in)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`GRANT USAGE ON TABLE "database"."schema"."table" TO PUBLIC;`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Grant Id
+		gp := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_tables.name = 'table'`
+		testhelpers.MockTableScan(mock, gp)
+
+		// Query Params
+		pp := `WHERE mz_tables.id = 'u1'`
+		testhelpers.MockTableScan(mock, pp)
+
+		if err := grantTableCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:GRANT|TABLE|u1|p|USAGE" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
 func TestResourceGrantTableDelete(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
It looks like that we used to be generating the following:

```
GRANT USAGE ON CLUSTER "example_cluster" TO "PUBLIC";
ERROR:  unknown role 'PUBLIC'
```

This PR checks if the role is `PUBLIC` and if so, it does not quote it.