### PR TITLE
 resource: add password to user create route

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -29,6 +29,7 @@ resource "materialize_user" "example_user" {
 
 ### Optional
 
+- `password` (String, Sensitive) The password for the user. If not provided, an activation email will be sent.
 - `send_activation_email` (Boolean) Whether to send an email either inviting the user to activate their account, if the user is new, or inviting the user to join the organization, if the user already exists in another organization. Changing this property after the resource is created has no effect.
 
 ### Read-Only

--- a/pkg/frontegg/user.go
+++ b/pkg/frontegg/user.go
@@ -22,6 +22,7 @@ const (
 // UserRequest represents the request payload for creating or updating a user.
 type UserRequest struct {
 	Email           string   `json:"email"`
+	Password        string   `json:"password,omitempty"`
 	RoleIDs         []string `json:"roleIds"`
 	SkipInviteEmail bool     `json:"skipInviteEmail"`
 }
@@ -85,7 +86,7 @@ func CreateUser(ctx context.Context, client *clients.FronteggClient, userRequest
 func ReadUser(ctx context.Context, client *clients.FronteggClient, userID string) (UserResponse, error) {
 	var userResponse UserResponse
 
-	endpoint := fmt.Sprintf("%s%s/%s", client.GetEndpoint(), UsersApiPathV1, userID)
+	endpoint := fmt.Sprintf("%s%s/%s", client.Endpoint, UsersApiPathV1, userID)
 	resp, err := doRequest(ctx, client, "GET", endpoint, nil)
 	if err != nil {
 		return userResponse, err


### PR DESCRIPTION
Closes #643 

As per the discussion [here](https://github.com/MaterializeInc/materialize/pull/29331), I now remember why I did not initially implement this on the Terraform side, if you were to try and create a user with a pre-defined password using the staging Frontegg API you would get:

```
Failed to create user: Frontegg API error (HTTP 400): unexpected status code: 400 - {"errors":["User creation with password is forbidden"]}
```

We could still have this supported in the mock service, but it will diverge from the staging/prod Frontegg API.