### PR TITLE
Allow aws_connection updates without ForceNew for iceberg connection

### DIFF
--- a/pkg/provider/acceptance_connection_iceberg_catalog_test.go
+++ b/pkg/provider/acceptance_connection_iceberg_catalog_test.go
@@ -46,8 +46,8 @@ func TestAccConnectionIcebergCatalog_update(t *testing.T) {
 	url := "https://s3tables.us-east-1.amazonaws.com/iceberg"
 	warehouse := "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket"
 
-	// TODO: Only the connection name can be updated in-place via ALTER CONNECTION RENAME.
-	// Changes to catalog_type, url, warehouse, and aws_connection require resource recreation.
+	// TODO: Only the connection name and aws_connection can be updated in-place via ALTER CONNECTION.
+	// Changes to catalog_type, url, and warehouse require resource recreation.
 	// Error: "storage error: cannot be altered in the requested way (SQLSTATE XX000)"
 	// Once Materialize supports ALTER for these properties, add test steps for in-place updates.
 	resource.ParallelTest(t, resource.TestCase{
@@ -71,6 +71,38 @@ func TestAccConnectionIcebergCatalog_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", updatedConnectionName),
 					resource.TestCheckResourceAttr(resourceName, "url", url),
 					resource.TestCheckResourceAttr(resourceName, "warehouse", warehouse),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConnectionIcebergCatalog_updateAwsConnection(t *testing.T) {
+	resourceName := "materialize_connection_iceberg_catalog.test"
+	connectionName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	catalogType := "s3tablesrest"
+	url := "https://s3tables.us-east-1.amazonaws.com/iceberg"
+	warehouse := "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckConnectionIcebergCatalogDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionIcebergCatalogResource(connectionName, catalogType, url, warehouse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnectionIcebergCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.name", connectionName+"_aws"),
+				),
+			},
+			{
+				Config: testAccConnectionIcebergCatalogResourceWithDifferentAwsConnection(connectionName, catalogType, url, warehouse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnectionIcebergCatalogExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", connectionName),
+					resource.TestCheckResourceAttr(resourceName, "aws_connection.0.name", connectionName+"_aws_updated"),
 				),
 			},
 		},
@@ -133,6 +165,63 @@ resource "materialize_connection_iceberg_catalog" "test" {
     name          = materialize_connection_aws.test_aws.name
     database_name = materialize_connection_aws.test_aws.database_name
     schema_name   = materialize_connection_aws.test_aws.schema_name
+  }
+  validate = false
+}
+`, name, catalogType, url, warehouse)
+}
+
+func testAccConnectionIcebergCatalogResourceWithDifferentAwsConnection(name, catalogType, url, warehouse string) string {
+	return fmt.Sprintf(`
+resource "materialize_secret" "aws_secret_access_key" {
+  name  = "%[1]s_secret"
+  value = "test_secret_key"
+}
+
+resource "materialize_secret" "aws_secret_access_key_updated" {
+  name  = "%[1]s_secret_updated"
+  value = "test_secret_key_updated"
+}
+
+resource "materialize_connection_aws" "test_aws" {
+  name       = "%[1]s_aws"
+  endpoint   = "http://localhost:4566"
+  aws_region = "us-east-1"
+  access_key_id {
+    text = "test_access_key"
+  }
+  secret_access_key {
+    name          = materialize_secret.aws_secret_access_key.name
+    database_name = materialize_secret.aws_secret_access_key.database_name
+    schema_name   = materialize_secret.aws_secret_access_key.schema_name
+  }
+  validate = false
+}
+
+resource "materialize_connection_aws" "test_aws_updated" {
+  name       = "%[1]s_aws_updated"
+  endpoint   = "http://localhost:4566"
+  aws_region = "us-east-1"
+  access_key_id {
+    text = "test_access_key_updated"
+  }
+  secret_access_key {
+    name          = materialize_secret.aws_secret_access_key_updated.name
+    database_name = materialize_secret.aws_secret_access_key_updated.database_name
+    schema_name   = materialize_secret.aws_secret_access_key_updated.schema_name
+  }
+  validate = false
+}
+
+resource "materialize_connection_iceberg_catalog" "test" {
+  name          = "%[1]s"
+  catalog_type  = "%[2]s"
+  url           = "%[3]s"
+  warehouse     = "%[4]s"
+  aws_connection {
+    name          = materialize_connection_aws.test_aws_updated.name
+    database_name = materialize_connection_aws.test_aws_updated.database_name
+    schema_name   = materialize_connection_aws.test_aws_updated.schema_name
   }
   validate = false
 }


### PR DESCRIPTION
As per the comment here: https://github.com/MaterializeInc/terraform-provider-materialize/pull/810#discussion_r2740100829