### PR TITLE
Add 'options' override for Materialize provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **Provider `options` configuration** [#859](https://github.com/MaterializeInc/terraform-provider-materialize/pull/859): Added an `options` map to the provider schema that forwards arbitrary Postgres connection options (such as `cluster`, `search_path`, or `oidc_auth_enabled`) through the `options` parameter of the connection string. This unblocks connecting to Self-Managed Materialize with [OIDC/SSO authentication](https://materialize.com/docs/security/self-managed/sso/), which requires `oidc_auth_enabled=true`. The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.
+
 ## 0.11.2 - 2026-02-18
 
 ### Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,30 @@ provider "materialize" {
 }
 
 # =============================================================================
+# Self-Hosted Materialize with OIDC/SSO Authentication
+# =============================================================================
+# Use this configuration when Self-Managed Materialize is deployed with
+# `authenticatorKind: Oidc`. The `oidc_auth_enabled=true` connection option is
+# REQUIRED — without it, Materialize falls back to password authentication.
+#
+# The `password` field should be an OIDC ID token obtained from your identity
+# provider; the `username` should be the value of the JWT claim configured via
+# `oidc_authentication_claim` (e.g. the user's email).
+#
+# See https://materialize.com/docs/security/self-managed/sso/ for details.
+#
+provider "materialize" {
+  host     = "materialized"
+  port     = 6875
+  username = var.oidc_username # e.g. alice@your-org.com
+  password = var.oidc_id_token # OIDC ID token from your IdP
+  database = "materialize"
+  options = {
+    oidc_auth_enabled = "true"
+  }
+}
+
+# =============================================================================
 # Migration Note
 # =============================================================================
 # Switching between SaaS and self-hosted modes requires careful state file
@@ -79,6 +103,32 @@ These organization and identity management resources depend on Frontegg (Materia
 * `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
+* `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.
+
+## Authenticating via OIDC/SSO (self-hosted)
+
+When Self-Managed Materialize is configured for [OIDC authentication](https://materialize.com/docs/security/self-managed/sso/),
+connect by passing `oidc_auth_enabled = "true"` via the `options` map and using
+an OIDC ID token as the password:
+
+```terraform
+provider "materialize" {
+  host     = "materialized"
+  port     = 6875
+  username = var.oidc_username # e.g. the value of the `oidc_authentication_claim`
+  password = var.oidc_id_token # an OIDC ID token from your IdP
+  database = "materialize"
+  options = {
+    oidc_auth_enabled = "true"
+  }
+}
+```
+
+**Token lifetime:** Materialize validates the OIDC token at connection time
+only. If a single `terraform apply` outlives the token's expiry and the
+provider needs to reconnect, authentication will fail. Use a token with a
+lifetime comfortably longer than your longest apply, or plan to rerun with a
+fresh token.
 
 ## Order precedence
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -31,6 +31,30 @@ provider "materialize" {
 }
 
 # =============================================================================
+# Self-Hosted Materialize with OIDC/SSO Authentication
+# =============================================================================
+# Use this configuration when Self-Managed Materialize is deployed with
+# `authenticatorKind: Oidc`. The `oidc_auth_enabled=true` connection option is
+# REQUIRED — without it, Materialize falls back to password authentication.
+#
+# The `password` field should be an OIDC ID token obtained from your identity
+# provider; the `username` should be the value of the JWT claim configured via
+# `oidc_authentication_claim` (e.g. the user's email).
+#
+# See https://materialize.com/docs/security/self-managed/sso/ for details.
+#
+provider "materialize" {
+  host     = "materialized"
+  port     = 6875
+  username = var.oidc_username # e.g. alice@your-org.com
+  password = var.oidc_id_token # OIDC ID token from your IdP
+  database = "materialize"
+  options = {
+    oidc_auth_enabled = "true"
+  }
+}
+
+# =============================================================================
 # Migration Note
 # =============================================================================
 # Switching between SaaS and self-hosted modes requires careful state file

--- a/pkg/clients/db_client.go
+++ b/pkg/clients/db_client.go
@@ -3,6 +3,8 @@ package clients
 import (
 	"fmt"
 	"net/url"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/jmoiron/sqlx"
@@ -12,14 +14,14 @@ type DBClient struct {
 	*sqlx.DB
 }
 
-func NewDBClient(host, user, password string, port int, database, application_name, version, sslmode string) (*DBClient, diag.Diagnostics) {
+func NewDBClient(host, user, password string, port int, database, application_name, version, sslmode string, options map[string]string) (*DBClient, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if application_name == "" {
 		application_name = fmt.Sprintf("terraform-provider-materialize v%s", version)
 	}
 
-	connStr := buildConnectionString(host, user, password, port, database, sslmode, application_name)
+	connStr := buildConnectionString(host, user, password, port, database, sslmode, application_name, options)
 	db, err := sqlx.Open("pgx", connStr)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -32,8 +34,17 @@ func NewDBClient(host, user, password string, port int, database, application_na
 	return &DBClient{DB: db}, diags
 }
 
-func buildConnectionString(host, user, password string, port int, database, sslmode, application_name string) string {
-	options := "--transaction_isolation=strict\\ serializable"
+func buildConnectionString(host, user, password string, port int, database, sslmode, application_name string, options map[string]string) string {
+	parts := []string{`--transaction_isolation=strict\ serializable`}
+
+	keys := make([]string, 0, len(options))
+	for k := range options {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("--%s=%s", escapeOptionToken(k), escapeOptionToken(options[k])))
+	}
 
 	url := &url.URL{
 		Scheme: "postgres",
@@ -43,11 +54,17 @@ func buildConnectionString(host, user, password string, port int, database, sslm
 		RawQuery: url.Values{
 			"application_name": {application_name},
 			"sslmode":          {sslmode},
-			"options":          {options},
+			"options":          {strings.Join(parts, " ")},
 		}.Encode(),
 	}
 
 	return url.String()
+}
+
+func escapeOptionToken(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, ` `, `\ `)
+	return s
 }
 
 func (c *DBClient) SQLX() *sqlx.DB {

--- a/pkg/clients/db_client_test.go
+++ b/pkg/clients/db_client_test.go
@@ -8,20 +8,37 @@ import (
 
 func TestConnectionString(t *testing.T) {
 	r := require.New(t)
-	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf")
+	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf", nil)
 	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable&sslmode=require`, c)
 }
 
 func TestConnectionStringTesting(t *testing.T) {
 	r := require.New(t)
-	c := buildConnectionString("host", "user", "pass", 6875, "database", "disable", "tf")
+	c := buildConnectionString("host", "user", "pass", 6875, "database", "disable", "tf", nil)
 	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable&sslmode=disable`, c)
+}
+
+func TestConnectionStringWithOptions(t *testing.T) {
+	r := require.New(t)
+	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf", map[string]string{
+		"search_path": "public,extra",
+		"cluster":     "quickstart",
+	})
+	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable+--cluster%3Dquickstart+--search_path%3Dpublic%2Cextra&sslmode=require`, c)
+}
+
+func TestConnectionStringOptionEscaping(t *testing.T) {
+	r := require.New(t)
+	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf", map[string]string{
+		"application_name": "my app",
+	})
+	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable+--application_name%3Dmy%5C+app&sslmode=require`, c)
 }
 
 func TestNewDBClientFailure(t *testing.T) {
 	r := require.New(t)
 
-	client, diags := NewDBClient("localhost", "user", "pass", 6875, "database", "tf-provider", "v0.1.0", "invalid-sslmode")
+	client, diags := NewDBClient("localhost", "user", "pass", 6875, "database", "tf-provider", "v0.1.0", "invalid-sslmode", nil)
 	r.NotEmpty(diags)
 	r.Nil(client)
 }

--- a/pkg/clients/db_client_test.go
+++ b/pkg/clients/db_client_test.go
@@ -35,6 +35,19 @@ func TestConnectionStringOptionEscaping(t *testing.T) {
 	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable+--application_name%3Dmy%5C+app&sslmode=require`, c)
 }
 
+// Guard against regressions in escapeOptionToken: backslashes MUST be escaped
+// before spaces, otherwise an input like `a\ b` (backslash + space) would
+// double-escape the newly added backslash and produce a malformed token.
+func TestConnectionStringBackslashAndSpaceEscaping(t *testing.T) {
+	r := require.New(t)
+	c := buildConnectionString("host", "user", "pass", 6875, "database", "require", "tf", map[string]string{
+		"search_path": `a\b c`,
+	})
+	// The options value after escaping is `--search_path=a\\b\ c`, which the
+	// URL encoder renders with %5C for each backslash and + for the space.
+	r.Equal(`postgres://user:pass@host:6875/database?application_name=tf&options=--transaction_isolation%3Dstrict%5C+serializable+--search_path%3Da%5C%5Cb%5C+c&sslmode=require`, c)
+}
+
 func TestNewDBClientFailure(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/datasources"
@@ -11,10 +12,55 @@ import (
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/resources"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	_ "github.com/jackc/pgx/v4/stdlib"
 )
+
+// reservedOptionKeys are connection parameters the provider manages itself.
+// Accepting them via `options` would either conflict with a dedicated schema
+// field (application_name) or break Materialize outright (transaction_isolation
+// must remain `strict serializable`).
+var reservedOptionKeys = map[string]string{
+	"transaction_isolation": "Materialize requires `transaction_isolation=strict serializable`; overriding it will break the provider.",
+	"application_name":      "`application_name` is set by the provider.",
+}
+
+var optionKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func validateProviderOptions(v interface{}, p cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	raw, ok := v.(map[string]interface{})
+	if !ok {
+		return diags
+	}
+	for k, val := range raw {
+		if reason, reserved := reservedOptionKeys[k]; reserved {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("option %q is reserved", k),
+				Detail:   reason,
+			})
+			continue
+		}
+		if !optionKeyPattern.MatchString(k) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("invalid option key %q", k),
+				Detail:   "Option keys must start with a letter or underscore and contain only letters, digits, or underscores.",
+			})
+		}
+		if _, ok := val.(string); !ok && val != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("invalid option value for %q", k),
+				Detail:   "Option values must be strings.",
+			})
+		}
+	}
+	return diags
+}
 
 func Provider(version string) *schema.Provider {
 	return &schema.Provider{
@@ -82,10 +128,11 @@ func Provider(version string) *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("MZ_USERNAME", "materialize"),
 			},
 			"options": {
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: "Additional Postgres connection options forwarded as `--key=value` flags in the `options` connection string parameter. Note: `transaction_isolation` defaults to `strict serializable` (required by Materialize) unless overridden here.",
+				Type:             schema.TypeMap,
+				Optional:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				ValidateDiagFunc: validateProviderOptions,
+				Description:      "Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/datasources"
@@ -22,6 +23,9 @@ import (
 // Accepting them via `options` would either conflict with a dedicated schema
 // field (application_name) or break Materialize outright (transaction_isolation
 // must remain `strict serializable`).
+//
+// Keys here MUST be lowercase. Postgres GUC names are case-insensitive, so the
+// validator lowercases incoming keys before looking them up.
 var reservedOptionKeys = map[string]string{
 	"transaction_isolation": "Materialize requires `transaction_isolation=strict serializable`; overriding it will break the provider.",
 	"application_name":      "`application_name` is set by the provider.",
@@ -36,7 +40,7 @@ func validateProviderOptions(v interface{}, p cty.Path) diag.Diagnostics {
 		return diags
 	}
 	for k, val := range raw {
-		if reason, reserved := reservedOptionKeys[k]; reserved {
+		if reason, reserved := reservedOptionKeys[strings.ToLower(k)]; reserved {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  fmt.Sprintf("option %q is reserved", k),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -81,6 +81,12 @@ func Provider(version string) *schema.Provider {
 				Description: "The Materialize username. Can also come from the `MZ_USERNAME` environment variable.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_USERNAME", "materialize"),
 			},
+			"options": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Additional Postgres connection options forwarded as `--key=value` flags in the `options` connection string parameter. Note: `transaction_isolation` defaults to `strict serializable` (required by Materialize) unless overridden here.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"materialize_app_password":                         resources.AppPassword(),
@@ -201,6 +207,7 @@ func configureSelfHosted(ctx context.Context, d *schema.ResourceData, version st
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
 	sslmode := d.Get("sslmode").(string)
+	options := optionsFromResourceData(d)
 	application_name := fmt.Sprintf("terraform-provider-materialize v%s", version)
 
 	// Initialize single DB client for self-hosted
@@ -213,6 +220,7 @@ func configureSelfHosted(ctx context.Context, d *schema.ResourceData, version st
 		application_name,
 		version,
 		sslmode,
+		options,
 	)
 	if diags.HasError() {
 		return nil, diags
@@ -234,6 +242,20 @@ func configureSelfHosted(ctx context.Context, d *schema.ResourceData, version st
 	return providerMeta, nil
 }
 
+func optionsFromResourceData(d *schema.ResourceData) map[string]string {
+	raw, ok := d.Get("options").(map[string]interface{})
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
 func configureSaaS(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
 	password := d.Get("password").(string)
 	database := d.Get("database").(string)
@@ -242,6 +264,7 @@ func configureSaaS(ctx context.Context, d *schema.ResourceData, version string) 
 	cloudEndpoint := d.Get("cloud_endpoint").(string)
 	defaultRegion := clients.Region(d.Get("default_region").(string))
 	baseEndpoint := d.Get("base_endpoint").(string)
+	options := optionsFromResourceData(d)
 	application_name := fmt.Sprintf("terraform-provider-materialize v%s", version)
 
 	err := utils.SetDefaultRegion(string(defaultRegion))
@@ -295,7 +318,7 @@ func configureSaaS(ctx context.Context, d *schema.ResourceData, version string) 
 		user := fronteggClient.Email
 
 		// Instantiate a new DB client for the region
-		dbClient, diags := clients.NewDBClient(host, user, password, port, database, application_name, version, sslmode)
+		dbClient, diags := clients.NewDBClient(host, user, password, port, database, application_name, version, sslmode, options)
 		if diags.HasError() {
 			log.Printf("[ERROR] Error initializing DB client for region %s: %v\n", provider.ID, diags)
 			continue

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -33,6 +33,27 @@ func TestProvider_impl(t *testing.T) {
 	var _ *schema.Provider = Provider("test")
 }
 
+func TestProviderOptionsSchema(t *testing.T) {
+	p := Provider("test")
+	s, ok := p.Schema["options"]
+	if !ok {
+		t.Fatal("provider schema missing `options` field")
+	}
+	if s.Type != schema.TypeMap {
+		t.Fatalf("expected options Type == TypeMap, got %v", s.Type)
+	}
+	if !s.Optional {
+		t.Fatal("expected options to be Optional")
+	}
+	elem, ok := s.Elem.(*schema.Schema)
+	if !ok {
+		t.Fatalf("expected options Elem to be *schema.Schema, got %T", s.Elem)
+	}
+	if elem.Type != schema.TypeString {
+		t.Fatalf("expected options Elem Type == TypeString, got %v", elem.Type)
+	}
+}
+
 var testAccProvider = Provider("test")
 var testAccProviderFactories = map[string]func() (*schema.Provider, error){
 	"materialize": func() (*schema.Provider, error) { return testAccProvider, nil },

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -51,6 +52,106 @@ func TestProviderOptionsSchema(t *testing.T) {
 	}
 	if elem.Type != schema.TypeString {
 		t.Fatalf("expected options Elem Type == TypeString, got %v", elem.Type)
+	}
+	if s.ValidateDiagFunc == nil {
+		t.Fatal("expected options to have a ValidateDiagFunc")
+	}
+}
+
+func TestValidateProviderOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name:  "valid keys pass",
+			input: map[string]interface{}{"cluster": "quickstart", "search_path": "public"},
+		},
+		{
+			name:  "nil input",
+			input: nil,
+		},
+		{
+			name:  "empty map",
+			input: map[string]interface{}{},
+		},
+		{
+			name:  "oidc option passes",
+			input: map[string]interface{}{"oidc_auth_enabled": "true"},
+		},
+		{
+			name:    "transaction_isolation is reserved",
+			input:   map[string]interface{}{"transaction_isolation": "serializable"},
+			wantErr: true,
+			errSub:  "transaction_isolation",
+		},
+		{
+			name:    "application_name is reserved",
+			input:   map[string]interface{}{"application_name": "custom"},
+			wantErr: true,
+			errSub:  "application_name",
+		},
+		{
+			name:    "invalid key with space",
+			input:   map[string]interface{}{"bad key": "v"},
+			wantErr: true,
+			errSub:  "invalid option key",
+		},
+		{
+			name:    "invalid key starting with digit",
+			input:   map[string]interface{}{"1abc": "v"},
+			wantErr: true,
+			errSub:  "invalid option key",
+		},
+		{
+			name:    "empty key",
+			input:   map[string]interface{}{"": "v"},
+			wantErr: true,
+			errSub:  "invalid option key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := validateProviderOptions(tc.input, nil)
+			hasErr := diags.HasError()
+			if hasErr != tc.wantErr {
+				t.Fatalf("got diags=%v, wantErr=%v", diags, tc.wantErr)
+			}
+			if tc.wantErr && tc.errSub != "" {
+				found := false
+				for _, d := range diags {
+					if strings.Contains(d.Summary, tc.errSub) || strings.Contains(d.Detail, tc.errSub) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected a diagnostic mentioning %q, got %v", tc.errSub, diags)
+				}
+			}
+		})
+	}
+}
+
+func TestOptionsFromResourceData(t *testing.T) {
+	s := Provider("test").Schema
+	r := schema.TestResourceDataRaw(t, s, map[string]interface{}{
+		"options": map[string]interface{}{
+			"cluster":           "quickstart",
+			"oidc_auth_enabled": "true",
+		},
+	})
+	got := optionsFromResourceData(r)
+	if got["cluster"] != "quickstart" || got["oidc_auth_enabled"] != "true" {
+		t.Fatalf("unexpected options map: %v", got)
+	}
+
+	empty := schema.TestResourceDataRaw(t, s, map[string]interface{}{})
+	if optionsFromResourceData(empty) != nil {
+		t.Fatal("expected nil options when map is unset")
 	}
 }
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -94,6 +94,18 @@ func TestValidateProviderOptions(t *testing.T) {
 			errSub:  "application_name",
 		},
 		{
+			name:    "reserved key check is case-insensitive",
+			input:   map[string]interface{}{"Transaction_Isolation": "serializable"},
+			wantErr: true,
+			errSub:  "Transaction_Isolation",
+		},
+		{
+			name:    "reserved key check catches uppercase application_name",
+			input:   map[string]interface{}{"APPLICATION_NAME": "custom"},
+			wantErr: true,
+			errSub:  "APPLICATION_NAME",
+		},
+		{
 			name:    "invalid key with space",
 			input:   map[string]interface{}{"bad key": "v"},
 			wantErr: true,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -41,6 +41,32 @@ These organization and identity management resources depend on Frontegg (Materia
 * `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
+* `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.
+
+## Authenticating via OIDC/SSO (self-hosted)
+
+When Self-Managed Materialize is configured for [OIDC authentication](https://materialize.com/docs/security/self-managed/sso/),
+connect by passing `oidc_auth_enabled = "true"` via the `options` map and using
+an OIDC ID token as the password:
+
+```terraform
+provider "materialize" {
+  host     = "materialized"
+  port     = 6875
+  username = var.oidc_username # e.g. the value of the `oidc_authentication_claim`
+  password = var.oidc_id_token # an OIDC ID token from your IdP
+  database = "materialize"
+  options = {
+    oidc_auth_enabled = "true"
+  }
+}
+```
+
+**Token lifetime:** Materialize validates the OIDC token at connection time
+only. If a single `terraform apply` outlives the token's expiry and the
+provider needs to reconnect, authentication will fail. Use a token with a
+lifetime comfortably longer than your longest apply, or plan to rerun with a
+fresh token.
 
 ## Order precedence
 


### PR DESCRIPTION
Adds an `options` map to the provider so you can forward arbitrary Postgres connection options. The main driver is the new [OIDC/SSO authentication](https://github.com/MaterializeInc/materialize/pull/35591) in Self-Managed Materialize, which requires `oidc_auth_enabled=true` on the wire protocol — otherwise it falls back to password auth.

```hcl
provider "materialize" {
  host     = "materialized"
  username = var.oidc_username # value of the oidc_authentication_claim
  password = var.oidc_id_token # OIDC ID token from your IdP
  options = {
    oidc_auth_enabled = "true"
  }
}
```

The `--transaction_isolation=strict\ serializable` default is still prepended (Materialize needs it), and `transaction_isolation` / `application_name` are reserved — a `ValidateDiagFunc` catches collisions and bad key names at plan time. Keys are sorted so the connection string is deterministic; spaces and backslashes are escaped.

Also includes docs + an OIDC example in `examples/provider/provider.tf`, a CHANGELOG entry, and unit tests for the validator and connection-string shape.

Acceptance test needs a live Materialize running with `authenticatorKind: Oidc` and a working IdP; tracked in #860.