### PR TITLE
Define goreleaser version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
+version: 2
+
 # behavior.
 before:
   hooks:


### PR DESCRIPTION
Fix failing release workflow:

```
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.0.1
/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/a292df80-44b9-44c0-8[14](https://github.com/MaterializeInc/terraform-provider-materialize/actions/runs/9594014319/job/26455681352#step:6:15)1-b20a5ade2227 -f /home/runner/work/_temp/6197fc64-cc86-41d2-902e-a60c2c48d08c
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser release --clean
  • starting release...
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.1/x64/goreleaser' failed with exit code 1
```