### PR TITLE
fix: correct memory_limit key in cluster-replica-sizes configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
     image: materialize/materialized:latest
     container_name: materialized
     command:
-      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
+      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false, "memory_limit": "256MiB"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false, "memory_limit": "256MiB"}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "256MiB"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "256MiB"}}'
       - --bootstrap-default-cluster-replica-size=3xsmall
       - --bootstrap-builtin-system-cluster-replica-size=3xsmall
       - --bootstrap-builtin-catalog-server-cluster-replica-size=3xsmall
@@ -32,7 +32,7 @@ services:
     image: materialize/materialized:latest
     container_name: materialized2
     command:
-      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1"}}'
+      - '--cluster-replica-sizes={"3xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false, "memory_limit": "256MiB"}, "2xsmall": {"workers": 1, "scale": 1, "credits_per_hour": "1", "is_cc": false, "memory_limit": "256MiB"}, "25cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "256MiB"}, "50cc": {"workers": 1, "scale": 1, "credits_per_hour": "1", "memory_limit": "256MiB"}}'
       - --bootstrap-default-cluster-replica-size=3xsmall
       - --bootstrap-builtin-system-cluster-replica-size=3xsmall
       - --bootstrap-builtin-catalog-server-cluster-replica-size=3xsmall

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -38,7 +38,7 @@ func Provider(version string) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("MZ_SSLMODE", "require"),
 				Description: "For testing purposes, the SSL mode to use.",
 			},
-			// TODO: Switch name to Admin Endpoint for consistency
+			// TODO: Switch name to Admin Endpoint for consistency:
 			"endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,


### PR DESCRIPTION
Noticed the issue in the weekly tests here: https://github.com/MaterializeInc/terraform-provider-materialize/actions/runs/14291857672/job/40054094367