### PR TITLE
Improve the Cloud Mock Service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -183,6 +183,9 @@ services:
     build: mocks/cloud
     ports:
       - "3001:3001"
+    environment:
+      - CLOUD_HOSTNAME=cloud
+      - CLOUD_PORT=3001
 
 volumes:
   certs:

--- a/mocks/cloud/README.md
+++ b/mocks/cloud/README.md
@@ -1,0 +1,93 @@
+# Cloud Mock API
+
+This mock service provides a configurable API for simulating the Materialize cloud API endpoints.
+
+## Prerequisites
+
+- Go 1.22 or later
+- Docker
+
+## Configuration
+
+The mock API can be configured using environment variables. Here are the available configuration options:
+
+- `CLOUD_HOSTNAME`: Hostname for the cloud API (default: "localhost")
+- `CLOUD_PORT`: Port for the cloud API (default: "3001")
+- `US_EAST_1_HOSTNAME`: Hostname for the US East 1 region (default: "materialized")
+- `US_EAST_1_SQL_PORT`: SQL port for the US East 1 region (default: "6877")
+- `US_EAST_1_HTTP_PORT`: HTTP port for the US East 1 region (default: "6875")
+- `US_WEST_2_HOSTNAME`: Hostname for the US West 2 region (default: "materialized2")
+- `US_WEST_2_SQL_PORT`: SQL port for the US West 2 region (default: "7877")
+- `US_WEST_2_HTTP_PORT`: HTTP port for the US West 2 region (default: "7875")
+
+## Running the Mock API
+
+1. Build the Docker image:
+   ```
+   docker build -t cloud-mock-api .
+   ```
+
+2. Run the container:
+   ```
+   docker run -p 3001:3001 \
+     -e CLOUD_HOSTNAME=cloud \
+     -e CLOUD_PORT=3001 \
+     -e US_EAST_1_HOSTNAME=materialized \
+     -e US_EAST_1_SQL_PORT=6877 \
+     -e US_EAST_1_HTTP_PORT=6875 \
+     -e US_WEST_2_HOSTNAME=materialized2 \
+     -e US_WEST_2_SQL_PORT=7877 \
+     -e US_WEST_2_HTTP_PORT=7875 \
+     cloud-mock-api
+   ```
+
+### Docker Compose Setup
+
+You can also use Docker Compose for easier setup and management. Create a `docker-compose.yml` file with the following content:
+
+```yaml
+version: '3'
+services:
+  cloud:
+    build: .
+    ports:
+      - "3001:3001"
+    environment:
+      - CLOUD_HOSTNAME=cloud
+      - CLOUD_PORT=3001
+      - US_EAST_1_HOSTNAME=materialized
+      - US_EAST_1_SQL_PORT=6877
+      - US_EAST_1_HTTP_PORT=6875
+      - US_WEST_2_HOSTNAME=materialized2
+      - US_WEST_2_SQL_PORT=7877
+      - US_WEST_2_HTTP_PORT=7875
+```
+
+Then run:
+
+```
+docker compose up -d --build
+```
+
+## API Endpoints
+
+- `/api/cloud-regions`: Get information about all cloud regions
+- `/{region-name}/api/region`: Get, update, or delete information about a specific region (e.g., `/us-east-1/api/region`).
+
+## Using with Terraform
+
+To use this mock API with Terraform, configure your provider like this:
+
+```hcl
+provider "materialize" {
+  # Define the cloud endpoint and port
+  cloud_endpoint = "http://${var.cloud_hostname}:${var.cloud_port}"
+
+  endpoint       = "http://0.0.0.0:3000"
+  password       = "your_app_password_here"
+  sslmode        = "disable"
+  database       = "materialize"
+}
+```
+
+Replace `var.cloud_hostname` and `var.cloud_port` with the appropriate values for your setup.

--- a/mocks/cloud/mock_server.go
+++ b/mocks/cloud/mock_server.go
@@ -5,7 +5,24 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"time"
 )
+
+type RegionConfig struct {
+	ID        string
+	Name      string
+	Hostname  string
+	SqlPort   string
+	HttpPort  string
+	EnabledAt time.Time
+}
+
+type Config struct {
+	CloudHostname string
+	CloudPort     string
+	Regions       []RegionConfig
+}
 
 type Region struct {
 	ID            string      `json:"id"`
@@ -31,47 +48,71 @@ type CloudProviderResponse struct {
 	NextCursor string   `json:"nextCursor,omitempty"`
 }
 
-// Mock data
-var regions = []Region{
-	{
-		ID:            "aws/us-east-1",
-		Name:          "us-east-1",
-		CloudProvider: "aws",
-		URL:           "http://cloud:3001/us-east-1",
-		RegionInfo: &RegionInfo{
-			SqlAddress:  "materialized:6877",
-			HttpAddress: "materialized:6875",
-			Resolvable:  true,
-			EnabledAt:   "2023-01-01T00:00:00Z",
+func getEnv(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
+
+func loadConfig() Config {
+	return Config{
+		CloudHostname: getEnv("CLOUD_HOSTNAME", "localhost"),
+		CloudPort:     getEnv("CLOUD_PORT", "3001"),
+		Regions: []RegionConfig{
+			{
+				ID:        "aws/us-east-1",
+				Name:      "us-east-1",
+				Hostname:  getEnv("US_EAST_1_HOSTNAME", "materialized"),
+				SqlPort:   getEnv("US_EAST_1_SQL_PORT", "6877"),
+				HttpPort:  getEnv("US_EAST_1_HTTP_PORT", "6875"),
+				EnabledAt: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:        "aws/us-west-2",
+				Name:      "us-west-2",
+				Hostname:  getEnv("US_WEST_2_HOSTNAME", "materialized2"),
+				SqlPort:   getEnv("US_WEST_2_SQL_PORT", "7877"),
+				HttpPort:  getEnv("US_WEST_2_HTTP_PORT", "7875"),
+				EnabledAt: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
 		},
-	},
-	{
-		ID:            "aws/us-west-2",
-		Name:          "us-west-2",
-		CloudProvider: "aws",
-		URL:           "http://cloud:3001/us-west-2",
-		RegionInfo: &RegionInfo{
-			SqlAddress:  "materialized2:7877",
-			HttpAddress: "materialized2:7875",
-			Resolvable:  true,
-			EnabledAt:   "2023-01-01T00:00:00Z",
-		},
-	},
+	}
+}
+
+func createRegions(config Config) []Region {
+	regions := make([]Region, len(config.Regions))
+	for i, r := range config.Regions {
+		regions[i] = Region{
+			ID:            r.ID,
+			Name:          r.Name,
+			CloudProvider: "aws",
+			URL:           fmt.Sprintf("http://%s:%s/%s", config.CloudHostname, config.CloudPort, r.Name),
+			RegionInfo: &RegionInfo{
+				SqlAddress:  fmt.Sprintf("%s:%s", r.Hostname, r.SqlPort),
+				HttpAddress: fmt.Sprintf("%s:%s", r.Hostname, r.HttpPort),
+				Resolvable:  true,
+				EnabledAt:   r.EnabledAt.Format(time.RFC3339),
+			},
+		}
+	}
+	return regions
 }
 
 func main() {
-	// Cloud Global API endpoint
-	http.HandleFunc("/api/cloud-regions", cloudRegionsHandler)
+	config := loadConfig()
+	regions := createRegions(config)
 
-	// Cloud Region API endpoints
-	http.HandleFunc("/us-east-1/api/region", regionHandler("aws/us-east-1"))
-	http.HandleFunc("/us-west-2/api/region", regionHandler("aws/us-west-2"))
+	http.HandleFunc("/api/cloud-regions", cloudRegionsHandler(regions))
+	for _, region := range regions {
+		http.HandleFunc(fmt.Sprintf("/%s/api/region", region.Name), regionHandler(region.ID, regions))
+	}
 
-	fmt.Println("Mock Cloud API server is running at http://localhost:3001")
-	log.Fatal(http.ListenAndServe(":3001", nil))
+	fmt.Printf("Mock Cloud API server is running at http://%s:%s\n", config.CloudHostname, config.CloudPort)
+	log.Fatal(http.ListenAndServe(":"+config.CloudPort, nil))
 }
 
-func regionHandler(regionID string) http.HandlerFunc {
+func regionHandler(regionID string, regions []Region) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Received %s request to %s", r.Method, r.URL.Path)
 
@@ -117,16 +158,18 @@ func regionHandler(regionID string) http.HandlerFunc {
 	}
 }
 
-func cloudRegionsHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	response := CloudProviderResponse{
-		Data: regions,
-	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+func cloudRegionsHandler(regions []Region) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		response := CloudProviderResponse{
+			Data: regions,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		}
 	}
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -168,7 +168,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, version stri
 		return nil, diag.FromErr(err)
 	}
 
-	// Initialize the Frontegg client.
+	// Initialize the Frontegg client
 	fronteggClient, err := clients.NewFronteggClient(ctx, password, endpoint)
 	if err != nil {
 		return nil, diag.Errorf("Unable to create Frontegg client: %s", err)


### PR DESCRIPTION
The Cloud mock service used to have most of the values like hostname, ports and etc hardcoded directly into the responses. This PR improves the mock service a little bit by introducing different env variables to make things more configurable so this could be used in a wider range of setups.

Also adding a README file for the mock service to document the newly added env variables.