### PR TITLE
Feature/graceful reconfig

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -38,6 +38,7 @@ resource "materialize_cluster" "example_cluster" {
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
 - `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))
 - `size` (String) The size of the managed cluster.
+- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options (see [below for nested schema](#nestedblock--wait_until_ready))
 
 ### Read-Only
 
@@ -58,6 +59,17 @@ Optional:
 - `enabled` (Boolean) Enable scheduling to refresh the cluster.
 - `hydration_time_estimate` (String) Estimated time to hydrate the cluster during refresh.
 - `rehydration_time_estimate` (String, Deprecated) Estimated time to rehydrate the cluster during refresh. This field is deprecated and will be removed in a future release. Use `hydration_time_estimate` instead.
+
+
+
+<a id="nestedblock--wait_until_ready"></a>
+### Nested Schema for `wait_until_ready`
+
+Optional:
+
+- `enabled` (Boolean) Enable wait_until_ready.
+- `on_timeout` (String) Action to take on timeout: COMMIT|ROLLBACK
+- `timeout` (String) Max duration to wait for the new replicas to be ready.
 
 ## Import
 


### PR DESCRIPTION
Adds `wait_until_ready` option to cluster resources, which will help reduce, ideally eliminating, downtime when terraform updates a cluster; for example, changes the size. The default will be to turn this off.

ex:
```hcl
resource "materialize_cluster" "cluster" {
  name = var.mz_cluster
  size = "25cc"
  wait_until_ready {
    enabled = true
    timeout = "10m"
    on_timeout = "COMMIT"
  }
}

```


This will be gated on a feature flag, and is not yet ready for primetime, we still have a few [PRs](https://github.com/MaterializeInc/materialize/pull/28836) that need to go in on the database side before this functionality is available. This  pr is also stacked on https://github.com/MaterializeInc/terraform-provider-materialize/pull/628, and will need to be rebased once that goes in.

