### PR TITLE
Add cluster AUTO SCALING STRATEGY (hydration burst) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-* Fixed `materialize_cluster` size/replication-factor drift under Materialize v26.34+ [#892](https://github.com/MaterializeInc/terraform-provider-materialize/pull/892): resizes are now graceful and proceed in the background, so the read reflects the target of an in-flight resize instead of the stale pre-resize values. Apply stays non-blocking; use `wait_until_ready` to block on completion.
+* Fixed cluster and source size/replication-factor drift under Materialize v26.34+ [#892](https://github.com/MaterializeInc/terraform-provider-materialize/pull/892): resizes are now graceful and proceed in the background, so `materialize_cluster` and `materialize_source_*` reads reflect the target of an in-flight resize instead of the stale pre-resize values. Apply stays non-blocking; use `wait_until_ready` to block on completion.
 
 ## 0.11.5 - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 0.11.6 - 2026-07-21
+## 0.11.6 - Unreleased
 
 ### Features
 
 * **Cluster autoscaling (hydration burst)** [#892](https://github.com/MaterializeInc/terraform-provider-materialize/pull/892): Added an `auto_scaling_strategy` block to `materialize_cluster` so managed clusters can burst to a larger `hydration_size` while they have un-hydrated objects, then return to their steady size. Supports create, alter, reset, and best-effort read-back from `mz_internal.mz_cluster_auto_scaling_strategies`.
+
+### Bug Fixes
+
+* Fixed `materialize_cluster` size/replication-factor drift under Materialize v26.34+ [#892](https://github.com/MaterializeInc/terraform-provider-materialize/pull/892): resizes are now graceful and proceed in the background, so the read reflects the target of an in-flight resize instead of the stale pre-resize values. Apply stays non-blocking; use `wait_until_ready` to block on completion.
 
 ## 0.11.5 - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.6 - 2026-07-21
+
+### Features
+
+* **Cluster autoscaling (hydration burst)** [#892](https://github.com/MaterializeInc/terraform-provider-materialize/pull/892): Added an `auto_scaling_strategy` block to `materialize_cluster` so managed clusters can burst to a larger `hydration_size` while they have un-hydrated objects, then return to their steady size. Supports create, alter, reset, and best-effort read-back from `mz_internal.mz_cluster_auto_scaling_strategies`.
+
 ## 0.11.5 - 2026-06-26
 
 ### Features

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -27,6 +27,7 @@ resource "materialize_cluster" "example_cluster" {
 
 ### Optional
 
+- `auto_scaling_strategy` (Block List, Max: 1) Lets the cluster temporarily burst to a larger size while it has un-hydrated objects, to speed up hydration. Only available on managed clusters and cannot be combined with a non-default `scheduling`. (see [below for nested schema](#nestedblock--auto_scaling_strategy))
 - `availability_zones` (List of String) The specific availability zones of the cluster.
 - `comment` (String) Comment on an object in the database.
 - `disk` (Boolean, Deprecated) **Deprecated**. This attribute is maintained for backward compatibility with existing configurations. New users should use 'cc' sizes for disk access.
@@ -43,6 +44,26 @@ resource "materialize_cluster" "example_cluster" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--auto_scaling_strategy"></a>
+### Nested Schema for `auto_scaling_strategy`
+
+Required:
+
+- `on_hydration` (Block List, Min: 1, Max: 1) Burst to a larger size while the cluster has un-hydrated objects. (see [below for nested schema](#nestedblock--auto_scaling_strategy--on_hydration))
+
+<a id="nestedblock--auto_scaling_strategy--on_hydration"></a>
+### Nested Schema for `auto_scaling_strategy.on_hydration`
+
+Required:
+
+- `hydration_size` (String) The size to burst to while the cluster has un-hydrated objects. Must differ from the cluster's steady `size`.
+
+Optional:
+
+- `linger_duration` (String) How long the burst replica lingers after the steady-size replicas hydrate, before it is removed. Defaults to `0s`.
+
+
 
 <a id="nestedblock--scheduling"></a>
 ### Nested Schema for `scheduling`

--- a/integration/cluster.tf
+++ b/integration/cluster.tf
@@ -62,6 +62,17 @@ resource "materialize_cluster" "scheduling_cluster_us_west" {
   }
 }
 
+resource "materialize_cluster" "autoscaling_cluster" {
+  name = "autoscaling_cluster"
+  size = "25cc"
+  auto_scaling_strategy {
+    on_hydration {
+      hydration_size  = "50cc"
+      linger_duration = "15s"
+    }
+  }
+}
+
 resource "materialize_cluster" "no_replication" {
   name               = "no_replication"
   size               = "25cc"

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -3,6 +3,7 @@ package materialize
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -25,6 +26,7 @@ type ClusterBuilder struct {
 	introspectionInterval  string
 	introspectionDebugging bool
 	schedulingConfig       SchedulingConfig
+	autoScalingConfig      AutoScalingConfig
 }
 
 func NewClusterBuilder(conn *sqlx.DB, obj MaterializeObject) *ClusterBuilder {
@@ -87,6 +89,52 @@ func GetSchedulingConfig(v interface{}) SchedulingConfig {
 
 	if rehydrationTimeEstimate, ok := onRefreshMap["rehydration_time_estimate"].(string); ok {
 		config.OnRefresh.RehydrationTimeEstimate = rehydrationTimeEstimate
+	}
+
+	return config
+}
+
+type AutoScalingConfig struct {
+	IsSet          bool
+	HydrationSize  string
+	LingerDuration string
+}
+
+// GetAutoScalingConfig parses the auto_scaling_strategy TF block into an
+// AutoScalingConfig. An empty/absent block yields IsSet: false.
+func GetAutoScalingConfig(v interface{}) AutoScalingConfig {
+	if v == nil {
+		return AutoScalingConfig{}
+	}
+
+	configSlice, ok := v.([]interface{})
+	if !ok || len(configSlice) == 0 {
+		return AutoScalingConfig{}
+	}
+
+	configMap, ok := configSlice[0].(map[string]interface{})
+	if !ok {
+		return AutoScalingConfig{}
+	}
+
+	onHydrationSlice, ok := configMap["on_hydration"].([]interface{})
+	if !ok || len(onHydrationSlice) == 0 {
+		return AutoScalingConfig{}
+	}
+
+	onHydrationMap, ok := onHydrationSlice[0].(map[string]interface{})
+	if !ok {
+		return AutoScalingConfig{}
+	}
+
+	config := AutoScalingConfig{IsSet: true}
+
+	if hydrationSize, ok := onHydrationMap["hydration_size"].(string); ok {
+		config.HydrationSize = hydrationSize
+	}
+
+	if lingerDuration, ok := onHydrationMap["linger_duration"].(string); ok {
+		config.LingerDuration = lingerDuration
 	}
 
 	return config
@@ -159,6 +207,11 @@ func (b *ClusterBuilder) Scheduling(v []interface{}) *ClusterBuilder {
 	return b
 }
 
+func (b *ClusterBuilder) AutoScalingStrategy(v []interface{}) *ClusterBuilder {
+	b.autoScalingConfig = GetAutoScalingConfig(v)
+	return b
+}
+
 func (b *ClusterBuilder) GenerateClusterOptions() string {
 	var p []string
 	if b.size != "" {
@@ -200,6 +253,10 @@ func (b *ClusterBuilder) GenerateClusterOptions() string {
 		// We skip setting this in alter cluster because it
 		// will be handled independently
 		p = append(p, b.GenSchedulingConfigSql(b.schedulingConfig))
+	}
+
+	if b.autoScalingConfig.IsSet {
+		p = append(p, b.GenAutoScalingStrategySql(b.autoScalingConfig))
 	}
 
 	if len(p) > 0 {
@@ -286,6 +343,27 @@ func (b *ClusterBuilder) SetSchedulingConfig(s interface{}) {
 	b.schedulingConfig = GetSchedulingConfig(s)
 }
 
+func (b *ClusterBuilder) SetAutoScalingStrategy(s interface{}) {
+	b.autoScalingConfig = GetAutoScalingConfig(s)
+}
+
+func (b *ClusterBuilder) GenAutoScalingStrategySql(s AutoScalingConfig) string {
+	var opts []string
+	opts = append(opts, fmt.Sprintf("HYDRATION SIZE = %s", QuoteString(s.HydrationSize)))
+	if s.LingerDuration != "" {
+		opts = append(opts, fmt.Sprintf("LINGER DURATION = %s", QuoteString(s.LingerDuration)))
+	}
+	return fmt.Sprintf("AUTO SCALING STRATEGY = (ON HYDRATION (%s))", strings.Join(opts, ", "))
+}
+
+// AlterClusterResetAutoScaling removes the autoscaling strategy from a cluster.
+// Handled independently of the reconfig/AlterCluster flow, mirroring
+// AlterClusterScheduling.
+func (b *ClusterBuilder) AlterClusterResetAutoScaling() error {
+	q := fmt.Sprintf(`ALTER CLUSTER %s RESET (AUTO SCALING STRATEGY);`, b.QualifiedName())
+	return b.ddl.exec(q)
+}
+
 func (b *ClusterBuilder) GenSchedulingConfigSql(s SchedulingConfig) string {
 	statement := "SCHEDULE = "
 	if !s.IsSet || !s.OnRefresh.Enabled {
@@ -364,6 +442,39 @@ func ScanCluster(conn *sqlx.DB, identifier string, byName bool) (ClusterParams, 
 	}
 
 	return c, nil
+}
+
+// AutoScalingStrategyParams holds the configured autoscaling strategy read back
+// from mz_internal.mz_cluster_auto_scaling_strategies.
+type AutoScalingStrategyParams struct {
+	HydrationSize  sql.NullString `db:"hydration_size"`
+	LingerDuration sql.NullString `db:"linger_duration"`
+}
+
+// ScanClusterAutoScalingStrategy reads the configured ON HYDRATION autoscaling
+// strategy for a cluster. It is best-effort: the backing catalog view is in
+// public preview and may not exist on older Materialize versions, and clusters
+// without a strategy have no row. In both cases it returns an empty result and
+// no error so it never breaks the main cluster read.
+func ScanClusterAutoScalingStrategy(conn *sqlx.DB, clusterId string) (AutoScalingStrategyParams, error) {
+	var s AutoScalingStrategyParams
+	q := `
+		SELECT
+			strategy->'on_hydration'->>'hydration_size' AS hydration_size,
+			strategy->'on_hydration'->>'linger_duration' AS linger_duration
+		FROM mz_internal.mz_cluster_auto_scaling_strategies
+		WHERE cluster_id = $1`
+
+	if err := conn.Get(&s, q, clusterId); err != nil {
+		if err == sql.ErrNoRows {
+			return AutoScalingStrategyParams{}, nil
+		}
+		// View may not exist on older versions; degrade gracefully.
+		log.Printf("[DEBUG] could not read auto scaling strategy for cluster %s: %s", clusterId, err)
+		return AutoScalingStrategyParams{}, nil
+	}
+
+	return s, nil
 }
 
 func ListClusters(conn *sqlx.DB) ([]ClusterParams, error) {

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -364,6 +364,42 @@ func (b *ClusterBuilder) AlterClusterResetAutoScaling() error {
 	return b.ddl.exec(q)
 }
 
+// ClusterReconfigParams holds the target configuration of an in-flight graceful
+// resize, read from mz_internal.mz_cluster_reconfigurations.
+type ClusterReconfigParams struct {
+	Size              sql.NullString `db:"size"`
+	ReplicationFactor sql.NullInt64  `db:"replication_factor"`
+}
+
+// ScanClusterPendingReconfiguration returns the target of an in-flight graceful
+// resize, if one is in progress. As of Materialize v26.34, a bare
+// `ALTER CLUSTER ... SET (SIZE = ...)` resizes gracefully in the background and
+// returns immediately; until it commits, mz_clusters keeps reporting the old
+// configuration. Callers use the returned target so the read reflects the
+// intended end-state instead of perpetually diffing against the pre-resize
+// values. Best-effort and version-safe: on older Materialize versions without
+// the reconfigurations view (where resizing was synchronous), it reports no
+// in-flight reconfiguration.
+func ScanClusterPendingReconfiguration(conn *sqlx.DB, clusterId string) (ClusterReconfigParams, bool, error) {
+	var p ClusterReconfigParams
+	q := `
+		SELECT
+			target->>'size' AS size,
+			(target->>'replication_factor')::bigint AS replication_factor
+		FROM mz_internal.mz_cluster_reconfigurations
+		WHERE cluster_id = $1 AND status = 'in-progress'`
+
+	if err := conn.Get(&p, q, clusterId); err != nil {
+		if err == sql.ErrNoRows {
+			return p, false, nil
+		}
+		log.Printf("[DEBUG] could not read pending reconfiguration for cluster %s: %s", clusterId, err)
+		return p, false, nil
+	}
+
+	return p, true, nil
+}
+
 func (b *ClusterBuilder) GenSchedulingConfigSql(s SchedulingConfig) string {
 	statement := "SCHEDULE = "
 	if !s.IsSet || !s.OnRefresh.Enabled {
@@ -445,10 +481,12 @@ func ScanCluster(conn *sqlx.DB, identifier string, byName bool) (ClusterParams, 
 }
 
 // AutoScalingStrategyParams holds the configured autoscaling strategy read back
-// from mz_internal.mz_cluster_auto_scaling_strategies.
+// from mz_internal.mz_cluster_auto_scaling_strategies. In the catalog the
+// linger duration is stored as a {"secs": <int>, "nanos": <int>} object, so we
+// read the seconds component and render it as a "<n>s" duration string.
 type AutoScalingStrategyParams struct {
-	HydrationSize  sql.NullString `db:"hydration_size"`
-	LingerDuration sql.NullString `db:"linger_duration"`
+	HydrationSize sql.NullString `db:"hydration_size"`
+	LingerSeconds sql.NullInt64  `db:"linger_seconds"`
 }
 
 // ScanClusterAutoScalingStrategy reads the configured ON HYDRATION autoscaling
@@ -461,7 +499,7 @@ func ScanClusterAutoScalingStrategy(conn *sqlx.DB, clusterId string) (AutoScalin
 	q := `
 		SELECT
 			strategy->'on_hydration'->>'hydration_size' AS hydration_size,
-			strategy->'on_hydration'->>'linger_duration' AS linger_duration
+			(strategy->'on_hydration'->'linger_duration'->>'secs')::bigint AS linger_seconds
 		FROM mz_internal.mz_cluster_auto_scaling_strategies
 		WHERE cluster_id = $1`
 

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -125,6 +125,93 @@ func TestClusterWithSchedulingCreate(t *testing.T) {
 	})
 }
 
+func TestClusterWithAutoScalingCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		expectedSQL := `CREATE CLUSTER "cluster" \(SIZE 'xsmall', AUTO SCALING STRATEGY = \(ON HYDRATION \(HYDRATION SIZE = '800cc', LINGER DURATION = '15s'\)\)\);`
+		mock.ExpectExec(expectedSQL).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "cluster"}
+		b := NewClusterBuilder(db, o)
+		b.Size("xsmall")
+
+		b.AutoScalingStrategy([]interface{}{
+			map[string]interface{}{
+				"on_hydration": []interface{}{
+					map[string]interface{}{
+						"hydration_size":  "800cc",
+						"linger_duration": "15s",
+					},
+				},
+			},
+		})
+
+		if err := b.Create(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestClusterWithAutoScalingNoLingerCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		expectedSQL := `CREATE CLUSTER "cluster" \(SIZE 'xsmall', AUTO SCALING STRATEGY = \(ON HYDRATION \(HYDRATION SIZE = '800cc'\)\)\);`
+		mock.ExpectExec(expectedSQL).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "cluster"}
+		b := NewClusterBuilder(db, o)
+		b.Size("xsmall")
+
+		b.AutoScalingStrategy([]interface{}{
+			map[string]interface{}{
+				"on_hydration": []interface{}{
+					map[string]interface{}{
+						"hydration_size": "800cc",
+					},
+				},
+			},
+		})
+
+		if err := b.Create(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestClusterAutoScalingUpdate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		expectedSQL := `ALTER CLUSTER "cluster" SET \(AUTO SCALING STRATEGY = \(ON HYDRATION \(HYDRATION SIZE = '800cc'\)\)\);`
+		mock.ExpectExec(expectedSQL).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "cluster"}
+		b := NewClusterBuilder(db, o)
+		b.SetAutoScalingStrategy([]interface{}{
+			map[string]interface{}{
+				"on_hydration": []interface{}{
+					map[string]interface{}{
+						"hydration_size": "800cc",
+					},
+				},
+			},
+		})
+
+		if err := b.AlterCluster(ReconfigurationOptions{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestClusterAutoScalingReset(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`ALTER CLUSTER "cluster" RESET \(AUTO SCALING STRATEGY\);`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "cluster"}
+		b := NewClusterBuilder(db, o)
+
+		if err := b.AlterClusterResetAutoScaling(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+
 func TestClusterUpdate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		expectedSQL := `ALTER CLUSTER "cluster" SET \(SIZE 'xsmall', REPLICATION FACTOR 2\);`

--- a/pkg/materialize/source.go
+++ b/pkg/materialize/source.go
@@ -120,6 +120,7 @@ type SourceParams struct {
 	ConnectionName         sql.NullString `db:"connection_name"`
 	ConnectionSchemaName   sql.NullString `db:"connection_schema_name"`
 	ConnectionDatabaseName sql.NullString `db:"connection_database_name"`
+	ClusterId              sql.NullString `db:"cluster_id"`
 	ClusterName            sql.NullString `db:"cluster_name"`
 	Comment                sql.NullString `db:"comment"`
 	OwnerName              sql.NullString `db:"owner_name"`
@@ -139,6 +140,7 @@ var sourceQuery = NewBaseQuery(`
 			mz_connections.name as connection_name,
 			conn_schemas.name as connection_schema_name,
 			conn_databases.name as connection_database_name,
+			mz_sources.cluster_id AS cluster_id,
 			mz_clusters.name as cluster_name,
 			comments.comment AS comment,
 			mz_roles.name AS owner_name,

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -316,9 +316,9 @@ func TestAccClusterWithAutoScaling(t *testing.T) {
 			},
 			{
 				// Update the hydration size
-				Config: testAccClusterWithAutoScalingConfig(clusterName, size, "100cc", "15s"),
+				Config: testAccClusterWithAutoScalingConfig(clusterName, size, "2xsmall", "15s"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.0.on_hydration.0.hydration_size", "100cc"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.0.on_hydration.0.hydration_size", "2xsmall"),
 				),
 			},
 			{

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -293,6 +293,45 @@ func TestAccClusterWithScheduling(t *testing.T) {
 	})
 }
 
+func TestAccClusterWithAutoScaling(t *testing.T) {
+	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	size := "25cc"
+	hydrationSize := "50cc"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAllClusterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Create with an autoscaling strategy
+				Config: testAccClusterWithAutoScalingConfig(clusterName, size, hydrationSize, "15s"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists("materialize_cluster.test_autoscaling"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "name", clusterName),
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "size", size),
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.0.on_hydration.0.hydration_size", hydrationSize),
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.0.on_hydration.0.linger_duration", "15s"),
+				),
+			},
+			{
+				// Update the hydration size
+				Config: testAccClusterWithAutoScalingConfig(clusterName, size, "100cc", "15s"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.0.on_hydration.0.hydration_size", "100cc"),
+				),
+			},
+			{
+				// Remove the strategy (RESET) by dropping the block from the same resource
+				Config: testAccClusterWithAutoScalingConfig(clusterName, size, "", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_autoscaling", "auto_scaling_strategy.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCluster_identifyByName(t *testing.T) {
 	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	resource.ParallelTest(t, resource.TestCase{
@@ -522,6 +561,28 @@ resource "materialize_cluster" "test_scheduling" {
     }
 }
 `, clusterName, size, onRefreshStr, rehydrationTimeEstimate)
+}
+
+func testAccClusterWithAutoScalingConfig(clusterName, size, hydrationSize, lingerDuration string) string {
+	strategy := ""
+	if hydrationSize != "" {
+		lingerLine := ""
+		if lingerDuration != "" {
+			lingerLine = fmt.Sprintf("\n            linger_duration = \"%s\"", lingerDuration)
+		}
+		strategy = fmt.Sprintf(`
+    auto_scaling_strategy {
+        on_hydration {
+            hydration_size  = "%s"%s
+        }
+    }`, hydrationSize, lingerLine)
+	}
+	return fmt.Sprintf(`
+resource "materialize_cluster" "test_autoscaling" {
+    name = "%s"
+    size = "%s"%s
+}
+`, clusterName, size, strategy)
 }
 
 func testAccClusterResourceWithNameAsId(clusterName, clusterSize, clusterReplicationFactor string) string {

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -76,6 +76,39 @@ var clusterSchema = map[string]*schema.Schema{
 			},
 		},
 	},
+	"auto_scaling_strategy": {
+		Type:          schema.TypeList,
+		Optional:      true,
+		MaxItems:      1,
+		Description:   "Lets the cluster temporarily burst to a larger size while it has un-hydrated objects, to speed up hydration. Only available on managed clusters and cannot be combined with a non-default `scheduling`.",
+		RequiredWith:  []string{"size"},
+		ConflictsWith: []string{"scheduling"},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"on_hydration": {
+					Type:        schema.TypeList,
+					Required:    true,
+					MaxItems:    1,
+					Description: "Burst to a larger size while the cluster has un-hydrated objects.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"hydration_size": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "The size to burst to while the cluster has un-hydrated objects. Must differ from the cluster's steady `size`.",
+							},
+							"linger_duration": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Description:  "How long the burst replica lingers after the steady-size replicas hydrate, before it is removed. Defaults to `0s`.",
+								ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\d+[smh]{1}$"), "Must be a valid duration in the form of <int><unit> ex: 1s, 10m"),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 	"identify_by_name": {
 		Type:        schema.TypeBool,
 		Optional:    true,
@@ -186,7 +219,37 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diag.FromErr(err)
 	}
 
+	// Best-effort read of the autoscaling strategy; keyed on the cluster id.
+	strategy, err := materialize.ScanClusterAutoScalingStrategy(metaDb, s.ClusterId.String)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("auto_scaling_strategy", flattenAutoScalingStrategy(strategy)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
+}
+
+// flattenAutoScalingStrategy converts a scanned strategy into the nested TF
+// block shape, or an empty list when no strategy is configured.
+func flattenAutoScalingStrategy(s materialize.AutoScalingStrategyParams) []interface{} {
+	if !s.HydrationSize.Valid || s.HydrationSize.String == "" {
+		return []interface{}{}
+	}
+
+	onHydration := map[string]interface{}{
+		"hydration_size": s.HydrationSize.String,
+	}
+	if s.LingerDuration.Valid {
+		onHydration["linger_duration"] = s.LingerDuration.String
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"on_hydration": []interface{}{onHydration},
+		},
+	}
 }
 
 func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -230,6 +293,10 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if v, ok := d.GetOk("scheduling"); ok {
 			b.Scheduling(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("auto_scaling_strategy"); ok {
+			b.AutoScalingStrategy(v.([]interface{}))
 		}
 	}
 
@@ -369,6 +436,23 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	if d.HasChange("auto_scaling_strategy") {
+		_, n := d.GetChange("auto_scaling_strategy")
+		config := materialize.GetAutoScalingConfig(n)
+		if config.IsSet {
+			// Set on the builder so it is emitted via GenerateClusterOptions
+			// under the AlterCluster path below.
+			b.SetAutoScalingStrategy(n)
+			changed = true
+		} else {
+			// Block removed: reset independently of the reconfig flow,
+			// mirroring how scheduling is handled.
+			if err := b.AlterClusterResetAutoScaling(); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
 	if changed {
 		_, reconfigOptsRaw := d.GetChange("wait_until_ready")
 		reconfigOpts := b.GetReconfigOpts(reconfigOptsRaw)
@@ -437,6 +521,12 @@ func clusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}
 	d.Set("disk", true)
 	d.Set("availability_zones", s.AvailabilityZones)
 	d.Set("comment", s.Comment.String)
+
+	strategy, err := materialize.ScanClusterAutoScalingStrategy(metaDb, s.ClusterId.String)
+	if err != nil {
+		return nil, err
+	}
+	d.Set("auto_scaling_strategy", flattenAutoScalingStrategy(strategy))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -98,10 +99,11 @@ var clusterSchema = map[string]*schema.Schema{
 								Description: "The size to burst to while the cluster has un-hydrated objects. Must differ from the cluster's steady `size`.",
 							},
 							"linger_duration": {
-								Type:         schema.TypeString,
-								Optional:     true,
-								Description:  "How long the burst replica lingers after the steady-size replicas hydrate, before it is removed. Defaults to `0s`.",
-								ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\d+[smh]{1}$"), "Must be a valid duration in the form of <int><unit> ex: 1s, 10m"),
+								Type:             schema.TypeString,
+								Optional:         true,
+								Description:      "How long the burst replica lingers after the steady-size replicas hydrate, before it is removed. Defaults to `0s`.",
+								ValidateFunc:     validation.StringMatch(regexp.MustCompile("^\\d+[smh]{1}$"), "Must be a valid duration in the form of <int><unit> ex: 1s, 10m"),
+								DiffSuppressFunc: suppressEquivalentDuration,
 							},
 						},
 					},
@@ -198,11 +200,31 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("replication_factor", s.ReplicationFactor.Int64); err != nil {
+	// If a graceful resize is in flight, mz_clusters still reports the old
+	// size/replication factor until it commits. Reflect the target so Terraform
+	// sees the intended end-state rather than perpetually diffing against the
+	// pre-resize values. The resize proceeds in the background; users who want
+	// apply to block on it use the `wait_until_ready` option instead.
+	size := s.Size.String
+	replicationFactor := s.ReplicationFactor.Int64
+	pending, inFlight, err := materialize.ScanClusterPendingReconfiguration(metaDb, s.ClusterId.String)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if inFlight {
+		if pending.Size.Valid {
+			size = pending.Size.String
+		}
+		if pending.ReplicationFactor.Valid {
+			replicationFactor = pending.ReplicationFactor.Int64
+		}
+	}
+
+	if err := d.Set("replication_factor", replicationFactor); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("size", s.Size.String); err != nil {
+	if err := d.Set("size", size); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -231,6 +253,42 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
+// parseDurationSeconds converts a "<int><unit>" duration (s/m/h), or an empty
+// string, into a number of seconds. An empty string means 0s (the default).
+func parseDurationSeconds(v string) (int64, bool) {
+	if v == "" {
+		return 0, true
+	}
+	unit := v[len(v)-1]
+	n, err := strconv.ParseInt(v[:len(v)-1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	switch unit {
+	case 's':
+		return n, true
+	case 'm':
+		return n * 60, true
+	case 'h':
+		return n * 3600, true
+	default:
+		return 0, false
+	}
+}
+
+// suppressEquivalentDuration treats durations that resolve to the same number
+// of seconds as equal (e.g. "1m" == "60s", "" == "0s"). Materialize normalizes
+// the linger duration to seconds, so without this the read-back would perpetually
+// diff against a config that used a different unit.
+func suppressEquivalentDuration(k, old, new string, d *schema.ResourceData) bool {
+	o, ok1 := parseDurationSeconds(old)
+	n, ok2 := parseDurationSeconds(new)
+	if !ok1 || !ok2 {
+		return false
+	}
+	return o == n
+}
+
 // flattenAutoScalingStrategy converts a scanned strategy into the nested TF
 // block shape, or an empty list when no strategy is configured.
 func flattenAutoScalingStrategy(s materialize.AutoScalingStrategyParams) []interface{} {
@@ -241,8 +299,11 @@ func flattenAutoScalingStrategy(s materialize.AutoScalingStrategyParams) []inter
 	onHydration := map[string]interface{}{
 		"hydration_size": s.HydrationSize.String,
 	}
-	if s.LingerDuration.Valid {
-		onHydration["linger_duration"] = s.LingerDuration.String
+	if s.LingerSeconds.Valid {
+		// The catalog stores the linger duration as seconds; render it in the
+		// "<n>s" form. The schema's DiffSuppressFunc treats this as equivalent
+		// to any other unit the user configured (e.g. "1m" == "60s").
+		onHydration["linger_duration"] = fmt.Sprintf("%ds", s.LingerSeconds.Int64)
 	}
 
 	return []interface{}{

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -59,7 +59,8 @@ func TestResourceClusterCreate(t *testing.T) {
 		// Query Params
 		pp := `WHERE mz_clusters.id = 'u1'`
 		testhelpers.MockClusterScan(mock, pp)
-		testhelpers.MockClusterAutoScalingScan(mock, "", "")
+		testhelpers.MockClusterReconfigurationScan(mock, "", 0)
+		testhelpers.MockClusterAutoScalingScan(mock, "", 0)
 
 		if err := clusterCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
@@ -101,7 +102,8 @@ func TestResourceClusterAutoScalingCreate(t *testing.T) {
 		// Query Params
 		pp := `WHERE mz_clusters.id = 'u1'`
 		testhelpers.MockClusterScan(mock, pp)
-		testhelpers.MockClusterAutoScalingScan(mock, "800cc", "15s")
+		testhelpers.MockClusterReconfigurationScan(mock, "", 0)
+		testhelpers.MockClusterAutoScalingScan(mock, "800cc", 15)
 
 		if err := clusterCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
@@ -159,7 +161,8 @@ func TestResourceClusterReadIdMigration(t *testing.T) {
 				// Query Params
 				pp := `WHERE mz_clusters.id = '` + tc.mockId + `'`
 				testhelpers.MockClusterScan(mock, pp)
-				testhelpers.MockClusterAutoScalingScan(mock, "", "")
+				testhelpers.MockClusterReconfigurationScan(mock, "", 0)
+				testhelpers.MockClusterAutoScalingScan(mock, "", 0)
 
 				if err := clusterRead(context.TODO(), d, db); err != nil {
 					t.Fatal(err)
@@ -204,7 +207,8 @@ func TestResourceClusterZeroReplicationCreate(t *testing.T) {
 		// Query Params
 		pp := `WHERE mz_clusters.id = 'u1'`
 		testhelpers.MockClusterScan(mock, pp)
-		testhelpers.MockClusterAutoScalingScan(mock, "", "")
+		testhelpers.MockClusterReconfigurationScan(mock, "", 0)
+		testhelpers.MockClusterAutoScalingScan(mock, "", 0)
 
 		if err := clusterCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -59,10 +59,56 @@ func TestResourceClusterCreate(t *testing.T) {
 		// Query Params
 		pp := `WHERE mz_clusters.id = 'u1'`
 		testhelpers.MockClusterScan(mock, pp)
+		testhelpers.MockClusterAutoScalingScan(mock, "", "")
 
 		if err := clusterCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)
 		}
+	})
+}
+
+func TestResourceClusterAutoScalingCreate(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name": "cluster",
+		"size": "3xsmall",
+		"auto_scaling_strategy": []interface{}{
+			map[string]interface{}{
+				"on_hydration": []interface{}{
+					map[string]interface{}{
+						"hydration_size":  "800cc",
+						"linger_duration": "15s",
+					},
+				},
+			},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, Cluster().Schema, in)
+	r.NotNil(d)
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`
+			CREATE CLUSTER "cluster" \(SIZE '3xsmall',
+			INTROSPECTION INTERVAL = '1s',
+			AUTO SCALING STRATEGY = \(ON HYDRATION \(HYDRATION SIZE = '800cc', LINGER DURATION = '15s'\)\)\);
+		`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Query Id
+		ip := `WHERE mz_clusters.name = 'cluster'`
+		testhelpers.MockClusterScan(mock, ip)
+
+		// Query Params
+		pp := `WHERE mz_clusters.id = 'u1'`
+		testhelpers.MockClusterScan(mock, pp)
+		testhelpers.MockClusterAutoScalingScan(mock, "800cc", "15s")
+
+		if err := clusterCreate(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		strategy := d.Get("auto_scaling_strategy").([]interface{})
+		r.Len(strategy, 1)
 	})
 }
 
@@ -113,6 +159,7 @@ func TestResourceClusterReadIdMigration(t *testing.T) {
 				// Query Params
 				pp := `WHERE mz_clusters.id = '` + tc.mockId + `'`
 				testhelpers.MockClusterScan(mock, pp)
+				testhelpers.MockClusterAutoScalingScan(mock, "", "")
 
 				if err := clusterRead(context.TODO(), d, db); err != nil {
 					t.Fatal(err)
@@ -157,6 +204,7 @@ func TestResourceClusterZeroReplicationCreate(t *testing.T) {
 		// Query Params
 		pp := `WHERE mz_clusters.id = 'u1'`
 		testhelpers.MockClusterScan(mock, pp)
+		testhelpers.MockClusterAutoScalingScan(mock, "", "")
 
 		if err := clusterCreate(context.TODO(), d, db); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -40,7 +40,22 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("size", s.Size.String); err != nil {
+	// A source's size is backed by its linked cluster. As of Materialize
+	// v26.34 a resize is graceful and proceeds in the background, so
+	// mz_clusters still reports the old size until it commits. Reflect the
+	// in-flight target so Terraform sees the intended end-state instead of
+	// perpetually diffing against the pre-resize value.
+	size := s.Size.String
+	if s.ClusterId.Valid {
+		pending, inFlight, err := materialize.ScanClusterPendingReconfiguration(metaDb, s.ClusterId.String)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if inFlight && pending.Size.Valid {
+			size = pending.Size.String
+		}
+	}
+	if err := d.Set("size", size); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -128,18 +128,35 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 
 // MockClusterAutoScalingScan mocks the best-effort read of a cluster's
 // autoscaling strategy. Pass an empty hydrationSize to simulate no configured
-// strategy (no rows).
-func MockClusterAutoScalingScan(mock sqlmock.Sqlmock, hydrationSize, lingerDuration string) {
+// strategy (no rows); lingerSeconds is the linger duration in seconds.
+func MockClusterAutoScalingScan(mock sqlmock.Sqlmock, hydrationSize string, lingerSeconds int64) {
 	q := `
 		SELECT
 			strategy->'on_hydration'->>'hydration_size' AS hydration_size,
-			strategy->'on_hydration'->>'linger_duration' AS linger_duration
+			\(strategy->'on_hydration'->'linger_duration'->>'secs'\)::bigint AS linger_seconds
 		FROM mz_internal.mz_cluster_auto_scaling_strategies
 		WHERE cluster_id = \$1`
 
-	rows := mock.NewRows([]string{"hydration_size", "linger_duration"})
+	rows := mock.NewRows([]string{"hydration_size", "linger_seconds"})
 	if hydrationSize != "" {
-		rows.AddRow(hydrationSize, lingerDuration)
+		rows.AddRow(hydrationSize, lingerSeconds)
+	}
+	mock.ExpectQuery(q).WillReturnRows(rows)
+}
+
+// MockClusterReconfigurationScan mocks the read of an in-flight graceful resize.
+// Pass an empty size to simulate no in-progress reconfiguration (no rows).
+func MockClusterReconfigurationScan(mock sqlmock.Sqlmock, size string, replicationFactor int64) {
+	q := `
+		SELECT
+			target->>'size' AS size,
+			\(target->>'replication_factor'\)::bigint AS replication_factor
+		FROM mz_internal.mz_cluster_reconfigurations
+		WHERE cluster_id = \$1 AND status = 'in-progress'`
+
+	rows := mock.NewRows([]string{"size", "replication_factor"})
+	if size != "" {
+		rows.AddRow(size, replicationFactor)
 	}
 	mock.ExpectQuery(q).WillReturnRows(rows)
 }

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -126,6 +126,24 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
+// MockClusterAutoScalingScan mocks the best-effort read of a cluster's
+// autoscaling strategy. Pass an empty hydrationSize to simulate no configured
+// strategy (no rows).
+func MockClusterAutoScalingScan(mock sqlmock.Sqlmock, hydrationSize, lingerDuration string) {
+	q := `
+		SELECT
+			strategy->'on_hydration'->>'hydration_size' AS hydration_size,
+			strategy->'on_hydration'->>'linger_duration' AS linger_duration
+		FROM mz_internal.mz_cluster_auto_scaling_strategies
+		WHERE cluster_id = \$1`
+
+	rows := mock.NewRows([]string{"hydration_size", "linger_duration"})
+	if hydrationSize != "" {
+		rows.AddRow(hydrationSize, lingerDuration)
+	}
+	mock.ExpectQuery(q).WillReturnRows(rows)
+}
+
 func MockConnectionScan(mock sqlmock.Sqlmock, predicate string) {
 	b := `
 	SELECT

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -654,6 +654,7 @@ func MockSourceScan(mock sqlmock.Sqlmock, predicate string) {
 		mz_connections.name as connection_name,
 		conn_schemas.name as connection_schema_name,
 		conn_databases.name as connection_database_name,
+		mz_sources.cluster_id AS cluster_id,
 		mz_clusters.name as cluster_name,
 		comments.comment AS comment,
 		mz_roles.name AS owner_name,


### PR DESCRIPTION
Adds an `auto_scaling_strategy` block to `materialize_cluster` so managed clusters can burst to a larger `hydration_size` while they have un-hydrated objects, then return to their steady size. Supports create, alter, reset, and best-effort read-back from `mz_internal.mz_cluster_auto_scaling_strategies`.