### PR TITLE
dependabot: Implement a 3 day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: weekly
       day: sunday
       time: "22:00"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns & https://materializeinc.slack.com/archives/CUCF68PEV/p1764014095155649