### PR TITLE
Update listener configs for per-route-group allowed_roles schema

### DIFF
--- a/.github/listener_configs/no_auth.json
+++ b/.github/listener_configs/no_auth.json
@@ -17,27 +17,31 @@
     "external": {
       "addr": "0.0.0.0:7876",
       "authenticator_kind": "None",
-      "allowed_roles": "NormalAndInternal",
       "enable_tls": false,
       "routes": {
-        "base": true,
-        "webhook": true,
-        "internal": false,
-        "metrics": false,
-        "profiling": false
+        "base": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "webhook": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "internal": { "enabled": false },
+        "metrics": { "enabled": false },
+        "profiling": { "enabled": false },
+        "mcp_agent": { "enabled": false },
+        "mcp_developer": { "enabled": false },
+        "console_config": { "enabled": false }
       }
     },
     "internal": {
       "addr": "0.0.0.0:7878",
       "authenticator_kind": "None",
-      "allowed_roles": "NormalAndInternal",
       "enable_tls": false,
       "routes": {
-        "base": true,
-        "webhook": true,
-        "internal": true,
-        "metrics": true,
-        "profiling": true
+        "base": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "webhook": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "internal": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "metrics": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "profiling": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "mcp_agent": { "enabled": false },
+        "mcp_developer": { "enabled": false },
+        "console_config": { "enabled": false }
       }
     }
   }

--- a/.github/listener_configs/password.json
+++ b/.github/listener_configs/password.json
@@ -1,44 +1,48 @@
 {
-    "sql": {
-      "external": {
-        "addr": "0.0.0.0:6875",
-        "authenticator_kind": "Password",
-        "allowed_roles": "NormalAndInternal",
-        "enable_tls": false
-      },
-      "internal": {
-        "addr": "0.0.0.0:6877",
-        "authenticator_kind": "None",
-        "allowed_roles": "Internal",
-        "enable_tls": false
+  "sql": {
+    "external": {
+      "addr": "0.0.0.0:6875",
+      "authenticator_kind": "Password",
+      "allowed_roles": "NormalAndInternal",
+      "enable_tls": false
+    },
+    "internal": {
+      "addr": "0.0.0.0:6877",
+      "authenticator_kind": "None",
+      "allowed_roles": "Internal",
+      "enable_tls": false
+    }
+  },
+  "http": {
+    "external": {
+      "addr": "0.0.0.0:6876",
+      "authenticator_kind": "Password",
+      "enable_tls": false,
+      "routes": {
+        "base": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "webhook": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "internal": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "metrics": { "enabled": false },
+        "profiling": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "mcp_agent": { "enabled": false },
+        "mcp_developer": { "enabled": false },
+        "console_config": { "enabled": false }
       }
     },
-    "http": {
-      "external": {
-        "addr": "0.0.0.0:6876",
-        "authenticator_kind": "Password",
-        "allowed_roles": "NormalAndInternal",
-        "enable_tls": false,
-        "routes": {
-          "base": true,
-          "webhook": true,
-          "internal": true,
-          "metrics": false,
-          "profiling": true
-        }
-      },
-      "metrics": {
-        "addr": "0.0.0.0:6878",
-        "authenticator_kind": "None",
-        "allowed_roles": "NormalAndInternal",
-        "enable_tls": false,
-        "routes": {
-          "base": false,
-          "webhook": false,
-          "internal": false,
-          "metrics": true,
-          "profiling": false
-        }
+    "metrics": {
+      "addr": "0.0.0.0:6878",
+      "authenticator_kind": "None",
+      "enable_tls": false,
+      "routes": {
+        "base": { "enabled": false },
+        "webhook": { "enabled": false },
+        "internal": { "enabled": false },
+        "metrics": { "enabled": true, "allowed_roles": "NormalAndInternal" },
+        "profiling": { "enabled": false },
+        "mcp_agent": { "enabled": false },
+        "mcp_developer": { "enabled": false },
+        "console_config": { "enabled": false }
       }
     }
   }
+}


### PR DESCRIPTION
The latest materialized image adopts the new listener config schema where each HTTP route group carries its own `{ "enabled", "allowed_roles" }` instead of a bool, plus new mcp_agent/mcp_developer/console_config groups. Updates no_auth.json and password.json to match so the container stops panicking on startup.