### PR TITLE
Fix password and sslmode schema descriptions

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -23,7 +23,7 @@ func Provider(version string) *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Materialize host. Can also come from the `MZ_PASSWORD` environment variable.",
+				Description: "Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_PASSWORD", nil),
 			},
 			"database": {
@@ -36,7 +36,7 @@ func Provider(version string) *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MZ_SSLMODE", "require"),
-				Description: "For testing purposes, the SSL mode to use.",
+				Description: "SSL mode to use when connecting to Materialize (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.",
 			},
 			// TODO: Switch name to Admin Endpoint for consistency
 			"endpoint": {


### PR DESCRIPTION
Two longstanding copy-paste / leftover bugs in the provider schema descriptions:

- `password` was described as *"Materialize host."*
- `sslmode` was described as *"For testing purposes, the SSL mode to use."* — it's production-facing.

The hand-maintained docs already had the correct wording; this just brings the schema descriptions in line so the IDE hover and any auto-rendered help match.