### PR TITLE
goreleaser: change changelog.skip to disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,4 +59,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
As per the goreleaser documentation:

### changelog.skip

> since 2024-01-14 (v1.24), removed 2024-05-26 (v2.0)

Changed to `disable` to conform with all other pipes.

=== "Before"

    ```yaml
    changelog:
      skip: true
    ```

=== "After"

    ```yaml
    changelog:
      disable: true
    ```