### PR TITLE
Pin Frontegg mock to stable version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -158,12 +158,12 @@ services:
       sh -c "tail -F /dev/null"
 
   test-certs:
-    image: materialize/test-certs:devel-67251c0eb77e76eb6ef81bb78e2fb128dea2b1fb
+    image: materialize/test-certs:v0.116.0
     volumes:
       - certs:/secrets
 
   frontegg:
-    image: materialize/frontegg-mock:devel-67251c0eb77e76eb6ef81bb78e2fb128dea2b1fb
+    image: materialize/frontegg-mock:v0.116.0
     depends_on:
       - test-certs
     ports:

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -38,7 +38,7 @@ func Provider(version string) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("MZ_SSLMODE", "require"),
 				Description: "For testing purposes, the SSL mode to use.",
 			},
-			// TODO: Switch to Admin Endpoint for consistency
+			// TODO: Switch name to Admin Endpoint for consistency
 			"endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,


### PR DESCRIPTION
Switching the Frontegg mock and certs version to v0.116.0 which includes the latest Frontegg mock changes and refactor.