### PR TITLE
Fix bug when creating index does not converge

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -37,11 +37,11 @@ resource "materialize_index" "loadgen_index" {
 ### Required
 
 - `cluster_name` (String) The cluster to maintain this index.
-- `col_expr` (Block List, Min: 1) The expressions to use as the key for the index. (see [below for nested schema](#nestedblock--col_expr))
 - `obj_name` (Block List, Min: 1, Max: 1) The name of the source, view, or materialized view on which you want to create an index. (see [below for nested schema](#nestedblock--obj_name))
 
 ### Optional
 
+- `col_expr` (Block List) The expressions to use as the key for the index. (see [below for nested schema](#nestedblock--col_expr))
 - `comment` (String) Comment on an object in the database.
 - `default` (Boolean) Creates a default index using all inferred columns are used.
 - `method` (String) The name of the index method to use.
@@ -55,14 +55,6 @@ resource "materialize_index" "loadgen_index" {
 - `qualified_sql_name` (String) The fully qualified name of the index.
 - `schema_name` (String) The identifier for the index schema.
 
-<a id="nestedblock--col_expr"></a>
-### Nested Schema for `col_expr`
-
-Required:
-
-- `field` (String) The name of the option you want to set.
-
-
 <a id="nestedblock--obj_name"></a>
 ### Nested Schema for `obj_name`
 
@@ -74,6 +66,14 @@ Optional:
 
 - `database_name` (String) The obj_name database name. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `schema_name` (String) The obj_name schema name. Defaults to `public`.
+
+
+<a id="nestedblock--col_expr"></a>
+### Nested Schema for `col_expr`
+
+Required:
+
+- `field` (String) The name of the option you want to set.
 
 ## Import
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -43,7 +43,7 @@ resource "materialize_index" "loadgen_index" {
 
 - `col_expr` (Block List) The expressions to use as the key for the index. (see [below for nested schema](#nestedblock--col_expr))
 - `comment` (String) Comment on an object in the database.
-- `default` (Boolean) Creates a default index using all inferred columns are used.
+- `default` (Boolean) Creates a default index using all inferred columns are used. Required if col_expr is not set.
 - `method` (String) The name of the index method to use.
 - `name` (String) The identifier for the index.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/integration/index.tf
+++ b/integration/index.tf
@@ -49,6 +49,20 @@ resource "materialize_index" "materialized_view_index" {
   }
 }
 
+resource "materialize_index" "materialized_view_default_index" {
+  name         = "simple_default_index"
+  cluster_name = "quickstart"
+
+  default = true
+
+  obj_name {
+    name          = materialize_materialized_view.simple_materialized_view.name
+    schema_name   = materialize_materialized_view.simple_materialized_view.schema_name
+    database_name = materialize_materialized_view.simple_materialized_view.database_name
+  }
+
+}
+
 output "qualified_index" {
   value = materialize_index.loadgen_index.qualified_sql_name
 }

--- a/integration/index.tf
+++ b/integration/index.tf
@@ -50,7 +50,6 @@ resource "materialize_index" "materialized_view_index" {
 }
 
 resource "materialize_index" "materialized_view_default_index" {
-  name         = "simple_default_index"
   cluster_name = "quickstart"
 
   default = true

--- a/pkg/materialize/column.go
+++ b/pkg/materialize/column.go
@@ -76,16 +76,25 @@ var indexColumnQuery = NewBaseQuery(`
 		ON mz_index_columns.index_id = mz_indexes.id
 		AND mz_index_columns.index_position = mz_columns.position`).Order("mz_columns.position")
 
-func ListIndexColumns(conn *sqlx.DB, indexiId string) ([]IndexColumnParams, error) {
+func ListIndexColumns(conn *sqlx.DB, indexId string) ([]IndexColumnParams, error) {
 	p := map[string]string{
-		"mz_indexes.id": indexiId,
+		"mz_indexes.id": indexId,
 	}
 	q := indexColumnQuery.QueryPredicate(p)
 
-	var c []IndexColumnParams
-	if err := conn.Select(&c, q); err != nil {
-		return c, err
+	// Filter out non-indexed columns
+	var allColumns []IndexColumnParams
+	if err := conn.Select(&allColumns, q); err != nil {
+		return allColumns, err
 	}
 
-	return c, nil
+	// Only keep columns that are part of the index
+	var indexedColumns []IndexColumnParams
+	for _, col := range allColumns {
+		if col.IndexedColumn.Bool {
+			indexedColumns = append(indexedColumns, col)
+		}
+	}
+
+	return indexedColumns, nil
 }

--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -81,21 +81,17 @@ func (b *IndexBuilder) Create() error {
 		q.WriteString(fmt.Sprintf(` USING %s`, b.method))
 	}
 
-	if len(b.colExpr) > 0 && !b.indexDefault {
-		var columns []string
-
-		for _, c := range b.colExpr {
-			s := strings.Builder{}
-
-			s.WriteString(c.Field)
-			o := s.String()
-			columns = append(columns, o)
-
+	if !b.indexDefault {
+		if len(b.colExpr) > 0 {
+			var columns []string
+			for _, c := range b.colExpr {
+				columns = append(columns, c.Field)
+			}
+			p := strings.Join(columns[:], ", ")
+			q.WriteString(fmt.Sprintf(` (%s)`, p))
+		} else {
+			q.WriteString(` ()`)
 		}
-		p := strings.Join(columns[:], ", ")
-		q.WriteString(fmt.Sprintf(` (%s)`, p))
-	} else {
-		q.WriteString(` ()`)
 	}
 
 	q.WriteString(`;`)

--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -179,3 +179,23 @@ func ListIndexes(conn *sqlx.DB, schemaName, databaseName string) ([]IndexParams,
 
 	return c, nil
 }
+
+func FindIndexByObject(conn *sqlx.DB, objectName, schemaName, databaseName string) (IndexParams, error) {
+	p := map[string]string{
+		"mz_objects.name":   objectName,
+		"mz_schemas.name":   schemaName,
+		"mz_databases.name": databaseName,
+	}
+	q := indexQuery.QueryPredicate(p)
+
+	var indexes []IndexParams
+	if err := conn.Select(&indexes, q); err != nil {
+		return IndexParams{}, err
+	}
+
+	if len(indexes) == 0 {
+		return IndexParams{}, fmt.Errorf("no index found for object %s.%s.%s", databaseName, schemaName, objectName)
+	}
+
+	return indexes[0], nil
+}

--- a/pkg/materialize/index.go
+++ b/pkg/materialize/index.go
@@ -180,22 +180,25 @@ func ListIndexes(conn *sqlx.DB, schemaName, databaseName string) ([]IndexParams,
 	return c, nil
 }
 
-func FindIndexByObject(conn *sqlx.DB, objectName, schemaName, databaseName string) (IndexParams, error) {
+func FindDefaultIndexByObject(conn *sqlx.DB, objectName, schemaName, databaseName string) (IndexParams, error) {
+	// Construct the expected default index name pattern
+	defaultIndexPattern := objectName + "_primary_idx"
+
+	// Set up predicates to find the index
 	p := map[string]string{
 		"mz_objects.name":   objectName,
 		"mz_schemas.name":   schemaName,
 		"mz_databases.name": databaseName,
+		"mz_indexes.name":   defaultIndexPattern,
 	}
+
 	q := indexQuery.QueryPredicate(p)
 
-	var indexes []IndexParams
-	if err := conn.Select(&indexes, q); err != nil {
-		return IndexParams{}, err
+	var index IndexParams
+	if err := conn.Get(&index, q); err != nil {
+		return IndexParams{}, fmt.Errorf("failed to find default index for object %s.%s.%s: %w",
+			databaseName, schemaName, objectName, err)
 	}
 
-	if len(indexes) == 0 {
-		return IndexParams{}, fmt.Errorf("no index found for object %s.%s.%s", databaseName, schemaName, objectName)
-	}
-
-	return indexes[0], nil
+	return index, nil
 }

--- a/pkg/materialize/index_test.go
+++ b/pkg/materialize/index_test.go
@@ -52,7 +52,7 @@ func TestIndexFieldLiteralCreate(t *testing.T) {
 func TestIndexDefaultCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT \(\);`,
+			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "index"}

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -215,7 +215,7 @@ func indexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	// set id
 	if indexDefault {
 		// For default indexes, find the index by the object it's on
-		idxParams, err := materialize.FindIndexByObject(
+		idxParams, err := materialize.FindDefaultIndexByObject(
 			metaDb,
 			obj["name"].(string),
 			obj["schema_name"].(string),

--- a/pkg/resources/resource_index_test.go
+++ b/pkg/resources/resource_index_test.go
@@ -119,8 +119,8 @@ func TestResourceIndexDefaultCreate(t *testing.T) {
 			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		// Update the WHERE clause order to match the actual query
-		ip := `WHERE mz_databases.name = 'database' AND mz_objects.name = 'source' AND mz_objects.type IN \('source', 'view', 'materialized-view'\) AND mz_schemas.name = 'schema'`
+		// Update the WHERE clause to include the default index name pattern
+		ip := `WHERE mz_databases.name = 'database' AND mz_indexes.name = 'source_primary_idx' AND mz_objects.name = 'source' AND mz_objects.type IN \('source', 'view', 'materialized-view'\) AND mz_schemas.name = 'schema'`
 		testhelpers.MockIndexScan(mock, ip)
 
 		// Query Params

--- a/pkg/resources/resource_index_test.go
+++ b/pkg/resources/resource_index_test.go
@@ -119,8 +119,8 @@ func TestResourceIndexDefaultCreate(t *testing.T) {
 			`CREATE DEFAULT INDEX IN CLUSTER cluster ON "database"."schema"."source" USING ARRANGEMENT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
-		// Query Id
-		ip := `WHERE mz_indexes.name = 'index' AND mz_objects.type IN \('source', 'view', 'materialized-view'\)`
+		// Update the WHERE clause order to match the actual query
+		ip := `WHERE mz_databases.name = 'database' AND mz_objects.name = 'source' AND mz_objects.type IN \('source', 'view', 'materialized-view'\) AND mz_schemas.name = 'schema'`
 		testhelpers.MockIndexScan(mock, ip)
 
 		// Query Params


### PR DESCRIPTION
Fixes #698 
Fixes #697

The problem occurred because the provider was retrieving all columns from the source object, rather than just the columns that were actually part of the index. This change prevents unnecessary recreation of index resources during subsequent Terraform runs, maintaining infrastructure stability.