### PR TITLE
Remove `idle_arrangement_merge_effort` option

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -30,7 +30,6 @@ resource "materialize_cluster" "example_cluster" {
 - `availability_zones` (List of String) The specific availability zones of the cluster.
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `disk` (Boolean, Deprecated) **Deprecated**. This attribute is maintained for backward compatibility with existing configurations. New users should use 'cc' sizes for disk access.
-- `idle_arrangement_merge_effort` (Number) The amount of effort to exert compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.
 - `introspection_debugging` (Boolean) Whether to introspect the gathering of the introspection data.
 - `introspection_interval` (String) The interval at which to collect introspection data.
 - `ownership_role` (String) The owernship role of the object.

--- a/docs/resources/cluster_replica.md
+++ b/docs/resources/cluster_replica.md
@@ -35,7 +35,6 @@ resource "materialize_cluster_replica" "example_cluster_replica" {
 - `availability_zone` (String) The specific availability zone of the replica.
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `disk` (Boolean, Deprecated) **Deprecated**. This attribute is maintained for backward compatibility with existing configurations. New users should use 'cc' sizes for disk access.
-- `idle_arrangement_merge_effort` (Number) The amount of effort to exert compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.
 - `introspection_debugging` (Boolean) Whether to introspect the gathering of the introspection data.
 - `introspection_interval` (String) The interval at which to collect introspection data.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -37,13 +37,12 @@ resource "materialize_cluster_grant_default_privilege" "example" {
 }
 
 resource "materialize_cluster" "managed_cluster" {
-  name                          = "managed_cluster"
-  replication_factor            = 2
-  size                          = "25cc"
-  introspection_interval        = "1s"
-  introspection_debugging       = true
-  idle_arrangement_merge_effort = 2
-  disk                          = true
+  name                    = "managed_cluster"
+  replication_factor      = 2
+  size                    = "25cc"
+  introspection_interval  = "1s"
+  introspection_debugging = true
+  disk                    = true
 }
 
 data "materialize_cluster" "all" {}

--- a/integration/cluster_replica.tf
+++ b/integration/cluster_replica.tf
@@ -6,14 +6,13 @@ resource "materialize_cluster_replica" "cluster_replica_1" {
 }
 
 resource "materialize_cluster_replica" "cluster_replica_2" {
-  name                          = "r2"
-  cluster_name                  = materialize_cluster.cluster.name
-  size                          = "3xsmall"
-  availability_zone             = "test2"
-  introspection_interval        = "2s"
-  introspection_debugging       = true
-  idle_arrangement_merge_effort = 1
-  disk                          = true
+  name                    = "r2"
+  cluster_name            = materialize_cluster.cluster.name
+  size                    = "3xsmall"
+  availability_zone       = "test2"
+  introspection_interval  = "2s"
+  introspection_debugging = true
+  disk                    = true
 }
 
 resource "materialize_cluster_replica" "cluster_replica_source" {

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -19,7 +19,6 @@ type ClusterBuilder struct {
 	availabilityZones          []string
 	introspectionInterval      string
 	introspectionDebugging     bool
-	idleArrangementMergeEffort int
 }
 
 func NewClusterBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterBuilder {
@@ -63,11 +62,6 @@ func (b *ClusterBuilder) IntrospectionDebugging() *ClusterBuilder {
 	return b
 }
 
-func (b *ClusterBuilder) IdleArrangementMergeEffort(e int) *ClusterBuilder {
-	b.idleArrangementMergeEffort = e
-	return b
-}
-
 func (b *ClusterBuilder) Create() error {
 	q := strings.Builder{}
 
@@ -105,11 +99,6 @@ func (b *ClusterBuilder) Create() error {
 
 		if b.introspectionDebugging {
 			p = append(p, ` INTROSPECTION DEBUGGING = TRUE`)
-		}
-
-		if b.idleArrangementMergeEffort != 0 {
-			m := fmt.Sprintf(` IDLE ARRANGEMENT MERGE EFFORT = %d`, b.idleArrangementMergeEffort)
-			p = append(p, m)
 		}
 
 		if len(p) > 0 {
@@ -158,11 +147,6 @@ func (b *ClusterBuilder) SetIntrospectionInterval(introspectionInterval string) 
 
 func (b *ClusterBuilder) SetIntrospectionDebugging(introspectionDebugging bool) error {
 	q := fmt.Sprintf(`ALTER CLUSTER %s SET (INTROSPECTION DEBUGGING %t);`, b.QualifiedName(), introspectionDebugging)
-	return b.ddl.exec(q)
-}
-
-func (b *ClusterBuilder) SetIdleArrangementMergeEffort(idleArrangementMergeEffort int) error {
-	q := fmt.Sprintf(`ALTER CLUSTER %s SET (IDLE ARRANGEMENT MERGE EFFORT %d);`, b.QualifiedName(), idleArrangementMergeEffort)
 	return b.ddl.exec(q)
 }
 

--- a/pkg/materialize/cluster_replica.go
+++ b/pkg/materialize/cluster_replica.go
@@ -18,7 +18,6 @@ type ClusterReplicaBuilder struct {
 	availabilityZone           string
 	introspectionInterval      string
 	introspectionDebugging     bool
-	idleArrangementMergeEffort int
 }
 
 func NewClusterReplicaBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterReplicaBuilder {
@@ -58,11 +57,6 @@ func (b *ClusterReplicaBuilder) IntrospectionDebugging() *ClusterReplicaBuilder 
 	return b
 }
 
-func (b *ClusterReplicaBuilder) IdleArrangementMergeEffort(e int) *ClusterReplicaBuilder {
-	b.idleArrangementMergeEffort = e
-	return b
-}
-
 func (b *ClusterReplicaBuilder) Create() error {
 	q := strings.Builder{}
 	q.WriteString(fmt.Sprintf(`CREATE CLUSTER REPLICA %s`, b.QualifiedName()))
@@ -90,11 +84,6 @@ func (b *ClusterReplicaBuilder) Create() error {
 
 	if b.introspectionDebugging {
 		p = append(p, ` INTROSPECTION DEBUGGING = TRUE`)
-	}
-
-	if b.idleArrangementMergeEffort != 0 {
-		m := fmt.Sprintf(` IDLE ARRANGEMENT MERGE EFFORT = %d`, b.idleArrangementMergeEffort)
-		p = append(p, m)
 	}
 
 	if len(p) > 0 {

--- a/pkg/materialize/cluster_replica_test.go
+++ b/pkg/materialize/cluster_replica_test.go
@@ -11,7 +11,7 @@ import (
 func TestClusterReplicaCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE CLUSTER REPLICA "cluster"."replica" SIZE = 'xsmall', DISK, AVAILABILITY ZONE = 'us-east-1', INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = TRUE, IDLE ARRANGEMENT MERGE EFFORT = 1;`,
+			`CREATE CLUSTER REPLICA "cluster"."replica" SIZE = 'xsmall', DISK, AVAILABILITY ZONE = 'us-east-1', INTROSPECTION INTERVAL = '1s', INTROSPECTION DEBUGGING = TRUE;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "replica", ClusterName: "cluster"}
@@ -21,7 +21,6 @@ func TestClusterReplicaCreate(t *testing.T) {
 		b.AvailabilityZone("us-east-1")
 		b.IntrospectionInterval("1s")
 		b.IntrospectionDebugging()
-		b.IdleArrangementMergeEffort(1)
 
 		if err := b.Create(); err != nil {
 			t.Fatal(err)

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -71,8 +71,7 @@ func TestClusterManagedAllCreate(t *testing.T) {
 			REPLICATION FACTOR 2,
 			AVAILABILITY ZONES = \['us-east-1'\],
 			INTROSPECTION INTERVAL = '1s',
-			INTROSPECTION DEBUGGING = TRUE,
-			IDLE ARRANGEMENT MERGE EFFORT = 1;
+			INTROSPECTION DEBUGGING = TRUE;
 		`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "cluster"}
@@ -83,7 +82,6 @@ func TestClusterManagedAllCreate(t *testing.T) {
 		b.AvailabilityZones([]string{"us-east-1"})
 		b.IntrospectionInterval("1s")
 		b.IntrospectionDebugging()
-		b.IdleArrangementMergeEffort(1)
 		if err := b.Create(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/provider/acceptance_cluster_replica_test.go
+++ b/pkg/provider/acceptance_cluster_replica_test.go
@@ -31,7 +31,6 @@ func TestAccClusterReplica_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "introspection_interval", "1s"),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "introspection_debugging", "false"),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "disk", "true"),
-					resource.TestCheckNoResourceAttr("materialize_cluster_replica.test", "idle_arrangement_merge_effort"),
 					resource.TestCheckResourceAttr("materialize_cluster_replica.test", "comment", ""),
 				),
 			},

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -22,7 +22,7 @@ func TestAccCluster_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "3xsmall", "1", "1s", "true", "2", "true", "Comment"),
+				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "3xsmall", "1", "1s", "true", "true", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestMatchResourceAttr("materialize_cluster.test", "id", terraformObjectIdRegex),
@@ -40,7 +40,6 @@ func TestAccCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "1"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "1s"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "true"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "idle_arrangement_merge_effort", "2"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "disk", "true"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "availability_zones.#", "2"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "comment", "Comment"),
@@ -66,7 +65,7 @@ func TestAccClusterCCSize_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "25cc", "1", "1s", "true", "2", "true", "Comment"),
+				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "25cc", "1", "1s", "true", "true", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "name", clusterName+"_managed"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "ownership_role", "mz_system"),
@@ -74,7 +73,6 @@ func TestAccClusterCCSize_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "1"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "1s"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "true"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "idle_arrangement_merge_effort", "2"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "disk", "true"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "comment", "Comment"),
 				),
@@ -153,7 +151,7 @@ func TestAccCluster_update(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterResource(roleName, oldClusterName, cluster2Name, "mz_system", "2xsmall", "2", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterResource(roleName, oldClusterName, cluster2Name, "mz_system", "2xsmall", "2", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "name", oldClusterName),
@@ -168,13 +166,12 @@ func TestAccCluster_update(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "2"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "1s"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "true"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "idle_arrangement_merge_effort", "2"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "disk", "false"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "comment", "Comment"),
 				),
 			},
 			{
-				Config: testAccClusterResource(roleName, newClusterName, cluster2Name, roleName, "3xsmall", "1", "2s", "false", "1", "true", "New Comment"),
+				Config: testAccClusterResource(roleName, newClusterName, cluster2Name, roleName, "3xsmall", "1", "2s", "false", "true", "New Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "name", newClusterName),
@@ -188,7 +185,6 @@ func TestAccCluster_update(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "replication_factor", "1"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_interval", "2s"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "introspection_debugging", "false"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "idle_arrangement_merge_effort", "1"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "disk", "true"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_managed_cluster", "comment", "New Comment"),
 				),
@@ -208,14 +204,14 @@ func TestAccCluster_updateName(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterManagedResource(oldClusterName, "2xsmall", "2", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(oldClusterName, "2xsmall", "2", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "name", oldClusterName),
 				),
 			},
 			{
-				Config: testAccClusterManagedResource(newClusterName, "2xsmall", "2", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(newClusterName, "2xsmall", "2", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "name", newClusterName),
@@ -233,14 +229,14 @@ func TestAccCluster_updateSize(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterManagedResource(clusterName, "2xsmall", "2", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(clusterName, "2xsmall", "2", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "size", "2xsmall"),
 				),
 			},
 			{
-				Config: testAccClusterManagedResource(clusterName, "3xsmall", "2", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(clusterName, "3xsmall", "2", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "size", "3xsmall"),
@@ -258,14 +254,14 @@ func TestAccCluster_updateReplicationFactor(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterManagedResource(clusterName, "2xsmall", "3", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(clusterName, "2xsmall", "3", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "replication_factor", "3"),
 				),
 			},
 			{
-				Config: testAccClusterManagedResource(clusterName, "3xsmall", "1", "1s", "true", "2", "false", "Comment"),
+				Config: testAccClusterManagedResource(clusterName, "3xsmall", "1", "1s", "true", "false", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					resource.TestCheckResourceAttr("materialize_cluster.test", "replication_factor", "1"),
@@ -285,7 +281,7 @@ func TestAccCluster_disappears(t *testing.T) {
 		CheckDestroy:      testAccCheckAllClusterDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "3xsmall", "1", "1s", "true", "2", "true", "Comment"),
+				Config: testAccClusterResource(roleName, clusterName, cluster2Name, roleName, "3xsmall", "1", "1s", "true", "true", "Comment"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test"),
 					testAccCheckObjectDisappears(materialize.MaterializeObject{ObjectType: "CLUSTER", Name: clusterName}),
@@ -308,7 +304,6 @@ func testAccClusterResource(
 	clusterReplicationFactor,
 	introspectionInterval,
 	introspectionDebugging,
-	idleArrangementMergeEffort,
 	disk,
 	comment string,
 ) string {
@@ -334,9 +329,8 @@ func testAccClusterResource(
 		replication_factor            = %[6]s
 		introspection_interval        = "%[7]s"
 		introspection_debugging       = %[8]s
-		idle_arrangement_merge_effort = %[9]s
-		disk                          = %[10]s
-		comment                       = "%[11]s"
+		disk                          = %[9]s
+		comment                       = "%[10]s"
 		availability_zones            = ["test1", "test2"]
 	}
 	`,
@@ -348,7 +342,6 @@ func testAccClusterResource(
 		clusterReplicationFactor,
 		introspectionInterval,
 		introspectionDebugging,
-		idleArrangementMergeEffort,
 		disk,
 		comment)
 }
@@ -380,7 +373,6 @@ func testAccClusterManagedResource(
 	clusterReplicationFactor,
 	introspectionInterval,
 	introspectionDebugging,
-	idleArrangementMergeEffort,
 	disk,
 	comment string) string {
 	return fmt.Sprintf(`
@@ -390,9 +382,8 @@ func testAccClusterManagedResource(
 		replication_factor            = %[3]s
 		introspection_interval        = "%[4]s"
 		introspection_debugging       = %[5]s
-		idle_arrangement_merge_effort = %[6]s
-		disk                          = %[7]s
-		comment                       = "%[8]s"
+		disk                          = %[6]s
+		comment                       = "%[7]s"
 	}
 	`,
 		clusterName,
@@ -400,7 +391,6 @@ func testAccClusterManagedResource(
 		clusterReplicationFactor,
 		introspectionInterval,
 		introspectionDebugging,
-		idleArrangementMergeEffort,
 		disk,
 		comment)
 }

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -36,7 +36,6 @@ var clusterSchema = map[string]*schema.Schema{
 	},
 	"introspection_interval":        IntrospectionIntervalSchema(false, []string{"size"}),
 	"introspection_debugging":       IntrospectionDebuggingSchema(false, []string{"size"}),
-	"idle_arrangement_merge_effort": IdleArrangementMergeEffortSchema(false, []string{"size"}),
 	"region":                        RegionSchema(),
 }
 
@@ -146,10 +145,6 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		if v, ok := d.GetOk("introspection_debugging"); ok && v.(bool) {
 			b.IntrospectionDebugging()
 		}
-
-		if v, ok := d.GetOk("idle_arrangement_merge_effort"); ok {
-			b.IdleArrangementMergeEffort(v.(int))
-		}
 	}
 
 	// create resource
@@ -256,13 +251,6 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		if d.HasChange("introspection_debugging") {
 			_, n := d.GetChange("introspection_debugging")
 			if err := b.SetIntrospectionDebugging(n.(bool)); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-
-		if d.HasChange("idle_arrangement_merge_effort") {
-			_, n := d.GetChange("idle_arrangement_merge_effort")
-			if err := b.SetIdleArrangementMergeEffort(n.(int)); err != nil {
 				return diag.FromErr(err)
 			}
 		}

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -27,7 +27,6 @@ var clusterReplicaSchema = map[string]*schema.Schema{
 	},
 	"introspection_interval":        IntrospectionIntervalSchema(true, []string{}),
 	"introspection_debugging":       IntrospectionDebuggingSchema(true, []string{}),
-	"idle_arrangement_merge_effort": IdleArrangementMergeEffortSchema(true, []string{}),
 	"region":                        RegionSchema(),
 }
 
@@ -128,10 +127,6 @@ func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("introspection_debugging"); ok && v.(bool) {
 		b.IntrospectionDebugging()
-	}
-
-	if v, ok := d.GetOk("idle_arrangement_merge_effort"); ok {
-		b.IdleArrangementMergeEffort(v.(int))
 	}
 
 	// create resource

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -22,7 +22,6 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 		"availability_zone":             "use1-az1",
 		"introspection_interval":        "10s",
 		"introspection_debugging":       true,
-		"idle_arrangement_merge_effort": 100,
 		"comment":                       "object comment",
 	}
 	d := schema.TestResourceDataRaw(t, ClusterReplica().Schema, in)
@@ -35,8 +34,7 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 			SIZE = 'small',
 			AVAILABILITY ZONE = 'use1-az1',
 			INTROSPECTION INTERVAL = '10s',
-			INTROSPECTION DEBUGGING = TRUE,
-			IDLE ARRANGEMENT MERGE EFFORT = 100;`,
+			INTROSPECTION DEBUGGING = TRUE;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Comment

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -19,7 +19,6 @@ var inCluster = map[string]interface{}{
 	"availability_zones":            []interface{}{"use1-az1", "use1-az2"},
 	"introspection_interval":        "10s",
 	"introspection_debugging":       true,
-	"idle_arrangement_merge_effort": 100,
 	"ownership_role":                "joe",
 }
 
@@ -37,8 +36,7 @@ func TestResourceClusterCreate(t *testing.T) {
 			REPLICATION FACTOR 2,
 			AVAILABILITY ZONES = \['use1-az1','use1-az2'\],
 			INTROSPECTION INTERVAL = '10s',
-			INTROSPECTION DEBUGGING = TRUE,
-			IDLE ARRANGEMENT MERGE EFFORT = 100;
+			INTROSPECTION DEBUGGING = TRUE;
 		`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Ownership

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -457,16 +457,6 @@ func IntrospectionDebuggingSchema(forceNew bool, requiredWith []string) *schema.
 	}
 }
 
-func IdleArrangementMergeEffortSchema(forceNew bool, requiredWith []string) *schema.Schema {
-	return &schema.Schema{
-		Description:  "The amount of effort to exert compacting arrangements during idle periods. This is an unstable option! It may be changed or removed at any time.",
-		Type:         schema.TypeInt,
-		Optional:     true,
-		ForceNew:     forceNew,
-		RequiredWith: requiredWith,
-	}
-}
-
 func GranteeNameSchema() *schema.Schema {
 	return &schema.Schema{
 		Description: "The role name that will gain the default privilege. Use the `PUBLIC` pseudo-role to grant privileges to all roles.",


### PR DESCRIPTION
This PR removes the `idle_arrangement_merge_effort` options for both cluster and replica resources. The Materialize option it controls, `IDLE ARRANGEMENT MERGE EFFORT` is being removed (https://github.com/MaterializeInc/materialize/pull/26319).