### PR TITLE
Update region attribute to computed

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -538,5 +538,6 @@ func RegionSchema() *schema.Schema {
 		Type:        schema.TypeString,
 		Optional:    true,
 		ForceNew:    true,
+		Computed:    true,
 	}
 }

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -65,6 +65,10 @@ func GetDBClientFromMeta(meta interface{}, d *schema.ResourceData) (*sqlx.DB, cl
 		region = providerMeta.DefaultRegion
 	}
 
+	if d != nil {
+		d.Set("region", string(region))
+	}
+
 	// Check if the region is enabled using the stored information
 	enabled, exists := providerMeta.RegionsEnabled[region]
 	if !exists {


### PR DESCRIPTION
Adding a computed property to the region resource, so that the region property will be updated in the state file on read.

With the old version, when importing a resource from a non-default region, it would work as expected in the following case, eg:

- Definition:
```hcl
resource "materialize_database" "example" {
  name = "example"
}
```

- Import command
```
terraform import materialize_database.example aws/eu-west-1:u3  
```

However, in the past we did not update the region attribute in the state file, so if you were to then define the region, even though the region did not change, we would still force a replacement:

```hcl
  # materialize_database.example_us must be replaced
-/+ resource "materialize_database" "example_us" {
      ~ id             = "aws/us-east-1:u25" -> (known after apply)
        name           = "example_us"
      ~ ownership_role = "bobby@materialize.com" -> (known after apply)
      + region         = "aws/us-east-1" # forces replacement
    }
```

With the current change, we will have the region attribute computed during read, so if a user was to set the region property to their existing region, it would not force a replacement unless the region is different.