### PR TITLE
Add scheduling option to clusters

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -35,11 +35,20 @@ resource "materialize_cluster" "example_cluster" {
 - `ownership_role` (String) The owernship role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
+- `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))
 - `size` (String) The size of the managed cluster.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--scheduling"></a>
+### Nested Schema for `scheduling`
+
+Optional:
+
+- `on_refresh` (Boolean) Enable scheduling to refresh the cluster.
+- `rehydration_time_estimate` (String) Estimated time to rehydrate the cluster during refresh.
 
 ## Import
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -47,7 +47,14 @@ resource "materialize_cluster" "example_cluster" {
 
 Optional:
 
-- `on_refresh` (Boolean) Enable scheduling to refresh the cluster.
+- `on_refresh` (Block List, Max: 1) Configuration for refreshing the cluster. (see [below for nested schema](#nestedblock--scheduling--on_refresh))
+
+<a id="nestedblock--scheduling--on_refresh"></a>
+### Nested Schema for `scheduling.on_refresh`
+
+Optional:
+
+- `enabled` (Boolean) Enable scheduling to refresh the cluster.
 - `rehydration_time_estimate` (String) Estimated time to rehydrate the cluster during refresh.
 
 ## Import

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -17,8 +17,10 @@ resource "materialize_cluster" "scheduling_cluster" {
   name = "scheduling_cluster"
   size = "25cc"
   scheduling {
-    on_refresh                = true
-    rehydration_time_estimate = "1 hour"
+    on_refresh {
+      enabled                   = true
+      rehydration_time_estimate = "1 hour"
+    }
   }
 }
 

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -12,6 +12,16 @@ resource "materialize_cluster" "cluster_sink" {
   size = "3xsmall"
 }
 
+
+resource "materialize_cluster" "scheduling_cluster" {
+  name = "scheduling_cluster"
+  size = "25cc"
+  scheduling {
+    on_refresh                = true
+    rehydration_time_estimate = "1 hour"
+  }
+}
+
 resource "materialize_cluster" "no_replication" {
   name               = "no_replication"
   size               = "25cc"

--- a/pkg/materialize/cluster_replica.go
+++ b/pkg/materialize/cluster_replica.go
@@ -10,14 +10,14 @@ import (
 
 // DDL
 type ClusterReplicaBuilder struct {
-	ddl                        Builder
-	replicaName                string
-	clusterName                string
-	size                       string
-	disk                       bool
-	availabilityZone           string
-	introspectionInterval      string
-	introspectionDebugging     bool
+	ddl                    Builder
+	replicaName            string
+	clusterName            string
+	size                   string
+	disk                   bool
+	availabilityZone       string
+	introspectionInterval  string
+	introspectionDebugging bool
 }
 
 func NewClusterReplicaBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterReplicaBuilder {

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -98,3 +98,24 @@ func TestClusterDrop(t *testing.T) {
 		}
 	})
 }
+
+func TestClusterWithSchedulingCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		expectedSQL := `CREATE CLUSTER "cluster" SIZE 'xsmall', SCHEDULE = ON REFRESH \(REHYDRATION TIME ESTIMATE = '2 hours'\);`
+		mock.ExpectExec(expectedSQL).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "cluster"}
+		b := NewClusterBuilder(db, o)
+		b.Size("xsmall")
+		b.Scheduling([]interface{}{
+			map[string]interface{}{
+				"on_refresh":                true,
+				"rehydration_time_estimate": "2 hours",
+			},
+		})
+
+		if err := b.Create(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -107,10 +107,15 @@ func TestClusterWithSchedulingCreate(t *testing.T) {
 		o := MaterializeObject{Name: "cluster"}
 		b := NewClusterBuilder(db, o)
 		b.Size("xsmall")
+
 		b.Scheduling([]interface{}{
 			map[string]interface{}{
-				"on_refresh":                true,
-				"rehydration_time_estimate": "2 hours",
+				"on_refresh": []interface{}{
+					map[string]interface{}{
+						"enabled":                   true,
+						"rehydration_time_estimate": "2 hours",
+					},
+				},
 			},
 		})
 

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -285,8 +285,8 @@ func TestAccClusterWithScheduling(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "name", clusterName),
 					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "size", size),
-					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh", "true"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.rehydration_time_estimate", rehydrationTimeEstimate),
+					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh.0.enabled", "true"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh.0.rehydration_time_estimate", rehydrationTimeEstimate),
 				),
 			},
 		},
@@ -427,8 +427,10 @@ resource "materialize_cluster" "test_scheduling" {
     name                    = "%s"
     size                    = "%s"
     scheduling {
-        on_refresh                = %s
-        rehydration_time_estimate = "%s"
+        on_refresh {
+			enabled = %s
+			rehydration_time_estimate = "%s"
+		}
     }
 }
 `, clusterName, size, onRefreshStr, rehydrationTimeEstimate)

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -46,15 +46,24 @@ var clusterSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"on_refresh": {
-					Type:        schema.TypeBool,
+					Type:        schema.TypeList,
 					Optional:    true,
-					Description: "Enable scheduling to refresh the cluster.",
-				},
-				"rehydration_time_estimate": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					RequiredWith: []string{"scheduling.0.on_refresh"},
-					Description:  "Estimated time to rehydrate the cluster during refresh.",
+					MaxItems:    1,
+					Description: "Configuration for refreshing the cluster.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"enabled": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Enable scheduling to refresh the cluster.",
+							},
+							"rehydration_time_estimate": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Estimated time to rehydrate the cluster during refresh.",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -37,11 +37,12 @@ var clusterSchema = map[string]*schema.Schema{
 	"introspection_interval":  IntrospectionIntervalSchema(false, []string{"size"}),
 	"introspection_debugging": IntrospectionDebuggingSchema(false, []string{"size"}),
 	"scheduling": {
-		Type:         schema.TypeList,
-		Optional:     true,
-		MaxItems:     1,
-		Description:  "Defines the scheduling parameters for the cluster.",
-		RequiredWith: []string{"size"},
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      1,
+		Description:   "Defines the scheduling parameters for the cluster.",
+		RequiredWith:  []string{"size"},
+		ConflictsWith: []string{"replication_factor"},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"on_refresh": {

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -25,9 +25,9 @@ var clusterReplicaSchema = map[string]*schema.Schema{
 		Computed:    true,
 		ForceNew:    true,
 	},
-	"introspection_interval":        IntrospectionIntervalSchema(true, []string{}),
-	"introspection_debugging":       IntrospectionDebuggingSchema(true, []string{}),
-	"region":                        RegionSchema(),
+	"introspection_interval":  IntrospectionIntervalSchema(true, []string{}),
+	"introspection_debugging": IntrospectionDebuggingSchema(true, []string{}),
+	"region":                  RegionSchema(),
 }
 
 func ClusterReplica() *schema.Resource {

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -16,13 +16,13 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":                          "replica",
-		"cluster_name":                  "cluster",
-		"size":                          "small",
-		"availability_zone":             "use1-az1",
-		"introspection_interval":        "10s",
-		"introspection_debugging":       true,
-		"comment":                       "object comment",
+		"name":                    "replica",
+		"cluster_name":            "cluster",
+		"size":                    "small",
+		"availability_zone":       "use1-az1",
+		"introspection_interval":  "10s",
+		"introspection_debugging": true,
+		"comment":                 "object comment",
 	}
 	d := schema.TestResourceDataRaw(t, ClusterReplica().Schema, in)
 	r.NotNil(d)

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -19,7 +19,13 @@ var inCluster = map[string]interface{}{
 	"availability_zones":      []interface{}{"use1-az1", "use1-az2"},
 	"introspection_interval":  "10s",
 	"introspection_debugging": true,
-	"ownership_role":          "joe",
+	"scheduling": []interface{}{
+		map[string]interface{}{
+			"on_refresh":                true,
+			"rehydration_time_estimate": "2 hours",
+		},
+	},
+	"ownership_role": "joe",
 }
 
 func TestResourceClusterCreate(t *testing.T) {
@@ -36,7 +42,8 @@ func TestResourceClusterCreate(t *testing.T) {
 			REPLICATION FACTOR 2,
 			AVAILABILITY ZONES = \['use1-az1','use1-az2'\],
 			INTROSPECTION INTERVAL = '10s',
-			INTROSPECTION DEBUGGING = TRUE;
+			INTROSPECTION DEBUGGING = TRUE,
+			SCHEDULE = ON REFRESH \(REHYDRATION TIME ESTIMATE = '2 hours'\);
 		`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Ownership

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -13,13 +13,13 @@ import (
 )
 
 var inCluster = map[string]interface{}{
-	"name":                          "cluster",
-	"size":                          "3xsmall",
-	"replication_factor":            2,
-	"availability_zones":            []interface{}{"use1-az1", "use1-az2"},
-	"introspection_interval":        "10s",
-	"introspection_debugging":       true,
-	"ownership_role":                "joe",
+	"name":                    "cluster",
+	"size":                    "3xsmall",
+	"replication_factor":      2,
+	"availability_zones":      []interface{}{"use1-az1", "use1-az2"},
+	"introspection_interval":  "10s",
+	"introspection_debugging": true,
+	"ownership_role":          "joe",
 }
 
 func TestResourceClusterCreate(t *testing.T) {

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -21,8 +21,12 @@ var inCluster = map[string]interface{}{
 	"introspection_debugging": true,
 	"scheduling": []interface{}{
 		map[string]interface{}{
-			"on_refresh":                true,
-			"rehydration_time_estimate": "2 hours",
+			"on_refresh": []interface{}{
+				map[string]interface{}{
+					"enabled":                   true,
+					"rehydration_time_estimate": "2 hours",
+				},
+			},
 		},
 	},
 	"ownership_role": "joe",

--- a/pkg/utils/provider_meta_test.go
+++ b/pkg/utils/provider_meta_test.go
@@ -77,7 +77,7 @@ func TestTransformIdWithRegion(t *testing.T) {
 			"expected": "aws/us-east-1:u1",
 		},
 	}
-	for tc, _ := range testCases {
+	for tc := range testCases {
 		c := testCases[tc]
 		o := TransformIdWithRegion("aws/us-east-1", c["input"].(string))
 		assert.Equal(t, o, c["expected"].(string))


### PR DESCRIPTION
This adds the new scheduling option to clusters:

```hcl
resource "materialize_cluster" "scheduling_cluster" {
  name = "scheduling_cluster"
  size = "25cc"
  scheduling {
    on_refresh                = true
    rehydration_time_estimate = "1 hour"
  }
}
```

Closes #544 