### PR TITLE
Drop public schema by default for database resource

### DIFF
--- a/docs/data-sources/scim_groups.md
+++ b/docs/data-sources/scim_groups.md
@@ -38,7 +38,7 @@ Read-Only:
 - `users` (List of Object) (see [below for nested schema](#nestedobjatt--groups--users))
 
 <a id="nestedobjatt--groups--roles"></a>
-### Nested Schema for `groups.roles`
+### Nested Schema for ``
 
 Read-Only:
 
@@ -50,7 +50,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--groups--users"></a>
-### Nested Schema for `groups.users`
+### Nested Schema for ``
 
 Read-Only:
 

--- a/docs/data-sources/sso_config.md
+++ b/docs/data-sources/sso_config.md
@@ -46,7 +46,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--sso_configs--domains"></a>
-### Nested Schema for `sso_configs.domains`
+### Nested Schema for ``
 
 Read-Only:
 
@@ -56,7 +56,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--sso_configs--groups"></a>
-### Nested Schema for `sso_configs.groups`
+### Nested Schema for ``
 
 Read-Only:
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -25,7 +25,7 @@ resource "materialize_database" "example" {
 # The Terraform provider on the other hand does not create a public schema by default
 # Optionally you can create a public schema in the database using the materialize_schema resource
 resource "materialize_schema" "public" {
-  name     = "public"
+  name          = "public"
   database_name = materialize_database.example.name
 }
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -28,7 +28,6 @@ resource "materialize_database" "example_database" {
 ### Optional
 
 - `comment` (String) **Public Preview** Comment on an object in the database.
-- `no_public_schema` (Boolean) When set to true, the default 'public' schema will be dropped from the database.
 - `ownership_role` (String) The owernship role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -4,17 +4,38 @@ page_title: "materialize_database Resource - terraform-provider-materialize"
 subcategory: ""
 description: |-
   The highest level namespace hierarchy in Materialize.
+  Note: This resource will not automatically create a public schema.If needed, the public schema must be explicitly defined in your configuration using the materialize_schema resource.
 ---
 
 # materialize_database (Resource)
 
 The highest level namespace hierarchy in Materialize.
 
+**Note**: This resource will not automatically create a public schema.If needed, the public schema must be explicitly defined in your configuration using the `materialize_schema` resource.
+
 ## Example Usage
 
 ```terraform
-resource "materialize_database" "example_database" {
-  name = "database"
+# Create a Materialize database without a public schema
+resource "materialize_database" "example" {
+  name = "example"
+}
+
+# By default, Materialize creates a public schema in each database
+# The Terraform provider on the other hand does not create a public schema by default
+# Optionally you can create a public schema in the database using the materialize_schema resource
+resource "materialize_schema" "public" {
+  name     = "public"
+  database_name = materialize_database.example.name
+}
+
+# Grant USAGE to the PUBLIC pseudo-role for the public schema
+# This matches the default behavior of Materialize
+resource "materialize_schema_grant" "schema_grant_usage" {
+  role_name     = "PUBLIC"
+  privilege     = "USAGE"
+  database_name = materialize_database.example.name
+  schema_name   = materialize_schema.public.name
 }
 ```
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -28,6 +28,7 @@ resource "materialize_database" "example_database" {
 ### Optional
 
 - `comment` (String) **Public Preview** Comment on an object in the database.
+- `no_public_schema` (Boolean) When set to true, the default 'public' schema will be dropped from the database.
 - `ownership_role` (String) The owernship role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 

--- a/docs/resources/scim_group_roles.md
+++ b/docs/resources/scim_group_roles.md
@@ -3,7 +3,7 @@
 page_title: "materialize_scim_group_roles Resource - terraform-provider-materialize"
 subcategory: ""
 description: |-
-  The materializescimgroup_role resource allows managing roles within a SCIM group in Frontegg.
+  The materialize_scim_group_role resource allows managing roles within a SCIM group in Frontegg.
 ---
 
 # materialize_scim_group_roles (Resource)

--- a/docs/resources/scim_group_users.md
+++ b/docs/resources/scim_group_users.md
@@ -3,7 +3,7 @@
 page_title: "materialize_scim_group_users Resource - terraform-provider-materialize"
 subcategory: ""
 description: |-
-  The materializescimgroup_users resource allows managing users within a SCIM group in Frontegg.
+  The materialize_scim_group_users resource allows managing users within a SCIM group in Frontegg.
 ---
 
 # materialize_scim_group_users (Resource)

--- a/examples/resources/materialize_database/resource.tf
+++ b/examples/resources/materialize_database/resource.tf
@@ -1,3 +1,21 @@
-resource "materialize_database" "example_database" {
-  name = "database"
+# Create a Materialize database without a public schema
+resource "materialize_database" "example" {
+  name = "example"
+}
+
+# By default, Materialize creates a public schema in each database
+# The Terraform provider on the other hand does not create a public schema by default
+# Optionally you can create a public schema in the database using the materialize_schema resource
+resource "materialize_schema" "public" {
+  name     = "public"
+  database_name = materialize_database.example.name
+}
+
+# Grant USAGE to the PUBLIC pseudo-role for the public schema
+# This matches the default behavior of Materialize
+resource "materialize_schema_grant" "schema_grant_usage" {
+  role_name     = "PUBLIC"
+  privilege     = "USAGE"
+  database_name = materialize_database.example.name
+  schema_name   = materialize_schema.public.name
 }

--- a/examples/resources/materialize_database/resource.tf
+++ b/examples/resources/materialize_database/resource.tf
@@ -7,7 +7,7 @@ resource "materialize_database" "example" {
 # The Terraform provider on the other hand does not create a public schema by default
 # Optionally you can create a public schema in the database using the materialize_schema resource
 resource "materialize_schema" "public" {
-  name     = "public"
+  name          = "public"
   database_name = materialize_database.example.name
 }
 

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -138,6 +138,7 @@ resource "materialize_schema_grant_default_privilege" "complex" {
   grantee_name     = each.value.grantee
   target_role_name = materialize_role.target.name
   database_name    = each.value.database
+  schema_name      = each.value.schema
 
   depends_on = [
     materialize_role.bi,

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -101,6 +101,8 @@ resource "materialize_database_grant_default_privilege" "complex" {
     materialize_role.target_2,
     materialize_database.db1,
     materialize_database.db2,
+    materialize_schema.schema1,
+    materialize_schema.schema2,
   ]
 }
 

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -138,7 +138,6 @@ resource "materialize_schema_grant_default_privilege" "complex" {
   grantee_name     = each.value.grantee
   target_role_name = materialize_role.target.name
   database_name    = each.value.database
-  schema_name      = each.value.schema
 
   depends_on = [
     materialize_role.bi,

--- a/integration/rbac.tf
+++ b/integration/rbac.tf
@@ -201,7 +201,7 @@ variable "table_grants" {
       grantee : "de",
       privilege : "UPDATE",
       database : "db1",
-      schema : "public",
+      schema : "schema1",
     },
   }
 }

--- a/integration/schema.tf
+++ b/integration/schema.tf
@@ -4,6 +4,18 @@ resource "materialize_schema" "public" {
   comment       = "public schema comment"
 }
 
+resource "materialize_schema" "db1_public" {
+  name          = "public"
+  database_name = materialize_database.db1.name
+  comment       = "public schema comment"
+}
+
+resource "materialize_schema" "db2_public" {
+  name          = "public"
+  database_name = materialize_database.db2.name
+  comment       = "public schema comment"
+}
+
 resource "materialize_schema" "schema" {
   name          = "example_schema"
   database_name = materialize_database.database.name

--- a/integration/schema.tf
+++ b/integration/schema.tf
@@ -1,3 +1,9 @@
+resource "materialize_schema" "public" {
+  name          = "public"
+  database_name = materialize_database.database.name
+  comment       = "public schema comment"
+}
+
 resource "materialize_schema" "schema" {
   name          = "example_schema"
   database_name = materialize_database.database.name

--- a/pkg/materialize/database.go
+++ b/pkg/materialize/database.go
@@ -34,6 +34,11 @@ func (b *DatabaseBuilder) Drop() error {
 	return b.ddl.drop(qn)
 }
 
+func (b *DatabaseBuilder) DropPublicSchema() error {
+	q := fmt.Sprintf(`DROP SCHEMA IF EXISTS %s.%s;`, b.QualifiedName(), QuoteIdentifier("public"))
+	return b.ddl.exec(q)
+}
+
 type DatabaseParams struct {
 	DatabaseId   sql.NullString `db:"id"`
 	DatabaseName sql.NullString `db:"database_name"`

--- a/pkg/provider/acceptance_datasource_connection_test.go
+++ b/pkg/provider/acceptance_datasource_connection_test.go
@@ -115,7 +115,7 @@ func testAccDatasourceConnection(nameSpace string) string {
 	resource "materialize_connection_kafka" "e" {
 		name              = "%[1]s_e"
 		database_name     = materialize_database.test_2.name
-		script_name       = materialize_schema.public_schema2.name
+		schema_name       = materialize_schema.public_schema2.name
 		security_protocol = "PLAINTEXT"
 	  
 		kafka_broker {

--- a/pkg/provider/acceptance_datasource_connection_test.go
+++ b/pkg/provider/acceptance_datasource_connection_test.go
@@ -24,7 +24,7 @@ func TestAccDatasourceConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_connection.test_database", "connections.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_connection.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_connection.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_connection.test_database_schema", "connections.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_connection.test_database_schema", "connections.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_connection.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_connection.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_connection.test_database_2", "connections.#", "2"),

--- a/pkg/provider/acceptance_datasource_connection_test.go
+++ b/pkg/provider/acceptance_datasource_connection_test.go
@@ -67,6 +67,7 @@ func testAccDatasourceConnection(nameSpace string) string {
 	resource "materialize_connection_kafka" "a" {
 		name              = "%[1]s_a"
 		database_name     = materialize_database.test.name
+		schema_name       = materialize_schema.test.name
 		security_protocol = "PLAINTEXT"
 	  
 		kafka_broker {
@@ -102,6 +103,7 @@ func testAccDatasourceConnection(nameSpace string) string {
 	resource "materialize_connection_kafka" "d" {
 		name              = "%[1]s_d"
 		database_name     = materialize_database.test_2.name
+		script_name       = materialize_schema.public_schema2.name
 		security_protocol = "PLAINTEXT"
 	  
 		kafka_broker {
@@ -113,6 +115,7 @@ func testAccDatasourceConnection(nameSpace string) string {
 	resource "materialize_connection_kafka" "e" {
 		name              = "%[1]s_e"
 		database_name     = materialize_database.test_2.name
+		script_name       = materialize_schema.public_schema2.name
 		security_protocol = "PLAINTEXT"
 	  
 		kafka_broker {

--- a/pkg/provider/acceptance_datasource_connection_test.go
+++ b/pkg/provider/acceptance_datasource_connection_test.go
@@ -49,6 +49,16 @@ func testAccDatasourceConnection(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_connection_test.go
+++ b/pkg/provider/acceptance_datasource_connection_test.go
@@ -103,7 +103,7 @@ func testAccDatasourceConnection(nameSpace string) string {
 	resource "materialize_connection_kafka" "d" {
 		name              = "%[1]s_d"
 		database_name     = materialize_database.test_2.name
-		script_name       = materialize_schema.public_schema2.name
+		schema_name       = materialize_schema.public_schema2.name
 		security_protocol = "PLAINTEXT"
 	  
 		kafka_broker {

--- a/pkg/provider/acceptance_datasource_materialized_view_test.go
+++ b/pkg/provider/acceptance_datasource_materialized_view_test.go
@@ -72,6 +72,16 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_materialized_view_test.go
+++ b/pkg/provider/acceptance_datasource_materialized_view_test.go
@@ -90,6 +90,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.test.name
 		cluster_name  = "quickstart"
 		comment       = "some comment"
 	  
@@ -127,6 +128,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		cluster_name  = "quickstart"
 	  
 		statement = <<SQL
@@ -138,6 +140,7 @@ func testAccDatasourceMaterializedView(nameSpace string) string {
 	resource "materialize_materialized_view" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		cluster_name  = "quickstart"
 	  
 		statement = <<SQL

--- a/pkg/provider/acceptance_datasource_materialized_view_test.go
+++ b/pkg/provider/acceptance_datasource_materialized_view_test.go
@@ -47,7 +47,7 @@ func TestAccDatasourceMaterializedView_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database", "materialized_views.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_schema", "materialized_views.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_schema", "materialized_views.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_materialized_view.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_materialized_view.test_database_2", "materialized_views.#", "2"),

--- a/pkg/provider/acceptance_datasource_schema_test.go
+++ b/pkg/provider/acceptance_datasource_schema_test.go
@@ -21,13 +21,13 @@ func TestAccDatasourceSchema_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.materialize_schema.test_database", "database_name", nameSpace),
 					// Will be one greater than defined for public schema
-					resource.TestCheckResourceAttr("data.materialize_schema.test_database", "schemas.#", "3"),
+					resource.TestCheckResourceAttr("data.materialize_schema.test_database", "schemas.#", "2"),
 					resource.TestCheckResourceAttr("data.materialize_schema.test_database_2", "database_name", nameSpace+"_2"),
-					resource.TestCheckResourceAttr("data.materialize_schema.test_database_2", "schemas.#", "4"),
+					resource.TestCheckResourceAttr("data.materialize_schema.test_database_2", "schemas.#", "3"),
 					resource.TestCheckNoResourceAttr("data.materialize_schema.test_all", "database_name"),
 					// Cannot ensure the exact number of objects with parallel tests
 					// Ensuring minimum
-					resource.TestMatchResourceAttr("data.materialize_schema.test_all", "schemas.#", regexp.MustCompile("([7-9]|\\d{2,})")),
+					resource.TestMatchResourceAttr("data.materialize_schema.test_all", "schemas.#", regexp.MustCompile("([6-9]|\\d{2,})")),
 				),
 			},
 		},

--- a/pkg/provider/acceptance_datasource_secret_test.go
+++ b/pkg/provider/acceptance_datasource_secret_test.go
@@ -24,7 +24,7 @@ func TestAccDatasourceSecret_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_secret.test_database", "secrets.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_secret.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_secret.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_secret.test_database_schema", "secrets.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_secret.test_database_schema", "secrets.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_secret.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_secret.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_secret.test_database_2", "secrets.#", "2"),
@@ -49,54 +49,49 @@ func testAccDatasourceSecret(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
-	resource "materialize_schema" "public_schema" {
-		name          = "public"
-		database_name = materialize_database.test.name
-	}
-
-	resource "materialize_schema" "public_schema2" {
-		name          = "public"
-		database_name = materialize_database.test_2.name
-	}
-
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "test_2" {
+		name          = "%[1]s_2"
+		database_name = materialize_database.test_2.name
 	}
 
 	resource "materialize_secret" "a" {
 		name          = "%[1]s_a"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	resource "materialize_secret" "b" {
 		name          = "%[1]s_b"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	resource "materialize_secret" "c" {
 		name          = "%[1]s_c"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	resource "materialize_secret" "d" {
 		name          = "%[1]s_d"
 		value         = "some-secret-value"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 	}
 
 	resource "materialize_secret" "e" {
 		name  = "%[1]s_e"
 		value = "some-secret-value"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 	}
 
 	data "materialize_secret" "test_all" {

--- a/pkg/provider/acceptance_datasource_secret_test.go
+++ b/pkg/provider/acceptance_datasource_secret_test.go
@@ -49,6 +49,16 @@ func testAccDatasourceSecret(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_secret_test.go
+++ b/pkg/provider/acceptance_datasource_secret_test.go
@@ -68,6 +68,7 @@ func testAccDatasourceSecret(nameSpace string) string {
 		name          = "%[1]s_a"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	resource "materialize_secret" "b" {
@@ -88,12 +89,14 @@ func testAccDatasourceSecret(nameSpace string) string {
 		name          = "%[1]s_d"
 		value         = "some-secret-value"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	resource "materialize_secret" "e" {
 		name  = "%[1]s_e"
 		value = "some-secret-value"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.test.name
 	}
 
 	data "materialize_secret" "test_all" {

--- a/pkg/provider/acceptance_datasource_secret_test.go
+++ b/pkg/provider/acceptance_datasource_secret_test.go
@@ -68,35 +68,35 @@ func testAccDatasourceSecret(nameSpace string) string {
 		name          = "%[1]s_a"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 	}
 
 	resource "materialize_secret" "b" {
 		name          = "%[1]s_b"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 	}
 
 	resource "materialize_secret" "c" {
 		name          = "%[1]s_c"
 		value         = "some-secret-value"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 	}
 
 	resource "materialize_secret" "d" {
 		name          = "%[1]s_d"
 		value         = "some-secret-value"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema2.name
 	}
 
 	resource "materialize_secret" "e" {
 		name  = "%[1]s_e"
 		value = "some-secret-value"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema2.name
 	}
 
 	data "materialize_secret" "test_all" {

--- a/pkg/provider/acceptance_datasource_source_test.go
+++ b/pkg/provider/acceptance_datasource_source_test.go
@@ -20,12 +20,12 @@ func TestAccDatasourceSource_basic(t *testing.T) {
 				Config: testAccDatasourceSource(nameSpace),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.materialize_source.test_database", "database_name", nameSpace),
-					resource.TestCheckNoResourceAttr("data.materialize_source.test_database", "schema_name"),
+					resource.TestCheckResourceAttr("data.materialize_source.test_database", "schema_name", nameSpace),
 					// Will be double the amount for subsources
 					resource.TestCheckResourceAttr("data.materialize_source.test_database", "sources.#", "6"),
 					resource.TestCheckResourceAttr("data.materialize_source.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_source.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_source.test_database_schema", "sources.#", "4"),
+					resource.TestCheckResourceAttr("data.materialize_source.test_database_schema", "sources.#", "6"),
 					resource.TestCheckResourceAttr("data.materialize_source.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_source.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_source.test_database_2", "sources.#", "4"),
@@ -50,25 +50,20 @@ func testAccDatasourceSource(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
-	resource "materialize_schema" "public_schema" {
-		name          = "public"
-		database_name = materialize_database.test.name
-	}
-
-	resource "materialize_schema" "public_schema2" {
-		name          = "public"
-		database_name = materialize_database.test_2.name
-	}
-
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
 	}
 
+	resource "materialize_schema" "test_2" {
+		name          = "%[1]s_2"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_source_load_generator" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -76,7 +71,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "b" {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -84,7 +79,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -92,7 +87,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -100,7 +95,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -117,6 +112,7 @@ func testAccDatasourceSource(nameSpace string) string {
 
 	data "materialize_source" "test_database" {
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.test.name
 		depends_on    = [
 			materialize_source_load_generator.a,
 			materialize_source_load_generator.b,

--- a/pkg/provider/acceptance_datasource_source_test.go
+++ b/pkg/provider/acceptance_datasource_source_test.go
@@ -91,6 +91,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -98,6 +99,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}

--- a/pkg/provider/acceptance_datasource_source_test.go
+++ b/pkg/provider/acceptance_datasource_source_test.go
@@ -68,6 +68,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.public_schema.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -75,7 +76,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "b" {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}
@@ -83,7 +84,7 @@ func testAccDatasourceSource(nameSpace string) string {
 	resource "materialize_source_load_generator" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 		cluster_name  = "quickstart"
 		load_generator_type = "COUNTER"
 	}

--- a/pkg/provider/acceptance_datasource_source_test.go
+++ b/pkg/provider/acceptance_datasource_source_test.go
@@ -50,6 +50,16 @@ func testAccDatasourceSource(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_table_test.go
+++ b/pkg/provider/acceptance_datasource_table_test.go
@@ -67,6 +67,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.public_schema.name
 		comment       = "some comment"
 
 		column {
@@ -79,7 +80,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "b" {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 		column {
 			name = "column_1"
 			type = "text"
@@ -89,7 +90,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 		comment       = "some comment"
 
 		column {
@@ -102,6 +103,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		column {
 			name = "column_1"
 			type = "text"
@@ -111,6 +113,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		column {
 			name = "column_1"
 			type = "text"

--- a/pkg/provider/acceptance_datasource_table_test.go
+++ b/pkg/provider/acceptance_datasource_table_test.go
@@ -24,7 +24,7 @@ func TestAccDatasourceTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_table.test_database", "tables.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_table.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_table.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_table.test_database_schema", "tables.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_table.test_database_schema", "tables.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_table.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_table.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_table.test_database_2", "tables.#", "2"),
@@ -49,25 +49,21 @@ func testAccDatasourceTable(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
-	resource "materialize_schema" "public_schema" {
-		name          = "public"
-		database_name = materialize_database.test.name
-	}
-
-	resource "materialize_schema" "public_schema2" {
-		name          = "public"
-		database_name = materialize_database.test_2.name
-	}
-
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
 	}
 
+	resource "materialize_schema" "test_2" {
+		name          = "%[1]s_2"
+		database_name = materialize_database.test_2.name
+	}
+
+
 	resource "materialize_table" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		comment       = "some comment"
 
 		column {
@@ -80,7 +76,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "b" {
 		name          = "%[1]s_b"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		column {
 			name = "column_1"
 			type = "text"
@@ -90,7 +86,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		comment       = "some comment"
 
 		column {
@@ -103,7 +99,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		column {
 			name = "column_1"
 			type = "text"
@@ -113,7 +109,7 @@ func testAccDatasourceTable(nameSpace string) string {
 	resource "materialize_table" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		column {
 			name = "column_1"
 			type = "text"

--- a/pkg/provider/acceptance_datasource_table_test.go
+++ b/pkg/provider/acceptance_datasource_table_test.go
@@ -49,6 +49,16 @@ func testAccDatasourceTable(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_type_test.go
+++ b/pkg/provider/acceptance_datasource_type_test.go
@@ -24,9 +24,9 @@ func TestAccDatasourceType_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_type.test_database", "types.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_type.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_type.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_type.test_database_schema", "types.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_type.test_database_schema", "types.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_type.test_database_2", "database_name", nameSpace+"_2"),
-					resource.TestCheckNoResourceAttr("data.materialize_type.test_database_2", "schema_name"),
+					resource.TestCheckResourceAttr("data.materialize_type.test_database_2", "schema_name", nameSpace+"_2"),
 					resource.TestCheckResourceAttr("data.materialize_type.test_database_2", "types.#", "2"),
 					resource.TestCheckNoResourceAttr("data.materialize_type.test_all", "database_name"),
 					resource.TestCheckNoResourceAttr("data.materialize_type.test_all", "schema_name"),
@@ -49,25 +49,20 @@ func testAccDatasourceType(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
-	resource "materialize_schema" "public_schema" {
-		name          = "public"
-		database_name = materialize_database.test.name
-	}
-
-	resource "materialize_schema" "public_schema2" {
-		name          = "public"
-		database_name = materialize_database.test_2.name
-	}
-
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
 	}
 
+	resource "materialize_schema" "test_2" {
+		name          = "%[1]s_2"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_type" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -85,7 +80,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
+		schema_name   = materialize_schema.test.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -94,7 +89,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -103,7 +98,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
-		schema_name   = materialize_schema.public_schema2.name
+		schema_name   = materialize_schema.test_2.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -144,6 +139,7 @@ func testAccDatasourceType(nameSpace string) string {
 
 	data "materialize_type" "test_database_2" {
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.test_2.name
 		depends_on = [
 			materialize_type.a,
 			materialize_type.b,

--- a/pkg/provider/acceptance_datasource_type_test.go
+++ b/pkg/provider/acceptance_datasource_type_test.go
@@ -67,6 +67,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.public_schema.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -84,7 +85,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "c" {
 		name          = "%[1]s_c"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.test.name
+		schema_name   = materialize_schema.public_schema.name
 		list_properties {
 			element_type = "int4"
   		}

--- a/pkg/provider/acceptance_datasource_type_test.go
+++ b/pkg/provider/acceptance_datasource_type_test.go
@@ -93,6 +93,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		list_properties {
 			element_type = "int4"
   		}
@@ -101,6 +102,7 @@ func testAccDatasourceType(nameSpace string) string {
 	resource "materialize_type" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
 		list_properties {
 			element_type = "int4"
   		}

--- a/pkg/provider/acceptance_datasource_type_test.go
+++ b/pkg/provider/acceptance_datasource_type_test.go
@@ -49,6 +49,16 @@ func testAccDatasourceType(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/provider/acceptance_datasource_view_test.go
+++ b/pkg/provider/acceptance_datasource_view_test.go
@@ -39,7 +39,7 @@ func TestAccDatasourceView_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.materialize_view.test_database", "views.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_view.test_database_schema", "database_name", nameSpace),
 					resource.TestCheckResourceAttr("data.materialize_view.test_database_schema", "schema_name", nameSpace),
-					resource.TestCheckResourceAttr("data.materialize_view.test_database_schema", "views.#", "2"),
+					resource.TestCheckResourceAttr("data.materialize_view.test_database_schema", "views.#", "3"),
 					resource.TestCheckResourceAttr("data.materialize_view.test_database_2", "database_name", nameSpace+"_2"),
 					resource.TestCheckNoResourceAttr("data.materialize_view.test_database_2", "schema_name"),
 					resource.TestCheckResourceAttr("data.materialize_view.test_database_2", "views.#", "2"),
@@ -77,7 +77,6 @@ func testAccDatasourceView(nameSpace string) string {
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
-		schema_name   = materialize_schema.public_schema.name
 	}
 
 	resource "materialize_view" "a" {

--- a/pkg/provider/acceptance_datasource_view_test.go
+++ b/pkg/provider/acceptance_datasource_view_test.go
@@ -77,11 +77,13 @@ func testAccDatasourceView(nameSpace string) string {
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.public_schema.name
 	}
 
 	resource "materialize_view" "a" {
 		name          = "%[1]s_a"
 		database_name = materialize_database.test.name
+		schema_name   = materialize_schema.test.name
   		statement = <<SQL
 			SELECT
     		1 AS id
@@ -111,6 +113,7 @@ func testAccDatasourceView(nameSpace string) string {
 	resource "materialize_view" "d" {
 		name          = "%[1]s_d"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
   		statement = <<SQL
 			SELECT
     		1 AS id
@@ -120,6 +123,7 @@ func testAccDatasourceView(nameSpace string) string {
 	resource "materialize_view" "e" {
 		name          = "%[1]s_e"
 		database_name = materialize_database.test_2.name
+		schema_name   = materialize_schema.public_schema2.name
   		statement = <<SQL
 			SELECT
     		1 AS id

--- a/pkg/provider/acceptance_datasource_view_test.go
+++ b/pkg/provider/acceptance_datasource_view_test.go
@@ -64,6 +64,16 @@ func testAccDatasourceView(nameSpace string) string {
 		name    = "%[1]s_2"
 	}
 
+	resource "materialize_schema" "public_schema" {
+		name          = "public"
+		database_name = materialize_database.test.name
+	}
+
+	resource "materialize_schema" "public_schema2" {
+		name          = "public"
+		database_name = materialize_database.test_2.name
+	}
+
 	resource "materialize_schema" "test" {
 		name          = "%[1]s"
 		database_name = materialize_database.test.name

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -13,13 +13,7 @@ import (
 )
 
 var databaseSchema = map[string]*schema.Schema{
-	"name": ObjectNameSchema("database", true, true),
-	"no_public_schema": {
-		Description: "When set to true, the default 'public' schema will be dropped from the database.",
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-	},
+	"name":           ObjectNameSchema("database", true, true),
 	"comment":        CommentSchema(false),
 	"ownership_role": OwnershipRoleSchema(),
 	"region":         RegionSchema(),
@@ -91,10 +85,9 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 
-	if d.Get("no_public_schema").(bool) {
-		if err := b.DropPublicSchema(); err != nil {
-			return diag.FromErr(err)
-		}
+	// drop public schema by default
+	if err := b.DropPublicSchema(); err != nil {
+		return diag.FromErr(err)
 	}
 
 	// ownership
@@ -153,15 +146,6 @@ func databaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{
 
 		if err := b.Object(newComment.(string)); err != nil {
 			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("no_public_schema") {
-		b := materialize.NewDatabaseBuilder(metaDb, o)
-		if _, newNoPublicSchema := d.GetChange("no_public_schema"); newNoPublicSchema.(bool) {
-			if err := b.DropPublicSchema(); err != nil {
-				return diag.FromErr(err)
-			}
 		}
 	}
 

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -21,7 +21,9 @@ var databaseSchema = map[string]*schema.Schema{
 
 func Database() *schema.Resource {
 	return &schema.Resource{
-		Description: "The highest level namespace hierarchy in Materialize.",
+		Description: "The highest level namespace hierarchy in Materialize.\n\n" +
+			"**Note**: This resource will not automatically create a public schema." +
+			"If needed, the public schema must be explicitly defined in your configuration using the `materialize_schema` resource.",
 
 		CreateContext: databaseCreate,
 		ReadContext:   databaseRead,

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -13,7 +13,13 @@ import (
 )
 
 var databaseSchema = map[string]*schema.Schema{
-	"name":           ObjectNameSchema("database", true, true),
+	"name": ObjectNameSchema("database", true, true),
+	"no_public_schema": {
+		Description: "When set to true, the default 'public' schema will be dropped from the database.",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+	},
 	"comment":        CommentSchema(false),
 	"ownership_role": OwnershipRoleSchema(),
 	"region":         RegionSchema(),
@@ -85,6 +91,12 @@ func databaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 
+	if d.Get("no_public_schema").(bool) {
+		if err := b.DropPublicSchema(); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	// ownership
 	if v, ok := d.GetOk("ownership_role"); ok {
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
@@ -141,6 +153,15 @@ func databaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{
 
 		if err := b.Object(newComment.(string)); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("no_public_schema") {
+		b := materialize.NewDatabaseBuilder(metaDb, o)
+		if _, newNoPublicSchema := d.GetChange("no_public_schema"); newNoPublicSchema.(bool) {
+			if err := b.DropPublicSchema(); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 

--- a/pkg/resources/resource_database_test.go
+++ b/pkg/resources/resource_database_test.go
@@ -27,6 +27,9 @@ func TestResourceDatabaseCreate(t *testing.T) {
 			`CREATE DATABASE "database";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
+		// Drop public schema
+		mock.ExpectExec(`DROP SCHEMA IF EXISTS "database"."public";`).WillReturnResult(sqlmock.NewResult(1, 1))
+
 		// Query Id
 		ip := `WHERE mz_databases.name = 'database'`
 		testhelpers.MockDatabaseScan(mock, ip)


### PR DESCRIPTION
As per the discussion here https://github.com/MaterializeInc/terraform-provider-materialize/issues/284 

Closes #284

---

## Migration Guide: Handling Public Schemas with Terraform in Materialize

With the latest update to our Terraform provider for Materialize, the automatic creation of a public schema within new databases has been removed. This change aligns more closely with common infrastructure-as-code practices, providing users with more control over schema management and security settings. 

Here is a quick guide that will walk you through the necessary steps to manually create and configure a public schema if you need its presence.

### Changes in Behavior
Prior to this update, Materialize would automatically create a public schema in each new database, matching traditional SQL database behaviors. However, with the new version of the Terraform provider, this is no longer the case. You now need to explicitly define and manage the public schemas within your Terraform configuration.

### Step-by-Step Migration

#### 1. Update Your Terraform Configuration

Existing databases will not be affected, the change only affects newly created databases using the `materialize_database` resource.

If your databases rely on the public schema, you will need to add a few lines to your Terraform configuration to manually create this schema and set the necessary permissions. Below is an example configuration that illustrates these changes:

```hcl
# Create a Materialize database without a public schema
resource "materialize_database" "example" {
  name = "example"
}

# Optionally create a public schema in the database
resource "materialize_schema" "public" {
  name          = "public"
  database_name = materialize_database.example.name
}

# Grant USAGE to the PUBLIC pseudo-role for the public schema
# This matches the default behavior of Materialize
resource "materialize_schema_grant" "schema_grant_usage" {
  role_name     = "PUBLIC"
  privilege     = "USAGE"
  database_name = materialize_database.example.name
  schema_name   = materialize_schema.public.name
}
```

#### 2. Apply Configuration Changes
After updating your configuration files, run `terraform apply` to apply the changes. Ensure that you review the plan before applying to avoid unintended modifications to your infrastructure.

#### 3. Integrating the Public Schema with Other Resources

Once the public schema is successfully created and configured, you can integrate it with other resources within your Materialize environment by referencing the schema name and database name:


```hcl
resource "materialize_connection_ssh_tunnel" "ssh_connection" {
  name          = "ssh_connection"
  database_name = materialize_database.example.name
  schema_name   = materialize_schema.public.name
  comment       = "Connection through SSH tunnel for secure data transfer"

  host = "ssh_host"
  user = "ssh_user"
  port = 22

  validate = false
}
```

#### 4.  Importing Existing Schemas and Grants

If you have existing public schemas that were automatically created in previous versions, and if you need to manage them in your Terraform project, you'll need to first import these resources into your new Terraform configuration to manage them effectively.

Start by first defining the resources in your project, and then:

- For schemas, you can import them into your Terraform state using the following command:

    ```shell
    terraform import materialize_schema.example_schema <region>:<schema_id>
    ```

    Here, `<region>` is the region where your database is located (e.g., `aws/us-east-1`), and `<schema_id>` is the unique identifier for the schema, which you can find in the `mz_catalog.mz_schemas` table.

- For schema grants, use the following format to ensure that existing permissions are accurately represented in your Terraform state:

    ```shell
    terraform import materialize_schema_grant.example_grant <region>:GRANT|SCHEMA|<schema_id>|<role_id>|<privilege>
    ```

This update to the Materialize Terraform provider aims for a more explicit and controlled configuration approach in database schema management.
