### PR TITLE
Add support for service accounts to provider auth

### DIFF
--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -127,7 +127,20 @@ func getToken(ctx context.Context, password string, endpoint string) (string, st
 
 	email, ok := claims["email"].(string)
 	if !ok {
-		return "", "", time.Time{}, errors.New("email claim not found in token")
+		// If email is not present (service account case), use metadata.user or sub as identifier
+		if metadata, hasMetadata := claims["metadata"].(map[string]interface{}); hasMetadata {
+			if user, hasUser := metadata["user"].(string); hasUser {
+				email = user
+			}
+		}
+
+		if email == "" {
+			if sub, hasSub := claims["sub"].(string); hasSub {
+				email = sub
+			} else {
+				return "", "", time.Time{}, errors.New("neither email nor subject found in token")
+			}
+		}
 	}
 
 	var tokenExpiry time.Time

--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -127,13 +127,13 @@ func getToken(ctx context.Context, password string, endpoint string) (string, st
 
 	email, ok := claims["email"].(string)
 	if !ok {
+		email = ""
 		// If email is not present (service account case), use metadata.user or sub as identifier
 		if metadata, hasMetadata := claims["metadata"].(map[string]interface{}); hasMetadata {
 			if user, hasUser := metadata["user"].(string); hasUser {
 				email = user
 			}
 		}
-
 		if email == "" {
 			if sub, hasSub := claims["sub"].(string); hasSub {
 				email = sub


### PR DESCRIPTION
Fixes the following when using service accounts for the provider auth:

```sh
Unable to create Frontegg client: failed to get token: email claim not found in token
```

Depends on: https://github.com/MaterializeInc/cloud/pull/10632