### PR TITLE
sink/kafka: sort topic config map keys for consistent SQL generation

### DIFF
--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -2,6 +2,7 @@ package materialize
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -157,9 +158,15 @@ func (b *SinkKafkaBuilder) Create() error {
 			q.WriteString(fmt.Sprintf(`, TOPIC PARTITION COUNT = %d`, b.topicPartitionCount))
 		}
 		if len(b.topicConfig) > 0 {
+			keys := make([]string, 0, len(b.topicConfig))
+			for k := range b.topicConfig {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
 			configItems := make([]string, 0, len(b.topicConfig))
-			for k, v := range b.topicConfig {
-				configItems = append(configItems, fmt.Sprintf("%s => %s", QuoteString(k), QuoteString(v)))
+			for _, k := range keys {
+				configItems = append(configItems, fmt.Sprintf("%s => %s", QuoteString(k), QuoteString(b.topicConfig[k])))
 			}
 			q.WriteString(fmt.Sprintf(`, TOPIC CONFIG MAP[%s]`, strings.Join(configItems, ", ")))
 		}

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -432,7 +432,7 @@ func TestSinkKafkaTopicOptionsWithCompressionCreate(t *testing.T) {
 			FROM "database"."schema"."src"
 			INTO KAFKA CONNECTION "database"."schema"."kafka_conn"
 			\(TOPIC 'testdrive-snk1-seed', COMPRESSION TYPE = gzip, TOPIC REPLICATION FACTOR = 3, TOPIC PARTITION COUNT = 6,
-			TOPIC CONFIG MAP\[.*?'cleanup\.policy' => 'compact'.*?'retention\.ms' => '86400000'.*?\]\)
+			TOPIC CONFIG MAP\['cleanup.policy' => 'compact', 'compression.type' => 'gzip', 'retention.ms' => '86400000'\]\)
 			FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."csr_conn"
 			ENVELOPE DEBEZIUM;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -446,8 +446,9 @@ func TestSinkKafkaTopicOptionsWithCompressionCreate(t *testing.T) {
 		b.TopicReplicationFactor(3)
 		b.TopicPartitionCount(6)
 		b.TopicConfig(map[string]string{
-			"cleanup.policy": "compact",
-			"retention.ms":   "86400000",
+			"cleanup.policy":   "compact",
+			"retention.ms":     "86400000",
+			"compression.type": "gzip",
 		})
 		b.Format(
 			SinkFormatSpecStruct{


### PR DESCRIPTION
Fix intermittent test failures by sorting map keys before generating SQL statement. Go maps have arbitrary iteration order, which caused test failures when topic config map entries appeared in different orders.

Fixes #676 