### PR TITLE
Set transaction_isolation as conneciton option

### DIFF
--- a/pkg/clients/db_client.go
+++ b/pkg/clients/db_client.go
@@ -33,6 +33,8 @@ func NewDBClient(host, user, password string, port int, database, application_na
 }
 
 func buildConnectionString(host, user, password string, port int, database, sslmode, application_name string) string {
+	options := "--transaction_isolation=strict\\ serializable"
+
 	url := &url.URL{
 		Scheme: "postgres",
 		User:   url.UserPassword(user, password),
@@ -41,6 +43,7 @@ func buildConnectionString(host, user, password string, port int, database, sslm
 		RawQuery: url.Values{
 			"application_name": {application_name},
 			"sslmode":          {sslmode},
+			"options":          {options},
 		}.Encode(),
 	}
 

--- a/pkg/clients/db_client_test.go
+++ b/pkg/clients/db_client_test.go
@@ -9,13 +9,13 @@ import (
 func TestConnectionString(t *testing.T) {
 	r := require.New(t)
 	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf")
-	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&sslmode=require`, c)
+	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable&sslmode=require`, c)
 }
 
 func TestConnectionStringTesting(t *testing.T) {
 	r := require.New(t)
 	c := buildConnectionString("host", "user", "pass", 6875, "database", "disable", "tf")
-	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&sslmode=disable`, c)
+	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable&sslmode=disable`, c)
 }
 
 func TestNewDBClientFailure(t *testing.T) {

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
@@ -93,12 +92,6 @@ func GetDBClientFromMeta(meta interface{}, d *schema.ResourceData) (*sqlx.DB, cl
 	dbClient, exists := providerMeta.DB[region]
 	if !exists {
 		return nil, region, fmt.Errorf("no database client for region: %s", region)
-	}
-
-	// Explicitly set the transaction isolation level to 'strict serializable'
-	_, err = dbClient.Exec("SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE'")
-	if err != nil {
-		log.Printf("[ERROR] Failed to set transaction isolation level for region %s: %v\n", region, err)
 	}
 
 	return dbClient.SQLX(), region, nil


### PR DESCRIPTION
Decided to refactor this a bit and set the transaction isolation to strict serializable via the PG options rather than actually running the SET command. This makes things easier for the unit tests.