### PR TITLE
Fix flaky TestAccDataSourceSourceTable_basic

### DIFF
--- a/pkg/provider/acceptance_datasource_source_table_test.go
+++ b/pkg/provider/acceptance_datasource_source_table_test.go
@@ -2,35 +2,78 @@ package provider
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceSourceTable_basic(t *testing.T) {
 	nameSpace := acctest.RandomWithPrefix("tf_test")
+	tableName := fmt.Sprintf("%s_table", nameSpace)
+	sourceName := fmt.Sprintf("%s_source", nameSpace)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSourceTable(nameSpace),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.name", fmt.Sprintf("%s_table", nameSpace)),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.schema_name", "public"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.database_name", "materialize"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.source.#", "1"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.source.0.name", fmt.Sprintf("%s_source", nameSpace)),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.source.0.schema_name", "public"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.source.0.database_name", "materialize"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.source_type", "postgres"),
-					resource.TestCheckResourceAttr("data.materialize_source_table.test", "tables.0.comment", "test comment"),
-					resource.TestCheckResourceAttrSet("data.materialize_source_table.test", "tables.0.owner_name"),
+				Check: checkSourceTableInDataSource(
+					"data.materialize_source_table.test", tableName,
+					map[string]string{
+						"schema_name":            "public",
+						"database_name":          "materialize",
+						"source.#":               "1",
+						"source.0.name":          sourceName,
+						"source.0.schema_name":   "public",
+						"source.0.database_name": "materialize",
+						"source_type":            "postgres",
+						"comment":                "test comment",
+					},
+					[]string{"owner_name"},
 				),
 			},
 		},
 	})
+}
+
+// checkSourceTableInDataSource locates the entry named `tableName` inside the
+// `tables.*` list of a `materialize_source_table` data source and asserts the
+// given attributes against it. The data source has no name filter and returns
+// every source table in the schema, so indexing with `tables.0` is unreliable
+// when parallel tests share `materialize.public`.
+func checkSourceTableInDataSource(dataSource, tableName string, equals map[string]string, set []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSource]
+		if !ok {
+			return fmt.Errorf("data source %q not found in state", dataSource)
+		}
+		attrs := rs.Primary.Attributes
+		count, err := strconv.Atoi(attrs["tables.#"])
+		if err != nil {
+			return fmt.Errorf("could not read tables.# on %s: %w", dataSource, err)
+		}
+		for i := 0; i < count; i++ {
+			prefix := fmt.Sprintf("tables.%d.", i)
+			if attrs[prefix+"name"] != tableName {
+				continue
+			}
+			for k, want := range equals {
+				if got := attrs[prefix+k]; got != want {
+					return fmt.Errorf("%s%s = %q, want %q", prefix, k, got, want)
+				}
+			}
+			for _, k := range set {
+				if attrs[prefix+k] == "" {
+					return fmt.Errorf("%s%s is empty, expected to be set", prefix, k)
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("source table %q not found in %s (searched %d entries)", tableName, dataSource, count)
+	}
 }
 
 func testAccDataSourceSourceTable(nameSpace string) string {


### PR DESCRIPTION
`materialize_source_table` is a listing data source with no name filter, it returns every source table in the schema. The test was asserting `tables.0.name` matched its own randomized table name, which only works if the test's row happens to land at index 0. With parallel tests also writing into `materialize.public`, another test's row can come first and the check fails (seen recently with `*_table_kafka` from a concurrent run).

Replaced the `tables.0.*` assertions with a small helper that walks `tables.*` and matches by the test's own table name, so the check no longer cares about position or other rows being present.

Surfaced while triaging CI failures on #861, unrelated to that PR and to #859.