### PR TITLE
Bump Go version to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a Terraform provider for managing resources in a [Mater
 
 * Materialize >= 0.27
 * [Terraform](https://www.terraform.io/downloads.html) >= 1.0.3
-* (Development) [Go](https://golang.org/doc/install) >= 1.25
+* (Development) [Go](https://golang.org/doc/install) >= 1.26
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MaterializeInc/terraform-provider-materialize
 
-go 1.25.8
+go 1.26
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/mocks/cloud/README.md
+++ b/mocks/cloud/README.md
@@ -4,7 +4,7 @@ This mock service provides a configurable API for simulating the Materialize clo
 
 ## Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - Docker
 
 ## Configuration

--- a/mocks/cloud/go.mod
+++ b/mocks/cloud/go.mod
@@ -1,3 +1,3 @@
 module cloud-mockserver
 
-go 1.25
+go 1.26


### PR DESCRIPTION
Bumps the Go version from 1.25.8 to 1.26 across go.mod, the mock server module, and the README prerequisites. The Dockerfile and CI workflows already target 1.26 (workflows derive the version from go.mod).