### PR TITLE
Add support for AWS IAM authentication in Kafka connections

### DIFF
--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -80,6 +80,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 ### Optional
 
+- `aws_connection` (Block List, Max: 1) The AWS connection to use for IAM authentication. (see [below for nested schema](#nestedblock--aws_connection))
 - `aws_privatelink` (Block List, Max: 1) AWS PrivateLink configuration. Conflicts with `kafka_broker`. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) **Public Preview** Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
@@ -103,6 +104,19 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 
 - `id` (String) The ID of this resource.
 - `qualified_sql_name` (String) The fully qualified name of the connection.
+
+<a id="nestedblock--aws_connection"></a>
+### Nested Schema for `aws_connection`
+
+Required:
+
+- `name` (String) The aws_connection name.
+
+Optional:
+
+- `database_name` (String) The aws_connection database name. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
+- `schema_name` (String) The aws_connection schema name. Defaults to `public`.
+
 
 <a id="nestedblock--aws_privatelink"></a>
 ### Nested Schema for `aws_privatelink`

--- a/pkg/materialize/connection_kafka.go
+++ b/pkg/materialize/connection_kafka.go
@@ -79,6 +79,7 @@ type ConnectionKafkaBuilder struct {
 	kafkaSSHTunnel                      IdentifierSchemaStruct
 	validate                            bool
 	awsPrivateLinkConnection            awsPrivateLinkConnection
+	awsConnection                       IdentifierSchemaStruct
 }
 
 func NewConnectionKafkaBuilder(conn *sqlx.DB, obj MaterializeObject) *ConnectionKafkaBuilder {
@@ -95,6 +96,11 @@ func (b *ConnectionKafkaBuilder) KafkaBrokers(kafkaBrokers []KafkaBroker) *Conne
 
 func (b *ConnectionKafkaBuilder) KafkaAwsPrivateLink(privatelink awsPrivateLinkConnection) *ConnectionKafkaBuilder {
 	b.awsPrivateLinkConnection = privatelink
+	return b
+}
+
+func (b *ConnectionKafkaBuilder) AwsConnection(awsConnection IdentifierSchemaStruct) *ConnectionKafkaBuilder {
+	b.awsConnection = awsConnection
 	return b
 }
 
@@ -212,6 +218,10 @@ func (b *ConnectionKafkaBuilder) Create() error {
 	}
 	if b.kafkaSASLPassword.Name != "" {
 		q.WriteString(fmt.Sprintf(`, SASL PASSWORD = SECRET %s`, b.kafkaSASLPassword.QualifiedName()))
+	}
+
+	if b.awsConnection.Name != "" {
+		q.WriteString(fmt.Sprintf(`, AWS CONNECTION = %s`, b.awsConnection.QualifiedName()))
 	}
 
 	q.WriteString(`)`)

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -274,9 +274,10 @@ func TestAccConnKafkaAwsIAM_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"assume_role_arn", "assume_role_session_name"},
 			},
 		},
 	})
@@ -410,6 +411,7 @@ resource "materialize_connection_kafka" "test" {
         database_name = materialize_connection_aws.test.database_name
         schema_name   = materialize_connection_aws.test.schema_name
     }
+	validate = false
 }
 `, connectionName, awsConnectionName)
 }

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -273,12 +273,6 @@ func TestAccConnKafkaAwsIAM_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.schema_name", "public"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"assume_role_arn", "assume_role_session_name"},
-			},
 		},
 	})
 }

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -246,6 +246,42 @@ func TestAccConnKafka_updateBrokersToPrivatelink(t *testing.T) {
 	})
 }
 
+func TestAccConnKafkaAwsIAM_basic(t *testing.T) {
+	connectionName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	awsConnectionName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resourceName := "materialize_connection_kafka.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAllConnKafkaDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnKafkaAwsIAMResource(connectionName, awsConnectionName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnKafkaExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "id", terraformObjectIdRegex),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "materialize"),
+					resource.TestCheckResourceAttr(resourceName, "schema_name", "public"),
+					resource.TestCheckResourceAttr(resourceName, "qualified_sql_name", fmt.Sprintf(`"materialize"."public"."%s"`, connectionName)),
+					resource.TestCheckResourceAttr(resourceName, "kafka_broker.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "kafka_broker.0.broker", "msk.mycorp.com:9092"),
+					resource.TestCheckResourceAttr(resourceName, "security_protocol", "SASL_SSL"),
+					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.name", awsConnectionName),
+					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.database_name", "materialize"),
+					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.schema_name", "public"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccConnKafkaBrokerResource(connectionName string) string {
 	return fmt.Sprintf(`
 resource "materialize_connection_kafka" "kafka_broker_conn" {
@@ -353,6 +389,29 @@ resource "materialize_connection_kafka" "kafka_connection2" {
   validate = false
 }
 `, connectionName)
+}
+
+func testAccConnKafkaAwsIAMResource(connectionName, awsConnectionName string) string {
+	return fmt.Sprintf(`
+resource "materialize_connection_aws" "test" {
+    name                    = "%[2]s"
+    assume_role_arn         = "arn:aws:iam::400121260767:role/MaterializeMSK"
+    assume_role_session_name = "materialize-session"
+}
+
+resource "materialize_connection_kafka" "test" {
+    name = "%[1]s"
+    kafka_broker {
+        broker = "msk.mycorp.com:9092"
+    }
+    security_protocol = "SASL_SSL"
+    aws_connection {
+        name          = materialize_connection_aws.test.name
+        database_name = materialize_connection_aws.test.database_name
+        schema_name   = materialize_connection_aws.test.schema_name
+    }
+}
+`, connectionName, awsConnectionName)
 }
 
 func TestAccConnKafka_disappears(t *testing.T) {

--- a/pkg/resources/resource_connection_aws.go
+++ b/pkg/resources/resource_connection_aws.go
@@ -132,13 +132,13 @@ func connectionAwsRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	// 	return diag.FromErr(err)
 	// }
 
-	if err := d.Set("assume_role_arn", s.AssumeRoleArn.String); err != nil {
-		return diag.FromErr(err)
-	}
+	// if err := d.Set("assume_role_arn", s.AssumeRoleArn.String); err != nil {
+	// 	return diag.FromErr(err)
+	// }
 
-	if err := d.Set("assume_role_session_name", s.AssumeRoleSessionName.String); err != nil {
-		return diag.FromErr(err)
-	}
+	// if err := d.Set("assume_role_session_name", s.AssumeRoleSessionName.String); err != nil {
+	// 	return diag.FromErr(err)
+	// }
 
 	if err := d.Set("ownership_role", s.OwnerName.String); err != nil {
 		return diag.FromErr(err)

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -161,7 +161,7 @@ func TestResourceConnectionKafkaCreateWithAwsConnection(t *testing.T) {
 			`CREATE CONNECTION "database"."schema"."conn"
             TO KAFKA \(BROKERS \('b-1.hostname-1:9096'\),
             SECURITY PROTOCOL = 'SASL_SSL',
-            AWS CONNECTION = "materialize"."pu1blic"."aws_conn"\);`,
+            AWS CONNECTION = "materialize"."public"."aws_conn"\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Comment

--- a/pkg/resources/resource_connection_kafka_test.go
+++ b/pkg/resources/resource_connection_kafka_test.go
@@ -136,3 +136,102 @@ func TestResourceConnectionKafkaCreateWithoutReplicationFactor(t *testing.T) {
 		}
 	})
 }
+
+func TestResourceConnectionKafkaCreateWithAwsConnection(t *testing.T) {
+	r := require.New(t)
+
+	inKafkaWithAwsConnection := map[string]interface{}{
+		"name":          "conn",
+		"schema_name":   "schema",
+		"database_name": "database",
+		"kafka_broker": []interface{}{map[string]interface{}{
+			"broker": "b-1.hostname-1:9096",
+		}},
+		"security_protocol": "SASL_SSL",
+		"aws_connection":    []interface{}{map[string]interface{}{"name": "aws_conn"}},
+		"comment":           "object comment",
+	}
+
+	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inKafkaWithAwsConnection)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`CREATE CONNECTION "database"."schema"."conn"
+            TO KAFKA \(BROKERS \('b-1.hostname-1:9096'\),
+            SECURITY PROTOCOL = 'SASL_SSL',
+            AWS CONNECTION = "materialize"."pu1blic"."aws_conn"\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Comment
+		mock.ExpectExec(`COMMENT ON CONNECTION "database"."schema"."conn" IS 'object comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Id
+		ip := `WHERE mz_connections.name = 'conn' AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
+		testhelpers.MockConnectionScan(mock, ip)
+
+		// Query Params
+		pp := `WHERE mz_connections.id = 'u1'`
+		testhelpers.MockConnectionScan(mock, pp)
+
+		if err := connectionKafkaCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestResourceConnectionKafkaCreateWithAwsConnectionAndPrivateLink(t *testing.T) {
+	r := require.New(t)
+
+	inKafkaWithAwsConnectionAndPrivateLink := map[string]interface{}{
+		"name":          "conn",
+		"schema_name":   "schema",
+		"database_name": "database",
+		"kafka_broker": []interface{}{map[string]interface{}{
+			"broker":                 "b-1.hostname-1:9096",
+			"target_group_port":      9001,
+			"availability_zone":      "use1-az1",
+			"privatelink_connection": []interface{}{map[string]interface{}{"name": "pl_conn"}},
+		}},
+		"aws_privatelink": []interface{}{map[string]interface{}{
+			"privatelink_connection":      []interface{}{map[string]interface{}{"name": "pl_conn"}},
+			"privatelink_connection_port": 9001,
+		}},
+		"security_protocol": "SASL_SSL",
+		"aws_connection":    []interface{}{map[string]interface{}{"name": "aws_conn"}},
+		"comment":           "object comment",
+	}
+
+	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inKafkaWithAwsConnectionAndPrivateLink)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`CREATE CONNECTION "database"."schema"."conn"
+            TO KAFKA \(BROKERS
+                \('b-1.hostname-1:9096'
+                USING AWS PRIVATELINK "materialize"."public"."pl_conn"
+                \(PORT 9001, AVAILABILITY ZONE 'use1-az1'\)\)
+            AWS PRIVATELINK "materialize"."public"."pl_conn" \(PORT 9001\),
+            SECURITY PROTOCOL = 'SASL_SSL',
+            AWS CONNECTION = "materialize"."public"."aws_conn"\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Comment
+		mock.ExpectExec(`COMMENT ON CONNECTION "database"."schema"."conn" IS 'object comment';`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Id
+		ip := `WHERE mz_connections.name = 'conn' AND mz_databases.name = 'database' AND mz_schemas.name = 'schema'`
+		testhelpers.MockConnectionScan(mock, ip)
+
+		// Query Params
+		pp := `WHERE mz_connections.id = 'u1'`
+		testhelpers.MockConnectionScan(mock, pp)
+
+		if err := connectionKafkaCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #624

Tests will be failing until this has actually been released: https://github.com/MaterializeInc/materialize/pull/28683

This introduces the ability to use AWS IAM authentication for Kafka connections, specifically for Amazon MSK.

Example usage:

```hcl
# Create an AWS connection for IAM authentication
resource "materialize_connection_aws" "msk_auth" {
  name                    = "aws_msk"
  assume_role_arn         = "arn:aws:iam::123456789012:role/MaterializeMSK"
}

# Create a Kafka connection using AWS IAM authentication
resource "materialize_connection_kafka" "kafka_msk" {
  name              = "kafka_msk"
  kafka_broker {
    broker = "b-1.your-cluster-name.abcdef.c1.kafka.us-east-1.amazonaws.com:9098"
  }
  security_protocol = "SASL_SSL"
  aws_connection {
    name          = materialize_connection_aws.msk_auth.name
    database_name = materialize_connection_aws.msk_auth.database_name
    schema_name   = materialize_connection_aws.msk_auth.schema_name
  }
}
```