### PR TITLE
Fix typo: 'owernship' to 'ownership' in schema description

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -33,7 +33,7 @@ resource "materialize_cluster" "example_cluster" {
 - `identify_by_name` (Boolean) Use the cluster name as the resource identifier in your state file, rather than the internal cluster ID. This is particularly useful in scenarios like dbt-materialize blue/green deployments, where clusters are swapped but the ID changes. By identifying by name, the resource can be managed consistently even when the underlying cluster ID is updated.
 - `introspection_debugging` (Boolean) Whether to introspect the gathering of the introspection data.
 - `introspection_interval` (String) The interval at which to collect introspection data.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
 - `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))

--- a/docs/resources/connection_aws.md
+++ b/docs/resources/connection_aws.md
@@ -43,7 +43,7 @@ resource "materialize_connection_aws" "example_connection" {
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `endpoint` (String) Override the default AWS endpoint URL.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the connection schema in Materialize. Defaults to `public`.
 - `secret_access_key` (Block List, Max: 1) The secret access key corresponding to the specified access key ID. (see [below for nested schema](#nestedblock--secret_access_key))

--- a/docs/resources/connection_aws_privatelink.md
+++ b/docs/resources/connection_aws_privatelink.md
@@ -42,7 +42,7 @@ resource "materialize_connection_aws_privatelink" "example_privatelink_connectio
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the connection schema in Materialize. Defaults to `public`.
 - `validate` (Boolean) If the connection should wait for validation.

--- a/docs/resources/connection_confluent_schema_registry.md
+++ b/docs/resources/connection_confluent_schema_registry.md
@@ -47,7 +47,7 @@ resource "materialize_connection_confluent_schema_registry" "example_confluent_s
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the Confluent Schema Registry. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `password` (Block List, Max: 1) The password for the Confluent Schema Registry. (see [below for nested schema](#nestedblock--password))
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the connection schema in Materialize. Defaults to `public`.

--- a/docs/resources/connection_kafka.md
+++ b/docs/resources/connection_kafka.md
@@ -85,7 +85,7 @@ resource "materialize_connection_kafka" "example_kafka_connection_multiple_broke
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `kafka_broker` (Block List) The Kafka broker's configuration. (see [below for nested schema](#nestedblock--kafka_broker))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `progress_topic` (String) The name of a topic that Kafka sinks can use to track internal consistency metadata.
 - `progress_topic_replication_factor` (Number) The replication factor to use when creating the Kafka progress topic (if the Kafka topic does not already exist).
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/docs/resources/connection_mysql.md
+++ b/docs/resources/connection_mysql.md
@@ -82,7 +82,7 @@ resource "materialize_connection_mysql" "example_mysql_connection" {
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the MySQL database. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `password` (Block List, Max: 1) The MySQL database password. (see [below for nested schema](#nestedblock--password))
 - `port` (Number) The MySQL database port.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/docs/resources/connection_postgres.md
+++ b/docs/resources/connection_postgres.md
@@ -87,7 +87,7 @@ resource "materialize_connection_postgres" "example_postgres_connection" {
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the Postgres database. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `password` (Block List, Max: 1) The Postgres database password. (see [below for nested schema](#nestedblock--password))
 - `port` (Number) The Postgres database port.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/docs/resources/connection_sqlserver.md
+++ b/docs/resources/connection_sqlserver.md
@@ -118,7 +118,7 @@ resource "materialize_connection_sqlserver" "privatelink_example" {
 - `aws_privatelink` (Block List, Max: 1) The AWS PrivateLink configuration for the SQL Server database. (see [below for nested schema](#nestedblock--aws_privatelink))
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `password` (Block List, Max: 1) The SQL Server database password. (see [below for nested schema](#nestedblock--password))
 - `port` (Number) The SQL Server database port.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.

--- a/docs/resources/connection_ssh_tunnel.md
+++ b/docs/resources/connection_ssh_tunnel.md
@@ -43,7 +43,7 @@ resource "materialize_connection_ssh_tunnel" "example_ssh_connection" {
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the connection database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the connection schema in Materialize. Defaults to `public`.
 - `validate` (Boolean) If the connection should wait for validation.

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -49,7 +49,7 @@ resource "materialize_schema_grant" "schema_grant_usage" {
 ### Optional
 
 - `comment` (String) Comment on an object in the database.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 
 ### Read-Only

--- a/docs/resources/materialized_view.md
+++ b/docs/resources/materialized_view.md
@@ -51,7 +51,7 @@ resource "materialize_materialized_view" "simple_materialized_view" {
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the materialized view database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `not_null_assertion` (List of String) A list of columns for which to create non-null assertions.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the materialized view schema in Materialize. Defaults to `public`.
 

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -30,7 +30,7 @@ resource "materialize_schema" "example_schema" {
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the schema database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 
 ### Read-Only

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -32,7 +32,7 @@ resource "materialize_secret" "example_secret" {
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the secret database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the secret schema in Materialize. Defaults to `public`.
 - `value` (String, Sensitive) The value for the secret. The value expression may not reference any relations, and must be a bytea string literal. Use value_wo for write-only ephemeral values that won't be stored in state.

--- a/docs/resources/sink_kafka.md
+++ b/docs/resources/sink_kafka.md
@@ -73,7 +73,7 @@ resource "materialize_sink_kafka" "example_sink_kafka" {
 - `headers` (String) The name of a column containing additional headers to add to each message emitted by the sink. The column must be of type map[text => text] or map[text => bytea].
 - `key` (List of String) An optional list of columns to use for the Kafka key. If unspecified, the Kafka key is left unset.
 - `key_not_enforced` (Boolean) Disable Materialize's validation of the key's uniqueness.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `partition_by` (String) A SQL expression used to partition the data in the Kafka sink. Can only be used with `ENVELOPE UPSERT`.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the sink schema in Materialize. Defaults to `public`.

--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -70,7 +70,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 - `include_timestamp` (Boolean, Deprecated) (Deprecated) Include a timestamp column containing the Kafka message timestamp. Use `materialize_source_table_kafka` resources instead.
 - `include_timestamp_alias` (String, Deprecated) (Deprecated) Provide an alias for the timestamp column. Use `materialize_source_table_kafka` resources instead.
 - `key_format` (Block List, Max: 1, Deprecated) (Deprecated) Set the key format explicitly. Use `materialize_source_table_kafka` resources instead. (see [below for nested schema](#nestedblock--key_format))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `start_offset` (List of Number) Read partitions from the specified offset.

--- a/docs/resources/source_load_generator.md
+++ b/docs/resources/source_load_generator.md
@@ -48,7 +48,7 @@ resource "materialize_source_load_generator" "example_source_load_generator" {
 - `database_name` (String) The identifier for the source database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (Block List, Max: 1) The name of the progress collection for the source. If this is not specified, the collection will be named `<src_name>_progress`. (see [below for nested schema](#nestedblock--expose_progress))
 - `marketing_options` (Block List, Max: 1) Marketing Options. (see [below for nested schema](#nestedblock--marketing_options))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `tpch_options` (Block List, Max: 1) TPCH Options. (see [below for nested schema](#nestedblock--tpch_options))

--- a/docs/resources/source_mysql.md
+++ b/docs/resources/source_mysql.md
@@ -58,7 +58,7 @@ resource "materialize_source_mysql" "test" {
 - `database_name` (String) The identifier for the source database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `expose_progress` (Block List, Max: 1) The name of the progress collection for the source. If this is not specified, the collection will be named `<src_name>_progress`. (see [below for nested schema](#nestedblock--expose_progress))
 - `ignore_columns` (List of String, Deprecated) (Deprecated) Ignore specific columns when reading data from MySQL. Use `materialize_source_table_mysql` resources instead.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `table` (Block Set, Deprecated) (Deprecated) Specify the tables to be included in the source. If not specified, all tables are included. Use `materialize_source_table_mysql` resources instead. (see [below for nested schema](#nestedblock--table))

--- a/docs/resources/source_postgres.md
+++ b/docs/resources/source_postgres.md
@@ -94,7 +94,7 @@ resource "materialize_source_postgres" "with_options" {
 - `database_name` (String) The identifier for the source database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `exclude_columns` (List of String, Deprecated) (Deprecated) Exclude specific columns when reading data from PostgreSQL. Can only be updated in place when also updating a corresponding `table` attribute.
 - `expose_progress` (Block List, Max: 1) The name of the progress collection for the source. If this is not specified, the collection will be named `<src_name>_progress`. (see [below for nested schema](#nestedblock--expose_progress))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `table` (Block Set, Deprecated) (Deprecated) Creates subsources for specific tables in the Postgres connection. Use `materialize_source_table_postgres` resources instead. (see [below for nested schema](#nestedblock--table))

--- a/docs/resources/source_sqlserver.md
+++ b/docs/resources/source_sqlserver.md
@@ -128,7 +128,7 @@ resource "materialize_source_sqlserver" "with_options" {
 - `database_name` (String) The identifier for the source database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `exclude_columns` (List of String, Deprecated) (Deprecated) Exclude specific columns when reading data from SQL Server. Can only be updated in place when also updating a corresponding `table` attribute.
 - `expose_progress` (Block List, Max: 1) The name of the progress collection for the source. If this is not specified, the collection will be named `<src_name>_progress`. (see [below for nested schema](#nestedblock--expose_progress))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `table` (Block Set, Deprecated) (Deprecated) Specify the tables to be included in the source. If not specified, all tables are included. Use `materialize_source_table_sqlserver` resources instead. (see [below for nested schema](#nestedblock--table))

--- a/docs/resources/source_table_kafka.md
+++ b/docs/resources/source_table_kafka.md
@@ -87,7 +87,7 @@ resource "materialize_source_table_kafka" "kafka_source_table" {
 - `include_timestamp` (Boolean) Include a timestamp column containing the Kafka message timestamp.
 - `include_timestamp_alias` (String) Provide an alias for the timestamp column.
 - `key_format` (Block List, Max: 1) Set the key format explicitly. (see [below for nested schema](#nestedblock--key_format))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source table schema in Materialize. Defaults to `public`.
 - `topic` (String) The name of the Kafka topic in the Kafka cluster.

--- a/docs/resources/source_table_mysql.md
+++ b/docs/resources/source_table_mysql.md
@@ -49,7 +49,7 @@ resource "materialize_source_table_mysql" "mysql_table_from_source" {
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the table database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `exclude_columns` (List of String) Exclude specific columns when reading data from MySQL. This option used to be called `ignore_columns`.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the table schema in Materialize. Defaults to `public`.
 - `text_columns` (List of String) Columns to be decoded as text.

--- a/docs/resources/source_table_postgres.md
+++ b/docs/resources/source_table_postgres.md
@@ -48,7 +48,7 @@ resource "materialize_source_table_postgres" "postgres_table_from_source" {
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the table database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `exclude_columns` (List of String) Exclude specific columns when reading data from PostgreSQL.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the table schema in Materialize. Defaults to `public`.
 - `text_columns` (List of String) Columns to be decoded as text.

--- a/docs/resources/source_table_sqlserver.md
+++ b/docs/resources/source_table_sqlserver.md
@@ -46,7 +46,7 @@ resource "materialize_source_table_sqlserver" "sqlserver_table_from_source" {
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the table database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `exclude_columns` (List of String) Exclude specific columns when reading data from SQL Server.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the table schema in Materialize. Defaults to `public`.
 - `text_columns` (List of String) Columns to be decoded as text.

--- a/docs/resources/source_table_webhook.md
+++ b/docs/resources/source_table_webhook.md
@@ -64,7 +64,7 @@ resource "materialize_source_table_webhook" "example_webhook" {
 - `database_name` (String) The identifier for the table database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `include_header` (Block List) Map a header value from a request into a column. (see [below for nested schema](#nestedblock--include_header))
 - `include_headers` (Block List, Max: 1) Include headers in the webhook. (see [below for nested schema](#nestedblock--include_headers))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the table schema in Materialize. Defaults to `public`.
 

--- a/docs/resources/source_webhook.md
+++ b/docs/resources/source_webhook.md
@@ -67,7 +67,7 @@ resource "materialize_source_webhook" "example_webhook" {
 - `database_name` (String) The identifier for the source database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `include_header` (Block List) Map a header value from a request into a column. (see [below for nested schema](#nestedblock--include_header))
 - `include_headers` (Block List, Max: 1) Include headers in the webhook. (see [below for nested schema](#nestedblock--include_headers))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -47,7 +47,7 @@ resource "materialize_table" "simple_table" {
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the table database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the table schema in Materialize. Defaults to `public`.
 

--- a/docs/resources/type.md
+++ b/docs/resources/type.md
@@ -48,7 +48,7 @@ resource "materialize_type" "map_type" {
 - `database_name` (String) The identifier for the type database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
 - `list_properties` (Block List, Max: 1) List properties. (see [below for nested schema](#nestedblock--list_properties))
 - `map_properties` (Block List, Max: 1) Map properties. (see [below for nested schema](#nestedblock--map_properties))
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `row_properties` (Block List) Row properties. (see [below for nested schema](#nestedblock--row_properties))
 - `schema_name` (String) The identifier for the type schema in Materialize. Defaults to `public`.

--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -49,7 +49,7 @@ resource "materialize_view" "simple_view" {
 
 - `comment` (String) Comment on an object in the database.
 - `database_name` (String) The identifier for the view database in Materialize. Defaults to `MZ_DATABASE` environment variable if set or `materialize` if environment variable is not set.
-- `ownership_role` (String) The owernship role of the object.
+- `ownership_role` (String) The ownership role of the object.
 - `region` (String) The region to use for the resource connection. If not set, the default region is used.
 - `schema_name` (String) The identifier for the view schema in Materialize. Defaults to `public`.
 

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -63,7 +63,7 @@ func ClusterNameSchema() *schema.Schema {
 func OwnershipRoleSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeString,
-		Description: "The owernship role of the object.",
+		Description: "The ownership role of the object.",
 		Optional:    true,
 		Computed:    true,
 	}


### PR DESCRIPTION
Fixes #793 