### PR TITLE
Fix Kafka source table REFERENCE to use string quoting for topic names

### DIFF
--- a/pkg/materialize/source_table.go
+++ b/pkg/materialize/source_table.go
@@ -166,12 +166,7 @@ func (b *SourceTableBuilder) BaseCreate(sourceType string, additionalOptions fun
 		if b.upstreamSchemaName != "" {
 			q.WriteString(fmt.Sprintf(`%s.`, QuoteIdentifier(b.upstreamSchemaName)))
 		}
-		// Kafka topic names are string literals, not SQL identifiers
-		if sourceType == "kafka" {
-			q.WriteString(QuoteString(b.upstreamName))
-		} else {
-			q.WriteString(QuoteIdentifier(b.upstreamName))
-		}
+		q.WriteString(QuoteIdentifier(b.upstreamName))
 
 		q.WriteString(")")
 	}

--- a/pkg/materialize/source_table_kafka_test.go
+++ b/pkg/materialize/source_table_kafka_test.go
@@ -13,7 +13,7 @@ func TestResourceSourceTableKafkaCreate(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."source"
             FROM SOURCE "database"."schema"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT JSON
             INCLUDE KEY AS "message_key", HEADERS AS "message_headers", PARTITION AS "message_partition"
             ENVELOPE UPSERT
@@ -45,7 +45,7 @@ func TestResourceSourceTableKafkaCreateWithAvroFormat(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."source"
             FROM SOURCE "database"."schema"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "database"."schema"."schema_registry"
             KEY STRATEGY EXTRACT
             VALUE STRATEGY EXTRACT
@@ -78,7 +78,7 @@ func TestResourceSourceTableKafkaCreateWithDashedTopic(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."source"
             FROM SOURCE "database"."schema"."kafka_source"
-            \(REFERENCE 'tidb-cloud-kouzoh-eagle-insight-jp-dbz-eagle-insight-eagle-insight-ads'\)
+            \(REFERENCE "tidb-cloud-kouzoh-eagle-insight-jp-dbz-eagle-insight-eagle-insight-ads"\)
             FORMAT JSON
             ENVELOPE NONE;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -101,7 +101,7 @@ func TestResourceSourceTableKafkaCreateWithUpsertOptions(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."source"
             FROM SOURCE "database"."schema"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT JSON
             INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP
             ENVELOPE UPSERT \(VALUE DECODING ERRORS = \(INLINE AS "my_error_col"\)\)

--- a/pkg/provider/acceptance_source_table_kafka_test.go
+++ b/pkg/provider/acceptance_source_table_kafka_test.go
@@ -279,7 +279,7 @@ func testAccSourceTableKafkaDashedTopicResource(nameSpace string) string {
 
 		topic = "terraform-dashed-topic"
 
-		value_format {
+		format {
 			json = true
 		}
 	}

--- a/pkg/resources/resource_source_table_kafka_test.go
+++ b/pkg/resources/resource_source_table_kafka_test.go
@@ -65,7 +65,7 @@ func TestResourceSourceTableKafkaCreate(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT JSON
             INCLUDE KEY AS "message_key", HEADERS AS "message_headers", PARTITION AS "message_partition"
             ENVELOPE UPSERT \(VALUE DECODING ERRORS = \(INLINE AS "decoding_error"\)\);`,
@@ -184,7 +184,7 @@ func TestResourceSourceTableKafkaCreateWithAvroFormat(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table_avro"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."sr_conn"
             ENVELOPE DEBEZIUM;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -224,7 +224,7 @@ func TestResourceSourceTableKafkaCreateIncludeTrueNoAlias(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT JSON
             INCLUDE KEY, HEADERS, PARTITION, OFFSET, TIMESTAMP
             ENVELOPE UPSERT \(VALUE DECODING ERRORS = \(INLINE AS "decoding_error"\)\);`,
@@ -262,7 +262,7 @@ func TestResourceSourceTableKafkaCreateIncludeFalseWithAlias(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT JSON
             ENVELOPE UPSERT \(VALUE DECODING ERRORS = \(INLINE AS "decoding_error"\)\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -314,7 +314,7 @@ func TestResourceSourceTableKafkaCreateWithCSVFormat(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table_csv"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT CSV WITH HEADER \( column1, column2, column3 \) DELIMITER ',';`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -375,7 +375,7 @@ func TestResourceSourceTableKafkaCreateWithKeyAndValueFormat(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table_key_value"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             KEY FORMAT JSON
             VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."sr_conn";`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -438,7 +438,7 @@ func TestResourceSourceTableKafkaCreateWithProtobufFormat(t *testing.T) {
 		mock.ExpectExec(
 			`CREATE TABLE "database"."schema"."table_protobuf"
             FROM SOURCE "materialize"."public"."kafka_source"
-            \(REFERENCE 'topic'\)
+            \(REFERENCE "topic"\)
             FORMAT PROTOBUF MESSAGE 'MyMessage' USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."sr_conn"
             ENVELOPE NONE;`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))


### PR DESCRIPTION
As reported, Kafka topic names in the `REFERENCE` clause were incorrectly quoted as SQL identifiers (double quotes) instead of string literals (single quotes), causing a parse error when topic names contain dashes. This changes `BaseCreate()` to use `QuoteString()` for Kafka source types, matching the existing behavior in `source_kafka.go` for the `TOPIC` clause.
