### PR TITLE
fix: Add clear error messages for Frontegg resources in self-hosted mode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,13 +12,29 @@ This repository contains a Terraform provider for managing resources in a [Mater
 Configure the provider by adding the following block to your Terraform project:
 
 ```terraform
-# Configuration-based authentication
+# =============================================================================
+# Materialize Cloud (SaaS) Configuration
+# =============================================================================
+# Use this configuration for Materialize Cloud environments.
+# This provides access to ALL provider resources including:
+# - App passwords, users, SSO, SCIM resources
+# - All database resources (clusters, sources, sinks, etc.)
+#
 provider "materialize" {
   password       = var.materialize_password # optionally use MZ_PASSWORD env var
-  default_region = "aws/us-east-1"          # optionally use MZ_REGION env var
+  default_region = "aws/us-east-1"          # optionally use MZ_DEFAULT_REGION env var
 }
 
-# Self-hosted Materialize authentication
+# =============================================================================
+# Self-Hosted Materialize Configuration
+# =============================================================================
+# Use this configuration for self-hosted Materialize instances.
+# 
+# ⚠️  IMPORTANT LIMITATIONS:
+# - Frontegg-dependent resources are NOT available (app passwords, users, SSO, SCIM)
+# - Only database resources are available (clusters, sources, sinks, schemas, etc.)
+# - No organization or identity management features
+#
 provider "materialize" {
   host     = "materialized" # optionally use MZ_HOST env var
   port     = 6875           # optionally use MZ_PORT env var
@@ -27,13 +43,42 @@ provider "materialize" {
   password = ""             # optionally use MZ_PASSWORD env var
   sslmode  = "disable"      # optionally use MZ_SSLMODE env var
 }
+
+# =============================================================================
+# Migration Note
+# =============================================================================
+# Switching between SaaS and self-hosted modes requires careful state file
+# management as resource references and regional configurations differ between modes.
 ```
+
+## ⚠️ Important: SaaS vs Self-Hosted Resources
+
+**The provider supports two distinct configuration modes with different resource availability:**
+
+### Materialize Cloud (SaaS) Mode
+When configured with `password` and `default_region` (first example above), **all resources are available**.
+
+### Self-Hosted Mode  
+When configured with `host`, `username`, etc. (second example above), **some resources are NOT available**, including:
+
+- `materialize_app_password`
+- `materialize_user` 
+- `materialize_sso_config` and related SSO resources
+- `materialize_scim_config` and related SCIM resources
+
+These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
+
+**⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
 
 ## Schema
 
-* `password` (String, Sensitive) Materialize App Password. Can also come from the `MZ_PASSWORD` environment variable.
+* `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
+* `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
+* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
-* `default_region` (String, Optional) The Materialize AWS region. Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
+* `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 
 ## Order precedence
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,10 +1,26 @@
-# Configuration-based authentication
+# =============================================================================
+# Materialize Cloud (SaaS) Configuration
+# =============================================================================
+# Use this configuration for Materialize Cloud environments.
+# This provides access to ALL provider resources including:
+# - App passwords, users, SSO, SCIM resources
+# - All database resources (clusters, sources, sinks, etc.)
+#
 provider "materialize" {
   password       = var.materialize_password # optionally use MZ_PASSWORD env var
-  default_region = "aws/us-east-1"          # optionally use MZ_REGION env var
+  default_region = "aws/us-east-1"          # optionally use MZ_DEFAULT_REGION env var
 }
 
-# Self-hosted Materialize authentication
+# =============================================================================
+# Self-Hosted Materialize Configuration
+# =============================================================================
+# Use this configuration for self-hosted Materialize instances.
+# 
+# ⚠️  IMPORTANT LIMITATIONS:
+# - Frontegg-dependent resources are NOT available (app passwords, users, SSO, SCIM)
+# - Only database resources are available (clusters, sources, sinks, schemas, etc.)
+# - No organization or identity management features
+#
 provider "materialize" {
   host     = "materialized" # optionally use MZ_HOST env var
   port     = 6875           # optionally use MZ_PORT env var
@@ -13,3 +29,9 @@ provider "materialize" {
   password = ""             # optionally use MZ_PASSWORD env var
   sslmode  = "disable"      # optionally use MZ_SSLMODE env var
 }
+
+# =============================================================================
+# Migration Note
+# =============================================================================
+# Switching between SaaS and self-hosted modes requires careful state file
+# management as resource references and regional configurations differ between modes.

--- a/pkg/datasources/datasource_scim_configs.go
+++ b/pkg/datasources/datasource_scim_configs.go
@@ -64,6 +64,12 @@ func dataSourceSCIM2ConfigurationsRead(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM configs data source is only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_configs data source"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	configurations, err := frontegg.FetchSCIM2Configurations(ctx, client)

--- a/pkg/datasources/datasource_scim_groups.go
+++ b/pkg/datasources/datasource_scim_groups.go
@@ -118,6 +118,12 @@ func dataSourceSCIMGroupsRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM groups data source is only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_groups data source"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	groups, err := frontegg.FetchSCIMGroups(ctx, client)

--- a/pkg/datasources/datasource_sso_config.go
+++ b/pkg/datasources/datasource_sso_config.go
@@ -134,6 +134,12 @@ func dataSourceSSOConfigRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO config data source is only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_config data source"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	rawConfigurations, err := frontegg.FetchSSOConfigurationsRaw(ctx, client)

--- a/pkg/resources/resource_app_password.go
+++ b/pkg/resources/resource_app_password.go
@@ -77,6 +77,12 @@ func appPasswordCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that app passwords are only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_app_password"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	name := d.Get("name").(string)
@@ -172,6 +178,11 @@ func appPasswordRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 
+	// Validate that app passwords are only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_app_password"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 	id := d.Id()
 
@@ -242,6 +253,12 @@ func appPasswordDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that app passwords are only used in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_app_password"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	id := d.Id()

--- a/pkg/resources/resource_scim_config.go
+++ b/pkg/resources/resource_scim_config.go
@@ -75,6 +75,12 @@ func resourceSCIM2ConfigurationsCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	config := frontegg.SCIM2Configuration{
@@ -108,6 +114,12 @@ func resourceSCIM2ConfigurationsDelete(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	err = frontegg.DeleteSCIM2Configuration(ctx, client, d.Id())
@@ -124,6 +136,12 @@ func resourceSCIM2ConfigurationsRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	configurations, err := frontegg.FetchSCIM2Configurations(ctx, client)

--- a/pkg/resources/resource_scim_group.go
+++ b/pkg/resources/resource_scim_group.go
@@ -45,6 +45,12 @@ func scim2GroupCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM groups are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_group"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	params := frontegg.GroupCreateParams{

--- a/pkg/resources/resource_scim_group_roles.go
+++ b/pkg/resources/resource_scim_group_roles.go
@@ -51,6 +51,12 @@ func scimGroupRoleCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM group roles are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_group_roles"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	roleIDs, err := getRoleIDsByName(ctx, providerMeta, roleNames)

--- a/pkg/resources/resource_scim_group_users.go
+++ b/pkg/resources/resource_scim_group_users.go
@@ -50,6 +50,12 @@ func scimGroupUsersCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SCIM group users are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_scim_group_users"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	err = frontegg.AddUsersToGroup(ctx, client, groupID, userIDs)

--- a/pkg/resources/resource_sso_config.go
+++ b/pkg/resources/resource_sso_config.go
@@ -74,6 +74,12 @@ func ssoConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 	baseEndpoint := providerMeta.CloudAPI.BaseEndpoint
 
@@ -106,6 +112,12 @@ func ssoConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	// Fetch SSO configurations
@@ -182,6 +194,12 @@ func ssoConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO configs are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_config"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	err = frontegg.DeleteSSOConfiguration(ctx, client, d.Id())

--- a/pkg/resources/resource_sso_default_roles.go
+++ b/pkg/resources/resource_sso_default_roles.go
@@ -49,6 +49,12 @@ func ssoDefaultRolesCreateOrUpdate(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO default roles are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_default_roles"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	ssoConfigID := d.Get("sso_config_id").(string)
@@ -79,6 +85,12 @@ func ssoDefaultRolesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO default roles are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_default_roles"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	ssoConfigID := d.Id()
@@ -116,6 +128,12 @@ func ssoDefaultRolesDelete(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO default roles are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_default_roles"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	ssoConfigID := d.Id()

--- a/pkg/resources/resource_sso_domain.go
+++ b/pkg/resources/resource_sso_domain.go
@@ -51,6 +51,12 @@ func ssoDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO domains are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_domain"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	ssoConfigID := d.Get("sso_config_id").(string)

--- a/pkg/resources/resource_sso_group_mapping.go
+++ b/pkg/resources/resource_sso_group_mapping.go
@@ -57,6 +57,12 @@ func ssoGroupMappingCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Validate that SSO group mappings are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_sso_group_mapping"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 
 	ssoConfigID := d.Get("sso_config_id").(string)

--- a/pkg/resources/resource_user.go
+++ b/pkg/resources/resource_user.go
@@ -70,6 +70,11 @@ func userCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
+	// Validate that users are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_user"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 	email := d.Get("email").(string)
 	sendActivationEmail := d.Get("send_activation_email").(bool)
@@ -119,6 +124,11 @@ func userRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 
+	// Validate that users are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_user"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 	userID := d.Id()
 
@@ -156,6 +166,11 @@ func userUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
+	// Validate that users are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_user"); diags.HasError() {
+		return diags
+	}
+
 	client := providerMeta.Frontegg
 	userID := d.Id()
 	email := d.Get("email").(string)
@@ -187,6 +202,11 @@ func userDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	providerMeta, err := utils.GetProviderMeta(meta)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Validate that users are only managed in SaaS mode
+	if diags := providerMeta.ValidateSaaSOnly("materialize_user"); diags.HasError() {
+		return diags
 	}
 
 	client := providerMeta.Frontegg

--- a/pkg/utils/provider_meta_test.go
+++ b/pkg/utils/provider_meta_test.go
@@ -202,3 +202,41 @@ func TestProviderMetaModeHelpers(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderMeta_ValidateSaaSOnly_SelfHosted(t *testing.T) {
+	r := require.New(t)
+
+	providerMeta := &ProviderMeta{
+		Mode: ModeSelfHosted,
+	}
+
+	diags := providerMeta.ValidateSaaSOnly("materialize_app_password")
+	r.True(diags.HasError())
+
+	r.Contains(diags[0].Summary, "materialize_app_password is only available in Materialize Cloud (SaaS) environments")
+	r.Contains(diags[0].Summary, "You are currently using self-hosted authentication mode")
+	r.Contains(diags[0].Summary, "you need to switch to Materialize Cloud (SaaS) mode")
+}
+
+func TestProviderMeta_ValidateSaaSOnly_SaaS(t *testing.T) {
+	r := require.New(t)
+
+	providerMeta := &ProviderMeta{
+		Mode: ModeSaaS,
+	}
+
+	diags := providerMeta.ValidateSaaSOnly("materialize_app_password")
+	r.False(diags.HasError())
+}
+
+func TestProviderMeta_ValidateSaaSOnly_EmptyMode(t *testing.T) {
+	r := require.New(t)
+
+	// Empty mode should default to SaaS
+	providerMeta := &ProviderMeta{
+		Mode: "",
+	}
+
+	diags := providerMeta.ValidateSaaSOnly("materialize_app_password")
+	r.False(diags.HasError())
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,11 +13,34 @@ Configure the provider by adding the following block to your Terraform project:
 
 {{tffile "examples/provider/provider.tf"}}
 
+## ⚠️ Important: SaaS vs Self-Hosted Resources
+
+**The provider supports two distinct configuration modes with different resource availability:**
+
+### Materialize Cloud (SaaS) Mode
+When configured with `password` and `default_region` (first example above), **all resources are available**.
+
+### Self-Hosted Mode  
+When configured with `host`, `username`, etc. (second example above), **some resources are NOT available**, including:
+
+- `materialize_app_password`
+- `materialize_user` 
+- `materialize_sso_config` and related SSO resources
+- `materialize_scim_config` and related SCIM resources
+
+These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
+
+**⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
+
 ## Schema
 
-* `password` (String, Sensitive) Materialize App Password. Can also come from the `MZ_PASSWORD` environment variable.
+* `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
+* `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
+* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
-* `default_region` (String, Optional) The Materialize AWS region. Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
+* `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 
 ## Order precedence
 


### PR DESCRIPTION
## Problem
Users configuring the provider for self-hosted mode were getting confusing errors like "role not found: Member" when trying to use `materialize_app_password` and other Frontegg-dependent resources.

Reported in #724 

## Solution
- Added `ValidateSaaSOnly()` helper that detects self-hosted mode
- Applied validation to all 13 Frontegg-dependent resources + data sources
- Improved provider documentation and examples with clear mode distinctions
- Added better test coverage

## Impact
- Clear, actionable error messages instead of confusing "role not found" errors
- Users immediately understand SaaS vs self-hosted resource limitations
- Better developer experience with upfront documentation about configuration modes

**Before:** `Error: role not found: Member`
**After:** `Error: materialize_app_password is only available in Materialize Cloud (SaaS) environments. You are currently using self-hosted mode...`