### PR TITLE
Make topic optional on materialize_source_kafka to support create table from source

### DIFF
--- a/docs/resources/source_kafka.md
+++ b/docs/resources/source_kafka.md
@@ -49,7 +49,6 @@ resource "materialize_source_kafka" "example_source_kafka" {
 
 - `kafka_connection` (Block List, Min: 1, Max: 1) The Kafka connection to use in the source. (see [below for nested schema](#nestedblock--kafka_connection))
 - `name` (String) The identifier for the source.
-- `topic` (String) The Kafka topic you want to subscribe to.
 
 ### Optional
 
@@ -75,6 +74,7 @@ resource "materialize_source_kafka" "example_source_kafka" {
 - `schema_name` (String) The identifier for the source schema in Materialize. Defaults to `public`.
 - `start_offset` (List of Number) Read partitions from the specified offset.
 - `start_timestamp` (Number) Use the specified value to set `START OFFSET` based on the Kafka timestamp.
+- `topic` (String) The Kafka topic you want to subscribe to. If not specified, topics are specified at the table level using materialize_source_table_kafka resources.
 - `value_format` (Block List, Max: 1, Deprecated) (Deprecated) Set the value format explicitly. Use `materialize_source_table_kafka` resources instead. (see [below for nested schema](#nestedblock--value_format))
 
 ### Read-Only

--- a/pkg/materialize/source_kafka.go
+++ b/pkg/materialize/source_kafka.go
@@ -211,24 +211,28 @@ func (b *SourceKafkaBuilder) Create() error {
 	}
 
 	q.WriteString(fmt.Sprintf(` FROM KAFKA CONNECTION %s`, b.kafkaConnection.QualifiedName()))
-	q.WriteString(fmt.Sprintf(` (TOPIC %s`, QuoteString(b.topic)))
 
-	// Time-based Offsets
-	if b.startTimestamp != 0 {
-		q.WriteString(fmt.Sprintf(`, START TIMESTAMP %d`, b.startTimestamp))
-	}
-	if len(b.startOffset) > 0 {
-		o := ""
-		for _, v := range b.startOffset {
-			if len(o) > 0 {
-				o += ","
-			}
-			o += strconv.Itoa((v))
+	// Topic and connection options are grouped in parentheses
+	if b.topic != "" {
+		q.WriteString(fmt.Sprintf(` (TOPIC %s`, QuoteString(b.topic)))
+
+		// Time-based Offsets
+		if b.startTimestamp != 0 {
+			q.WriteString(fmt.Sprintf(`, START TIMESTAMP %d`, b.startTimestamp))
 		}
-		q.WriteString(fmt.Sprintf(`, START OFFSET (%s)`, o))
-	}
+		if len(b.startOffset) > 0 {
+			o := ""
+			for _, v := range b.startOffset {
+				if len(o) > 0 {
+					o += ","
+				}
+				o += strconv.Itoa((v))
+			}
+			q.WriteString(fmt.Sprintf(`, START OFFSET (%s)`, o))
+		}
 
-	q.WriteString(`)`)
+		q.WriteString(`)`)
+	}
 
 	// Format
 	if b.format.Avro != nil {

--- a/pkg/materialize/source_kafka_test.go
+++ b/pkg/materialize/source_kafka_test.go
@@ -38,6 +38,25 @@ func TestResourceSourceKafkaCreate(t *testing.T) {
 	})
 }
 
+func TestResourceSourceKafkaCreateWithoutTopic(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."source"
+            FROM KAFKA CONNECTION "database"."schema"."kafka_connection"
+            EXPOSE PROGRESS AS "database"."schema"."progress";`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "source", SchemaName: "schema", DatabaseName: "database"}
+		b := NewSourceKafkaBuilder(db, o)
+		b.KafkaConnection(IdentifierSchemaStruct{Name: "kafka_connection", DatabaseName: "database", SchemaName: "schema"})
+		b.ExposeProgress(IdentifierSchemaStruct{Name: "progress", DatabaseName: "database", SchemaName: "schema"})
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestResourceSourceKafkaCreateWithUpsertOptions(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -227,6 +227,46 @@ func TestAccSourceKafka_disappears(t *testing.T) {
 	})
 }
 
+func TestAccSourceKafka_noTopic(t *testing.T) {
+	nameSpace := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSourceKafkaNoTopicResource(nameSpace),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSourceKafkaExists("materialize_source_kafka.test_no_topic"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test_no_topic", "name", nameSpace+"_source_no_topic"),
+					resource.TestCheckResourceAttr("materialize_source_kafka.test_no_topic", "topic", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccSourceKafkaNoTopicResource(nameSpace string) string {
+	return fmt.Sprintf(`
+	resource "materialize_connection_kafka" "kafka_connection" {
+		name = "%[1]s_connection_kafka"
+		kafka_broker {
+			broker = "redpanda:9092"
+		}
+		security_protocol = "PLAINTEXT"
+	}
+
+	resource "materialize_source_kafka" "test_no_topic" {
+		name         = "%[1]s_source_no_topic"
+		cluster_name = "quickstart"
+
+		kafka_connection {
+			name = materialize_connection_kafka.kafka_connection.name
+		}
+	}
+	`, nameSpace)
+}
+
 func testAccSourceKafkaResource(roleName, connName, sourceName, source2Name, sourceOwner, comment string) string {
 	return fmt.Sprintf(`
 	resource "materialize_role" "test" {

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -26,9 +26,9 @@ var sourceKafkaSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	}),
 	"topic": {
-		Description: "The Kafka topic you want to subscribe to.",
+		Description: "The Kafka topic you want to subscribe to. If not specified, topics are specified at the table level using materialize_source_table_kafka resources.",
 		Type:        schema.TypeString,
-		Required:    true,
+		Optional:    true,
 		ForceNew:    true,
 	},
 	"include_key": {

--- a/pkg/resources/resource_source_kafka_test.go
+++ b/pkg/resources/resource_source_kafka_test.go
@@ -289,6 +289,45 @@ func TestResourceSourceKafkaCreateIncludeFalseWithAlias(t *testing.T) {
 	})
 }
 
+func TestResourceSourceKafkaCreateWithoutTopic(t *testing.T) {
+	r := require.New(t)
+
+	inSourceKafkaNoTopic := map[string]interface{}{
+		"name":             "source_no_topic",
+		"schema_name":      "schema",
+		"database_name":    "database",
+		"cluster_name":     "cluster",
+		"kafka_connection": []interface{}{map[string]interface{}{"name": "kafka_conn"}},
+	}
+
+	d := schema.TestResourceDataRaw(t, SourceKafka().Schema, inSourceKafkaNoTopic)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Create
+		mock.ExpectExec(
+			`CREATE SOURCE "database"."schema"."source_no_topic"
+			IN CLUSTER "cluster" FROM KAFKA CONNECTION "materialize"."public"."kafka_conn";`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Id
+		ip := `WHERE mz_databases.name = 'database' AND mz_schemas.name = 'schema' AND mz_sources.name = 'source_no_topic'`
+		testhelpers.MockSourceScan(mock, ip)
+
+		// Query Params
+		pp := `WHERE mz_sources.id = 'u1'`
+		testhelpers.MockSourceScan(mock, pp)
+
+		// Query Subsources
+		ps := `WHERE filter_id = 'u1' AND type = 'source'`
+		testhelpers.MockSubsourceScan(mock, ps)
+
+		if err := sourceKafkaCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestResourceSourceKafkaCreateTextFormat(t *testing.T) {
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, SourceKafka().Schema, inSourceKafkaText)


### PR DESCRIPTION
As reported, the `topic` parameter on `materialize_source_kafka` has to be optional, allowing users to create a single Kafka source and specify different topics at the table level via `materialize_source_table_kafka` resources. 

Update: currently limited on the database side, discussing this internally