### PR TITLE
Set transaction isolation to strict serializable

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -48,6 +48,7 @@ services:
       - --system-parameter-default=max_clusters=100
       - --system-parameter-default=max_sources=100
       - --system-parameter-default=max_aws_privatelink_connections=10
+      - --system-parameter-default=transaction_isolation=serializable
       - --all-features
     environment:
       MZ_NO_TELEMETRY: 1

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -219,6 +219,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, version stri
 			log.Printf("[ERROR] Error initializing DB client for region %s: %v\n", provider.ID, diags)
 			continue
 		}
+		// Explicitly set the transaction isolation level to 'strict serializable' for each region
+		_, err = dbClient.Exec("SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE''")
+		if err != nil {
+			log.Printf("[ERROR] Failed to set transaction isolation level for region %s: %v\n", provider.ID, err)
+			continue
+		}
 
 		dbClients[clients.Region(provider.ID)] = dbClient
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -219,12 +219,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, version stri
 			log.Printf("[ERROR] Error initializing DB client for region %s: %v\n", provider.ID, diags)
 			continue
 		}
-		// Explicitly set the transaction isolation level to 'strict serializable' for each region
-		_, err = dbClient.Exec("SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE''")
-		if err != nil {
-			log.Printf("[ERROR] Failed to set transaction isolation level for region %s: %v\n", provider.ID, err)
-			continue
-		}
 
 		dbClients[clients.Region(provider.ID)] = dbClient
 	}

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
@@ -92,6 +93,12 @@ func GetDBClientFromMeta(meta interface{}, d *schema.ResourceData) (*sqlx.DB, cl
 	dbClient, exists := providerMeta.DB[region]
 	if !exists {
 		return nil, region, fmt.Errorf("no database client for region: %s", region)
+	}
+
+	// Explicitly set the transaction isolation level to 'strict serializable'
+	_, err = dbClient.Exec("SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE'")
+	if err != nil {
+		log.Printf("[ERROR] Failed to set transaction isolation level for region %s: %v\n", region, err)
 	}
 
 	return dbClient.SQLX(), region, nil


### PR DESCRIPTION
Explicitly set the transaction isolation level to 'strict serializable' for each db client.

Fixes #656 