### PR TITLE
Fix flaky SQL Server integration: gate healthcheck on CDC bootstrap, restore 2025-latest

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -177,17 +177,15 @@ services:
       MSSQL_USER: ${SQLSERVER_USER:-sa}
     healthcheck:
       test: |
-        if [ -f "/opt/mssql-tools18/bin/sqlcmd" ]; then
-          /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -Q "SELECT 1" -C || exit 1
-        elif [ -f "/opt/mssql-tools/bin/sqlcmd" ]; then
-          /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -Q "SELECT 1" -C || exit 1
-        else
-          exit 1
-        fi
+        SQLCMD=/opt/mssql-tools18/bin/sqlcmd
+        [ -f "$$SQLCMD" ] || SQLCMD=/opt/mssql-tools/bin/sqlcmd
+        [ -f "$$SQLCMD" ] || exit 1
+        "$$SQLCMD" -S localhost -U sa -P "$${SA_PASSWORD}" -C -b -Q \
+          "USE testdb; SET NOCOUNT ON; IF (SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1) < 10 RAISERROR('bootstrap incomplete', 16, 1);" || exit 1
       interval: 10s
       timeout: 10s
-      retries: 15
-      start_period: 60s
+      retries: 20
+      start_period: 120s
 
   provider:
     build:
@@ -196,6 +194,7 @@ services:
     depends_on:
       materialized: {condition: service_healthy}
       redpanda: {condition: service_healthy}
+      sqlserver: {condition: service_healthy}
     volumes:
       - ./integration:/usr/src/app/integration
     environment:

--- a/integration/sqlserver/Dockerfile
+++ b/integration/sqlserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2022-latest
+FROM mcr.microsoft.com/mssql/server:2025-latest
 
 # Switch to root to install packages and copy files
 USER root

--- a/integration/sqlserver/entrypoint.sh
+++ b/integration/sqlserver/entrypoint.sh
@@ -42,15 +42,19 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Run the bootstrap script
+# Run the bootstrap script. We intentionally do NOT pass -b here: the bootstrap
+# is not idempotent (re-running sp_cdc_enable_table on an already-CDC-enabled
+# table raises Msg 22926), so -b combined with `restart: always` would crash-loop
+# on any restart. Readiness is instead gated by the healthcheck, which verifies
+# CDC is actually enabled on all fixture tables before the container is marked
+# healthy (and thus before dependents like Terraform run).
 echo "Running bootstrap script..."
 $SQLCMD -S localhost -U sa -P "${SA_PASSWORD}" -i /docker-entrypoint-initdb.d/sqlserver_bootstrap.sql -C -t 30
 
 if [ $? -eq 0 ]; then
-    echo "Bootstrap script completed successfully"
+    echo "Bootstrap script completed"
 else
-    echo "Error: Bootstrap script failed"
-    exit 1
+    echo "Warning: bootstrap script reported a non-zero exit; the healthcheck will gate readiness on CDC state"
 fi
 
 # Keep the container running


### PR DESCRIPTION
Fixes the flaky `FOR ALL TABLES matched none` failures by gating the sqlserver healthcheck on bootstrap completion (verifies CDC is enabled on all 10 fixture tables) and making the `provider` service wait for sqlserver to be healthy, so Terraform never applies a SQL Server source before its CDC tables exist. Also restores `2025-latest` (verified locally: healthy in ~40s, CDC on all tables, no restart loop), closing #894.