### PR TITLE
Fix `CREATE ROLE` SQL clause ordering by placing all options after a single `WITH` keyword

### DIFF
--- a/pkg/materialize/role.go
+++ b/pkg/materialize/role.go
@@ -54,35 +54,33 @@ func (b *RoleBuilder) Create() error {
 	q := strings.Builder{}
 	q.WriteString(fmt.Sprintf(`CREATE ROLE %s`, b.QualifiedName()))
 
-	var p []string
+	var options []string
 
 	// NOINHERIT currently not supported
 	// https://materialize.com/docs/sql/create-role/#details
 	if b.inherit {
-		p = append(p, ` INHERIT`)
+		options = append(options, "INHERIT")
+	}
+
+	if b.login {
+		options = append(options, "LOGIN")
 	}
 
 	if b.password != "" {
-		if b.login {
-			p = append(p, fmt.Sprintf(` WITH LOGIN PASSWORD %s`, QuoteString(b.password)))
-		} else {
-			p = append(p, fmt.Sprintf(` WITH PASSWORD %s`, QuoteString(b.password)))
-		}
-	} else if b.login {
-		p = append(p, ` WITH LOGIN`)
+		options = append(options, fmt.Sprintf("PASSWORD %s", QuoteString(b.password)))
 	}
 
 	if b.superuserSet {
 		if b.superuser {
-			p = append(p, ` SUPERUSER`)
+			options = append(options, "SUPERUSER")
 		} else {
-			p = append(p, ` NOSUPERUSER`)
+			options = append(options, "NOSUPERUSER")
 		}
 	}
 
-	if len(p) > 0 {
-		f := strings.Join(p, "")
-		q.WriteString(f)
+	if len(options) > 0 {
+		q.WriteString(` WITH `)
+		q.WriteString(strings.Join(options, " "))
 	}
 
 	q.WriteString(`;`)

--- a/pkg/materialize/role_test.go
+++ b/pkg/materialize/role_test.go
@@ -13,7 +13,7 @@ import (
 func TestRoleCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT;`,
+			`CREATE ROLE "role" WITH INHERIT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -42,7 +42,7 @@ func TestRoleAlter(t *testing.T) {
 func TestRoleCreateWithSuperuser(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT SUPERUSER;`,
+			`CREATE ROLE "role" WITH INHERIT SUPERUSER;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -59,7 +59,7 @@ func TestRoleCreateWithSuperuser(t *testing.T) {
 func TestRoleCreateWithNoSuperuser(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT NOSUPERUSER;`,
+			`CREATE ROLE "role" WITH INHERIT NOSUPERUSER;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -76,7 +76,7 @@ func TestRoleCreateWithNoSuperuser(t *testing.T) {
 func TestRoleCreateWithLogin(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH LOGIN;`,
+			`CREATE ROLE "role" WITH INHERIT LOGIN;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -93,7 +93,7 @@ func TestRoleCreateWithLogin(t *testing.T) {
 func TestRoleCreateWithPasswordAndLogin(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH LOGIN PASSWORD 'password123';`,
+			`CREATE ROLE "role" WITH INHERIT LOGIN PASSWORD 'password123';`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -111,7 +111,7 @@ func TestRoleCreateWithPasswordAndLogin(t *testing.T) {
 func TestRoleCreateWithPasswordNoLogin(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH PASSWORD 'password123';`,
+			`CREATE ROLE "role" WITH INHERIT PASSWORD 'password123';`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		o := MaterializeObject{Name: "role"}
@@ -119,6 +119,40 @@ func TestRoleCreateWithPasswordNoLogin(t *testing.T) {
 		b.Inherit()
 		b.Password("password123")
 		b.Login(false)
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRoleCreateWithAllOptions(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE ROLE "role" WITH INHERIT LOGIN PASSWORD 'password123' SUPERUSER;`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "role"}
+		b := NewRoleBuilder(db, o)
+		b.Inherit()
+		b.Password("password123")
+		b.Login(true)
+		b.Superuser(true)
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestRoleCreateNoOptions(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE ROLE "role";`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "role"}
+		b := NewRoleBuilder(db, o)
 
 		if err := b.Create(); err != nil {
 			t.Fatal(err)

--- a/pkg/provider/acceptance_role_test.go
+++ b/pkg/provider/acceptance_role_test.go
@@ -144,6 +144,35 @@ func TestAccRole_withLogin(t *testing.T) {
 	})
 }
 
+func TestAccRole_withLoginAndPassword(t *testing.T) {
+	roleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	password := "test_password_456"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleWithLoginAndPassword(roleName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists("materialize_role.test"),
+					resource.TestMatchResourceAttr("materialize_role.test", "id", terraformObjectIdRegex),
+					resource.TestCheckResourceAttr("materialize_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("materialize_role.test", "inherit", "true"),
+					resource.TestCheckResourceAttr("materialize_role.test", "login", "true"),
+					resource.TestCheckResourceAttr("materialize_role.test", "password", password),
+				),
+			},
+			{
+				ResourceName:      "materialize_role.test",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 func testAccRoleResource(roleName string) string {
 	return fmt.Sprintf(`
 resource "materialize_role" "test" {
@@ -169,6 +198,16 @@ resource "materialize_role" "test" {
 	superuser = %t
 }
 `, roleName, password, superuser)
+}
+
+func testAccRoleWithLoginAndPassword(roleName, password string) string {
+	return fmt.Sprintf(`
+resource "materialize_role" "test" {
+	name     = "%s"
+	login    = true
+	password = "%s"
+}
+`, roleName, password)
 }
 
 func testAccRoleWithLogin(roleName string, login bool) string {

--- a/pkg/resources/resource_role_test.go
+++ b/pkg/resources/resource_role_test.go
@@ -52,7 +52,7 @@ func TestResourceRoleCreate(t *testing.T) {
 	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT;`,
+			`CREATE ROLE "role" WITH INHERIT;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
@@ -77,7 +77,7 @@ func TestResourceRoleCreateWithLogin(t *testing.T) {
 	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH LOGIN;`,
+			`CREATE ROLE "role" WITH INHERIT LOGIN;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
@@ -102,7 +102,7 @@ func TestResourceRoleCreateWithPasswordAndLogin(t *testing.T) {
 	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH LOGIN PASSWORD 'password123';`,
+			`CREATE ROLE "role" WITH INHERIT LOGIN PASSWORD 'password123';`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id
@@ -127,7 +127,7 @@ func TestResourceRoleCreateWithPasswordNoLogin(t *testing.T) {
 	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
 		// Create
 		mock.ExpectExec(
-			`CREATE ROLE "role" INHERIT WITH PASSWORD 'password123';`,
+			`CREATE ROLE "role" WITH INHERIT PASSWORD 'password123';`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id


### PR DESCRIPTION
Fixes #780