### PR TITLE
Change REHYDRATION TIME ESTIMATE to HYDRATION TIME ESTIMATE

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -55,7 +55,8 @@ Optional:
 Optional:
 
 - `enabled` (Boolean) Enable scheduling to refresh the cluster.
-- `rehydration_time_estimate` (String) Estimated time to rehydrate the cluster during refresh.
+- `hydration_time_estimate` (String) Estimated time to hydrate the cluster during refresh.
+- `rehydration_time_estimate` (String, Deprecated) Estimated time to rehydrate the cluster during refresh.
 
 ## Import
 

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -18,8 +18,8 @@ resource "materialize_cluster" "scheduling_cluster" {
   size = "25cc"
   scheduling {
     on_refresh {
-      enabled                   = true
-      rehydration_time_estimate = "1 hour"
+      enabled                 = true
+      hydration_time_estimate = "1 hour"
     }
   }
 }

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -101,7 +101,7 @@ func TestClusterDrop(t *testing.T) {
 
 func TestClusterWithSchedulingCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
-		expectedSQL := `CREATE CLUSTER "cluster" SIZE 'xsmall', SCHEDULE = ON REFRESH \(REHYDRATION TIME ESTIMATE = '2 hours'\);`
+		expectedSQL := `CREATE CLUSTER "cluster" SIZE 'xsmall', SCHEDULE = ON REFRESH \(HYDRATION TIME ESTIMATE = '2 hours'\);`
 		mock.ExpectExec(expectedSQL).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "cluster"}
@@ -112,8 +112,8 @@ func TestClusterWithSchedulingCreate(t *testing.T) {
 			map[string]interface{}{
 				"on_refresh": []interface{}{
 					map[string]interface{}{
-						"enabled":                   true,
-						"rehydration_time_estimate": "2 hours",
+						"enabled":                 true,
+						"hydration_time_estimate": "2 hours",
 					},
 				},
 			},

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -286,7 +286,7 @@ func TestAccClusterWithScheduling(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "name", clusterName),
 					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "size", size),
 					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh.0.enabled", "true"),
-					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh.0.rehydration_time_estimate", rehydrationTimeEstimate),
+					resource.TestCheckResourceAttr("materialize_cluster.test_scheduling", "scheduling.0.on_refresh.0.hydration_time_estimate", rehydrationTimeEstimate),
 				),
 			},
 		},
@@ -429,7 +429,7 @@ resource "materialize_cluster" "test_scheduling" {
     scheduling {
         on_refresh {
 			enabled = %s
-			rehydration_time_estimate = "%s"
+			hydration_time_estimate = "%s"
 		}
     }
 }

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -57,10 +57,16 @@ var clusterSchema = map[string]*schema.Schema{
 								Optional:    true,
 								Description: "Enable scheduling to refresh the cluster.",
 							},
+							"hydration_time_estimate": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Estimated time to hydrate the cluster during refresh.",
+							},
 							"rehydration_time_estimate": {
 								Type:        schema.TypeString,
 								Optional:    true,
 								Description: "Estimated time to rehydrate the cluster during refresh.",
+								Deprecated:  "This field is deprecated and will be removed in a future release. Use `hydration_time_estimate` instead.",
 							},
 						},
 					},

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -23,8 +23,8 @@ var inCluster = map[string]interface{}{
 		map[string]interface{}{
 			"on_refresh": []interface{}{
 				map[string]interface{}{
-					"enabled":                   true,
-					"rehydration_time_estimate": "2 hours",
+					"enabled":                 true,
+					"hydration_time_estimate": "2 hours",
 				},
 			},
 		},
@@ -47,7 +47,7 @@ func TestResourceClusterCreate(t *testing.T) {
 			AVAILABILITY ZONES = \['use1-az1','use1-az2'\],
 			INTROSPECTION INTERVAL = '10s',
 			INTROSPECTION DEBUGGING = TRUE,
-			SCHEDULE = ON REFRESH \(REHYDRATION TIME ESTIMATE = '2 hours'\);
+			SCHEDULE = ON REFRESH \(HYDRATION TIME ESTIMATE = '2 hours'\);
 		`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Ownership


### PR DESCRIPTION
Fixes #601 

As per @ggevay'scomment `REHYDRATION TIME ESTIMATE` will still be accepted by the parser so I am marking the `rehydration_time_estimate` as deprecated and will remove it once the parser no longer accepts it:
> This changes the REHYDRATION TIME ESTIMATE cluster option to HYDRATION TIME ESTIMATE. The parser still accepts the old version. Eventually, the old version will be completely removed, once users move to the new version. 