### PR TITLE
Update changelog for v0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.11.5 - 2026-06-26
 
 ### Features
 


### PR DESCRIPTION
Cuts the v0.11.5 changelog entry, covering the new broker_matching_rule support for Kafka PrivateLink connections (#881).