### PR TITLE
Check for nil values in GetSliceValueString

### DIFF
--- a/pkg/materialize/utils.go
+++ b/pkg/materialize/utils.go
@@ -26,7 +26,12 @@ func QualifiedName(fields ...string) string {
 func GetSliceValueString(v []interface{}) []string {
 	var o []string
 	for _, i := range v {
-		o = append(o, i.(string))
+		if i != nil {
+			str, ok := i.(string)
+			if ok {
+				o = append(o, str)
+			}
+		}
 	}
 	return o
 }

--- a/pkg/materialize/utils.go
+++ b/pkg/materialize/utils.go
@@ -1,6 +1,7 @@
 package materialize
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -23,17 +24,16 @@ func QualifiedName(fields ...string) string {
 	return q
 }
 
-func GetSliceValueString(v []interface{}) []string {
+func GetSliceValueString(attrName string, v []interface{}) ([]string, error) {
 	var o []string
-	for _, i := range v {
-		if i != nil {
-			str, ok := i.(string)
-			if ok {
-				o = append(o, str)
-			}
+	for _, item := range v {
+		str, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("value %v of attribute %s cannot be converted to string", item, attrName)
 		}
+		o = append(o, str)
 	}
-	return o
+	return o, nil
 }
 
 func GetSliceValueInt(v []interface{}) []int {

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -166,10 +166,11 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 
 		if v, ok := d.GetOk("availability_zones"); ok && len(v.([]interface{})) > 0 {
-			f := materialize.GetSliceValueString(v.([]interface{}))
-			if len(f) > 0 {
-				b.AvailabilityZones(f)
+			f, err := materialize.GetSliceValueString("availability_zones", v.([]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
 			}
+			b.AvailabilityZones(f)
 		}
 
 		if v, ok := d.GetOk("introspection_interval"); ok {
@@ -272,7 +273,10 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if d.HasChange("availability_zones") {
 			_, n := d.GetChange("availability_zones")
-			azs := materialize.GetSliceValueString(n.([]interface{}))
+			azs, err := materialize.GetSliceValueString("availability_zones", n.([]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			b := materialize.NewClusterBuilder(metaDb, o)
 			if err := b.SetAvailabilityZones(azs); err != nil {
 				return diag.FromErr(err)

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -165,9 +165,11 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 			}
 		}
 
-		if v, ok := d.GetOk("availability_zones"); ok {
+		if v, ok := d.GetOk("availability_zones"); ok && len(v.([]interface{})) > 0 {
 			f := materialize.GetSliceValueString(v.([]interface{}))
-			b.AvailabilityZones(f)
+			if len(f) > 0 {
+				b.AvailabilityZones(f)
+			}
 		}
 
 		if v, ok := d.GetOk("introspection_interval"); ok {

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -124,9 +124,11 @@ func connectionAwsPrivatelinkCreate(ctx context.Context, d *schema.ResourceData,
 		b.PrivateLinkServiceName(v.(string))
 	}
 
-	if v, ok := d.GetOk("availability_zones"); ok {
+	if v, ok := d.GetOk("availability_zones"); ok && len(v.([]interface{})) > 0 {
 		azs := materialize.GetSliceValueString(v.([]interface{}))
-		b.PrivateLinkAvailabilityZones(azs)
+		if len(azs) > 0 {
+			b.PrivateLinkAvailabilityZones(azs)
+		}
 	}
 
 	if v, ok := d.GetOk("validate"); ok {

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -135,10 +135,11 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("not_null_assertion"); ok && len(v.([]interface{})) > 0 {
-		nas := materialize.GetSliceValueString(v.([]interface{}))
-		if len(nas) > 0 {
-			b.NotNullAssertions(nas)
+		nas, err := materialize.GetSliceValueString("not_null_assertion", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.NotNullAssertions(nas)
 	}
 
 	if v, ok := d.GetOk("statement"); ok && v.(string) != "" {

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -134,9 +134,11 @@ func materializedViewCreate(ctx context.Context, d *schema.ResourceData, meta in
 		b.ClusterName(v.(string))
 	}
 
-	if v, ok := d.GetOk("not_null_assertion"); ok {
+	if v, ok := d.GetOk("not_null_assertion"); ok && len(v.([]interface{})) > 0 {
 		nas := materialize.GetSliceValueString(v.([]interface{}))
-		b.NotNullAssertions(nas)
+		if len(nas) > 0 {
+			b.NotNullAssertions(nas)
+		}
 	}
 
 	if v, ok := d.GetOk("statement"); ok && v.(string) != "" {

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -148,10 +148,11 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 	}
 
 	if v, ok := d.GetOk("key"); ok && len(v.([]interface{})) > 0 {
-		keys := materialize.GetSliceValueString(v.([]interface{}))
-		if len(keys) > 0 {
-			b.Key(keys)
+		keys, err := materialize.GetSliceValueString("key", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.Key(keys)
 	}
 
 	if v, ok := d.GetOk("key_not_enforced"); ok {

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -147,9 +147,11 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 		b.CompressionType(v.(string))
 	}
 
-	if v, ok := d.GetOk("key"); ok {
+	if v, ok := d.GetOk("key"); ok && len(v.([]interface{})) > 0 {
 		keys := materialize.GetSliceValueString(v.([]interface{}))
-		b.Key(keys)
+		if len(keys) > 0 {
+			b.Key(keys)
+		}
 	}
 
 	if v, ok := d.GetOk("key_not_enforced"); ok {

--- a/pkg/resources/resource_source_mysql.go
+++ b/pkg/resources/resource_source_mysql.go
@@ -108,14 +108,18 @@ func sourceMySQLCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 		b.Tables(t)
 	}
 
-	if v, ok := d.GetOk("ignore_columns"); ok {
+	if v, ok := d.GetOk("ignore_columns"); ok && len(v.([]interface{})) > 0 {
 		columns := materialize.GetSliceValueString(v.([]interface{}))
-		b.IgnoreColumns(columns)
+		if len(columns) > 0 {
+			b.IgnoreColumns(columns)
+		}
 	}
 
-	if v, ok := d.GetOk("text_columns"); ok {
+	if v, ok := d.GetOk("text_columns"); ok && len(v.([]interface{})) > 0 {
 		columns := materialize.GetSliceValueString(v.([]interface{}))
-		b.TextColumns(columns)
+		if len(columns) > 0 {
+			b.TextColumns(columns)
+		}
 	}
 
 	if err := b.Create(); err != nil {

--- a/pkg/resources/resource_source_mysql.go
+++ b/pkg/resources/resource_source_mysql.go
@@ -109,17 +109,19 @@ func sourceMySQLCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	if v, ok := d.GetOk("ignore_columns"); ok && len(v.([]interface{})) > 0 {
-		columns := materialize.GetSliceValueString(v.([]interface{}))
-		if len(columns) > 0 {
-			b.IgnoreColumns(columns)
+		columns, err := materialize.GetSliceValueString("ignore_columns", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.IgnoreColumns(columns)
 	}
 
 	if v, ok := d.GetOk("text_columns"); ok && len(v.([]interface{})) > 0 {
-		columns := materialize.GetSliceValueString(v.([]interface{}))
-		if len(columns) > 0 {
-			b.TextColumns(columns)
+		columns, err := materialize.GetSliceValueString("text_columns", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.TextColumns(columns)
 	}
 
 	if err := b.Create(); err != nil {

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -125,9 +125,11 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		b.Table(tables)
 	}
 
-	if v, ok := d.GetOk("schema"); ok {
+	if v, ok := d.GetOk("schema"); ok && len(v.([]interface{})) > 0 {
 		schemas := materialize.GetSliceValueString(v.([]interface{}))
-		b.Schema(schemas)
+		if len(schemas) > 0 {
+			b.Schema(schemas)
+		}
 	}
 
 	if v, ok := d.GetOk("expose_progress"); ok {
@@ -135,9 +137,11 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		b.ExposeProgress(e)
 	}
 
-	if v, ok := d.GetOk("text_columns"); ok {
+	if v, ok := d.GetOk("text_columns"); ok && len(v.([]interface{})) > 0 {
 		columns := materialize.GetSliceValueString(v.([]interface{}))
-		b.TextColumns(columns)
+		if len(columns) > 0 {
+			b.TextColumns(columns)
+		}
 	}
 
 	// create resource

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -126,10 +126,12 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if v, ok := d.GetOk("schema"); ok && len(v.([]interface{})) > 0 {
-		schemas := materialize.GetSliceValueString(v.([]interface{}))
-		if len(schemas) > 0 {
-			b.Schema(schemas)
+		schemas, err := materialize.GetSliceValueString("schema", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.Schema(schemas)
+
 	}
 
 	if v, ok := d.GetOk("expose_progress"); ok {
@@ -138,10 +140,11 @@ func sourcePostgresCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if v, ok := d.GetOk("text_columns"); ok && len(v.([]interface{})) > 0 {
-		columns := materialize.GetSliceValueString(v.([]interface{}))
-		if len(columns) > 0 {
-			b.TextColumns(columns)
+		columns, err := materialize.GetSliceValueString("text_columns", v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
 		}
+		b.TextColumns(columns)
 	}
 
 	// create resource

--- a/pkg/resources/resource_source_webhook.go
+++ b/pkg/resources/resource_source_webhook.go
@@ -214,12 +214,18 @@ func sourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if v, ok := u["only"]; ok {
-			o := materialize.GetSliceValueString(v.([]interface{}))
+			o, err := materialize.GetSliceValueString("only", v.([]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			i.Only = o
 		}
 
 		if v, ok := u["not"]; ok {
-			n := materialize.GetSliceValueString(v.([]interface{}))
+			n, err := materialize.GetSliceValueString("not", v.([]interface{}))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			i.Not = n
 		}
 		b.IncludeHeaders(i)


### PR DESCRIPTION
As reported internally, this fixes a panic when a nil value is passed to `GetSliceValueString`.

Closes #555

```
panic: interface conversion: interface {} is nil, not string
```