### PR TITLE
Fix index column detection in index read query

### DIFF
--- a/pkg/materialize/column.go
+++ b/pkg/materialize/column.go
@@ -74,7 +74,7 @@ var indexColumnQuery = NewBaseQuery(`
 		ON mz_columns.id = mz_indexes.on_id
 	LEFT JOIN mz_index_columns
 		ON mz_index_columns.index_id = mz_indexes.id
-		AND mz_index_columns.index_position = mz_columns.position`).Order("mz_columns.position")
+		AND mz_index_columns.on_position = mz_columns.position`).Order("mz_columns.position")
 
 func ListIndexColumns(conn *sqlx.DB, indexId string) ([]IndexColumnParams, error) {
 	p := map[string]string{

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -70,6 +70,7 @@ var indexSchema = map[string]*schema.Schema{
 					Description: "The name of the option you want to set.",
 					Type:        schema.TypeString,
 					Required:    true,
+					ForceNew:    true,
 				},
 			},
 		},

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -322,7 +322,7 @@ func MockIndexColumnScan(mock sqlmock.Sqlmock, predicate string) {
 		ON mz_columns.id = mz_indexes.on_id
 	LEFT JOIN mz_index_columns
 		ON mz_index_columns.index_id = mz_indexes.id
-		AND mz_index_columns.index_position = mz_columns.position`
+		AND mz_index_columns.on_position = mz_columns.position`
 
 	q := mockQueryBuilder(b, predicate, "ORDER BY mz_columns.position")
 	ir := mock.NewRows([]string{"id", "name", "position", "nullable", "type", "default", "indexed_column", "index_name", "index_id"}).


### PR DESCRIPTION
Fixes incorrect mapping of columns in index resources. The provider was using `index_position` instead of `on_position` when joining to `mz_index_columns`, causing the wrong columns to be identified as part of an index. This resulted in Terraform detecting false changes in `col_expr` fields during plan/apply operations.