### PR TITLE
Fix Kafka connection rename race condition

### DIFF
--- a/docs/data-sources/scim_groups.md
+++ b/docs/data-sources/scim_groups.md
@@ -38,7 +38,7 @@ Read-Only:
 - `users` (List of Object) (see [below for nested schema](#nestedobjatt--groups--users))
 
 <a id="nestedobjatt--groups--roles"></a>
-### Nested Schema for ``
+### Nested Schema for `groups.roles`
 
 Read-Only:
 
@@ -50,7 +50,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--groups--users"></a>
-### Nested Schema for ``
+### Nested Schema for `groups.users`
 
 Read-Only:
 

--- a/docs/data-sources/sso_config.md
+++ b/docs/data-sources/sso_config.md
@@ -46,7 +46,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--sso_configs--domains"></a>
-### Nested Schema for ``
+### Nested Schema for `sso_configs.domains`
 
 Read-Only:
 
@@ -56,7 +56,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--sso_configs--groups"></a>
-### Nested Schema for ``
+### Nested Schema for `sso_configs.groups`
 
 Read-Only:
 

--- a/pkg/resources/resource_connection_kafka.go
+++ b/pkg/resources/resource_connection_kafka.go
@@ -285,6 +285,15 @@ func connectionKafkaUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		resetOptions = append(resetOptions, option)
 	}
 
+	if d.HasChange("name") {
+		oldName, newName := d.GetChange("name")
+		o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
+		b := materialize.NewConnection(metaDb, o)
+		if err := b.Rename(newName.(string)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("kafka_broker") {
 		_, newBrokers := d.GetChange("kafka_broker")
 		kafkaBrokers := materialize.GetKafkaBrokersStruct(newBrokers)
@@ -420,15 +429,6 @@ func connectionKafkaUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				d.Set("ssh_tunnel", oldTunnel)
 				return diag.FromErr(err)
 			}
-		}
-	}
-
-	if d.HasChange("name") {
-		oldName, newName := d.GetChange("name")
-		o := materialize.MaterializeObject{ObjectType: "CONNECTION", Name: oldName.(string), SchemaName: schemaName, DatabaseName: databaseName}
-		b := materialize.NewConnection(metaDb, o)
-		if err := b.Rename(newName.(string)); err != nil {
-			return diag.FromErr(err)
 		}
 	}
 


### PR DESCRIPTION
Moving the Kafka connection rename statement to be executed first in order to prevent a race condition when updating multiple parameters at once.