### PR TITLE
Fix CI intermittent failing tests

### DIFF
--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -429,12 +429,12 @@ func TestSinkKafkaTopicOptionsWithCompressionCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			`CREATE SINK "database"."schema"."sink"
-            FROM "database"."schema"."src"
-            INTO KAFKA CONNECTION "database"."schema"."kafka_conn"
-            \(TOPIC 'testdrive-snk1-seed', COMPRESSION TYPE = gzip, TOPIC REPLICATION FACTOR = 3, TOPIC PARTITION COUNT = 6,
-            TOPIC CONFIG MAP\['cleanup.policy' => 'compact', 'retention.ms' => '86400000'\]\)
-            FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."csr_conn"
-            ENVELOPE DEBEZIUM;`,
+			FROM "database"."schema"."src"
+			INTO KAFKA CONNECTION "database"."schema"."kafka_conn"
+			\(TOPIC 'testdrive-snk1-seed', COMPRESSION TYPE = gzip, TOPIC REPLICATION FACTOR = 3, TOPIC PARTITION COUNT = 6,
+			TOPIC CONFIG MAP\[.*?'cleanup\.policy' => 'compact'.*?'retention\.ms' => '86400000'.*?\]\)
+			FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."csr_conn"
+			ENVELOPE DEBEZIUM;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "sink", SchemaName: "schema", DatabaseName: "database"}

--- a/pkg/resources/resource_connection_aws_test.go
+++ b/pkg/resources/resource_connection_aws_test.go
@@ -93,7 +93,7 @@ func TestResourceConnectionAwsUpdate(t *testing.T) {
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(ACCESS KEY ID = 'foo'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(SECRET ACCESS KEY = SECRET "materialize"."public"."conn_secret"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(SESSION TOKEN = SECRET "materialize"."public"."conn_session"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(ASSUME ROLE ARN = 'arn:aws:iam::123456789012:role/role'\), SET \(ASSUME ROLE SESSION NAME = 'session'\);`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \((ASSUME ROLE ARN = 'arn:aws:iam::123456789012:role/role'\), SET \(ASSUME ROLE SESSION NAME = 'session'|ASSUME ROLE SESSION NAME = 'session'\), SET \(ASSUME ROLE ARN = 'arn:aws:iam::123456789012:role/role')\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Params
 		pp := `WHERE mz_connections.id = 'u1'`

--- a/pkg/resources/resource_connection_confluent_schema_registry_test.go
+++ b/pkg/resources/resource_connection_confluent_schema_registry_test.go
@@ -86,7 +86,7 @@ func TestResourceConnectionConfluentSchemaRegistryUpdate(t *testing.T) {
 
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(SSL CERTIFICATE AUTHORITY = SECRET "materialize"."public"."ssl"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \(SSL CERTIFICATE = SECRET "materialize"."public"."ssl"\), SET \(SSL KEY = SECRET "ssl_key"."public"."ssl"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."old_conn" SET \((SSL CERTIFICATE = SECRET "materialize"."public"."ssl"\), SET \(SSL KEY = SECRET "ssl_key"."public"."ssl"|SSL KEY = SECRET "ssl_key"."public"."ssl"\), SET \(SSL CERTIFICATE = SECRET "materialize"."public"."ssl")\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Comment
 		mock.ExpectExec(`COMMENT ON CONNECTION "database"."schema"."old_conn" IS 'object comment';`).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/resources/resource_connection_mysql_test.go
+++ b/pkg/resources/resource_connection_mysql_test.go
@@ -101,7 +101,7 @@ func TestResourceConnectionMySQLUpdate(t *testing.T) {
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL CERTIFICATE AUTHORITY = SECRET "ssl_database"."public"."root"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// SSL Certificate and Key
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL CERTIFICATE = SECRET "materialize"."public"."cert"\), SET \(SSL KEY = SECRET "materialize"."public"."key"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \((?:SSL CERTIFICATE|SSL KEY) = SECRET "materialize"."public"."(?:cert|key)"\), SET \((?:SSL CERTIFICATE|SSL KEY) = SECRET "materialize"."public"."(?:cert|key)"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// SSL Mode
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL MODE = 'verify-ca'\);`).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/resources/resource_connection_postgres_test.go
+++ b/pkg/resources/resource_connection_postgres_test.go
@@ -106,7 +106,7 @@ func TestResourceConnectionPostgresUpdate(t *testing.T) {
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL CERTIFICATE AUTHORITY = SECRET "ssl_database"."public"."root"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// SSL Certificate and Key
-		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL CERTIFICATE = SECRET "materialize"."public"."cert"\), SET \(SSL KEY = SECRET "materialize"."public"."key"\);`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \((SSL CERTIFICATE = SECRET "materialize"."public"."cert"\), SET \(SSL KEY = SECRET "materialize"."public"."key"|SSL KEY = SECRET "materialize"."public"."key"\), SET \(SSL CERTIFICATE = SECRET "materialize"."public"."cert")\);`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// SSL Mode
 		mock.ExpectExec(`ALTER CONNECTION "database"."schema"."conn" SET \(SSL MODE = 'verify-full'\);`).WillReturnResult(sqlmock.NewResult(1, 1))


### PR DESCRIPTION
The unit tests for the update connection resources have been intermittently failing due to the order of the key and SSL certificate in the update statement.

As a fix, this PR adds a regex which will match both of these patterns:

- `SET (SSL CERTIFICATE = ...), SET (SSL KEY = ...)`
- `SET (SSL KEY = ...), SET (SSL CERTIFICATE = ...)`

That way the tests will pass even if the query builder generates the alter statement with the Key first and the Certificate second and vice versa.

Fixes #599