### PR TITLE
Fix integration fixtures: reserved role name and SQL Server image

### DIFF
--- a/integration/rbac_tutorial.tf
+++ b/integration/rbac_tutorial.tf
@@ -4,7 +4,7 @@ resource "materialize_role" "dev_role" {
 }
 
 resource "materialize_role" "user" {
-  name = "user"
+  name = "app_user"
 }
 
 # Step 4. Grant privileges to the role

--- a/integration/self_hosted/rbac_tutorial.tf
+++ b/integration/self_hosted/rbac_tutorial.tf
@@ -4,7 +4,7 @@ resource "materialize_role" "dev_role" {
 }
 
 resource "materialize_role" "user" {
-  name = "user"
+  name = "app_user"
 }
 
 # Step 4. Grant privileges to the role

--- a/integration/sqlserver/Dockerfile
+++ b/integration/sqlserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2025-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest
 
 # Switch to root to install packages and copy files
 USER root


### PR DESCRIPTION
Renames the `materialize_role` fixture from the now-reserved name `user` to `app_user` (reserved as of Materialize v26.34), and pins the SQL Server integration image back to `2022-latest` after a dependabot bump to `2025-latest` broke CDC setup (`FOR ALL TABLES matched none`). Both are pre-existing main failures, unrelated to any feature work.