### PR TITLE
Allow skipping activation emails when creating users

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -27,6 +27,10 @@ resource "materialize_user" "example_user" {
 - `email` (String) The email address of the user. This must be unique across all users in the organization.
 - `roles` (List of String) The roles to assign to the user. Allowed values are 'Member' and 'Admin'.
 
+### Optional
+
+- `send_activation_email` (Boolean) Whether to send an email either inviting the user to activate their account, if the user is new, or inviting the user to join the organization, if the user already exists in another organization. Changing this property after the resource is created has no effect.
+
 ### Read-Only
 
 - `auth_provider` (String) The authentication provider for the user.

--- a/mocks/frontegg/mock_server.go
+++ b/mocks/frontegg/mock_server.go
@@ -215,7 +215,8 @@ func getUser(w http.ResponseWriter, r *http.Request) {
 func createUser(w http.ResponseWriter, r *http.Request) {
 	var newUser struct {
 		User
-		RoleIDs []string `json:"roleIds"`
+		RoleIDs         []string `json:"roleIds"`
+		SkipInviteEmail bool     `json:"skipInviteEmail"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&newUser); err != nil {

--- a/pkg/frontegg/user.go
+++ b/pkg/frontegg/user.go
@@ -16,8 +16,9 @@ const (
 
 // UserRequest represents the request payload for creating or updating a user.
 type UserRequest struct {
-	Email   string   `json:"email"`
-	RoleIDs []string `json:"roleIds"`
+	Email           string   `json:"email"`
+	RoleIDs         []string `json:"roleIds"`
+	SkipInviteEmail bool     `json:"skipInviteEmail"`
 }
 
 type UserRole struct {

--- a/pkg/provider/acceptance_user_test.go
+++ b/pkg/provider/acceptance_user_test.go
@@ -20,10 +20,11 @@ func TestAccUser_basic(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig(email, "Member"),
+				Config: testAccUserConfig(email, false, "Member"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("materialize_user.example_user", email),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "email", email),
+					resource.TestCheckResourceAttr("materialize_user.example_user", "send_activation_email", "false"),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "roles.0", "Member"),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "verified", "false"),
 				),
@@ -40,7 +41,7 @@ func TestAccUser_disappears(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig(email, "Member"),
+				Config: testAccUserConfig(email, true, "Member"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("materialize_user.example_user", email),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "email", email),
@@ -62,7 +63,7 @@ func TestAccUser_updateRole(t *testing.T) {
 		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfig(email, "Member"),
+				Config: testAccUserConfig(email, true, "Member"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("materialize_user.example_user", email),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "email", email),
@@ -71,7 +72,7 @@ func TestAccUser_updateRole(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccUserConfig(email, "Admin"),
+				Config: testAccUserConfig(email, true, "Admin"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("materialize_user.example_user", email),
 					resource.TestCheckResourceAttr("materialize_user.example_user", "roles.0", "Admin"),
@@ -81,13 +82,14 @@ func TestAccUser_updateRole(t *testing.T) {
 	})
 }
 
-func testAccUserConfig(email, role string) string {
+func testAccUserConfig(email string, sendActivationEmail bool, role string) string {
 	return fmt.Sprintf(`
 resource "materialize_user" "example_user" {
   email = "%s"
+  send_activation_email = %v
   roles = ["%s"]
 }
-`, email, role)
+`, email, sendActivationEmail, role)
 }
 
 func testAccCheckUserExists(resourceName, email string) resource.TestCheckFunc {


### PR DESCRIPTION
This is useful for customers who need to create service accounts and don't have a dedicated email address for such accounts.

This is a partial solution to #20894.