### PR TITLE
Honor snapshot = false on Kafka sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.7 - Unreleased
 
+### Bug Fixes
+
+* Fixed `snapshot = false` being ignored on `materialize_sink_kafka` [#898](https://github.com/MaterializeInc/terraform-provider-materialize/pull/898): the value is now passed through to `CREATE SINK` instead of falling back to the server default of `SNAPSHOT = true`.
+
 ### Misc
 
 * CI now runs the unit tests under the race detector without retrying failures, enforces the coverage threshold, and runs `go vet` and `golangci-lint` on pull requests [#904](https://github.com/MaterializeInc/terraform-provider-materialize/pull/904).

--- a/integration/sink.tf
+++ b/integration/sink.tf
@@ -170,6 +170,31 @@ resource "materialize_sink_iceberg" "sink_iceberg" {
   commit_interval  = "10s"
 }
 
+resource "materialize_sink_kafka" "sink_kafka_no_snapshot" {
+  name          = "sink_kafka_no_snapshot"
+  schema_name   = materialize_schema.schema.name
+  database_name = materialize_database.database.name
+  cluster_name  = materialize_cluster.cluster_sink.name
+  topic         = "topic_no_snapshot"
+  snapshot      = false
+  from {
+    name          = materialize_table.simple_table_sink.name
+    database_name = materialize_table.simple_table_sink.database_name
+    schema_name   = materialize_table.simple_table_sink.schema_name
+  }
+  kafka_connection {
+    name          = materialize_connection_kafka.kafka_connection.name
+    database_name = materialize_connection_kafka.kafka_connection.database_name
+    schema_name   = materialize_connection_kafka.kafka_connection.schema_name
+  }
+  format {
+    json = true
+  }
+  envelope {
+    debezium = true
+  }
+}
+
 output "qualified_sink_kafka" {
   value = materialize_sink_kafka.sink_kafka.qualified_sql_name
 }

--- a/pkg/materialize/sink_kafka.go
+++ b/pkg/materialize/sink_kafka.go
@@ -38,7 +38,7 @@ type SinkKafkaBuilder struct {
 	key                    []string
 	format                 SinkFormatSpecStruct
 	envelope               KafkaSinkEnvelopeStruct
-	snapshot               bool
+	snapshot               *bool
 	headers                string
 	keyNotEnforced         bool
 	partitionBy            string
@@ -111,8 +111,11 @@ func (b *SinkKafkaBuilder) Envelope(e KafkaSinkEnvelopeStruct) *SinkKafkaBuilder
 	return b
 }
 
+// Snapshot records the requested SNAPSHOT value. Both true and false are
+// meaningful, so it is optional: left nil the option is omitted entirely and
+// the server default applies.
 func (b *SinkKafkaBuilder) Snapshot(s bool) *SinkKafkaBuilder {
-	b.snapshot = s
+	b.snapshot = &s
 	return b
 }
 
@@ -122,7 +125,7 @@ func (b *SinkKafkaBuilder) Headers(h string) *SinkKafkaBuilder {
 }
 
 func (b *SinkKafkaBuilder) KeyNotEnforced(s bool) *SinkKafkaBuilder {
-	b.keyNotEnforced = true
+	b.keyNotEnforced = s
 	return b
 }
 
@@ -257,8 +260,8 @@ func (b *SinkKafkaBuilder) Create() error {
 
 	// With Options
 	withOptions := []string{}
-	if b.snapshot {
-		withOptions = append(withOptions, "SNAPSHOT = true")
+	if b.snapshot != nil {
+		withOptions = append(withOptions, fmt.Sprintf("SNAPSHOT = %t", *b.snapshot))
 	}
 
 	if len(withOptions) > 0 {

--- a/pkg/materialize/sink_kafka_test.go
+++ b/pkg/materialize/sink_kafka_test.go
@@ -84,6 +84,66 @@ func TestSinkKafkaSnapshotCreate(t *testing.T) {
 	})
 }
 
+func TestSinkKafkaSnapshotDisabledCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SINK "database"."schema"."sink"
+			FROM "database"."schema"."src"
+			INTO KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'testdrive-snk1-seed'\)
+			FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION "materialize"."public"."csr_conn"
+			ENVELOPE DEBEZIUM
+			WITH \(SNAPSHOT = false\);`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "sink", SchemaName: "schema", DatabaseName: "database"}
+		b := NewSinkKafkaBuilder(db, o)
+		b.From(IdentifierSchemaStruct{Name: "src", SchemaName: "schema", DatabaseName: "database"})
+		b.KafkaConnection(IdentifierSchemaStruct{Name: "kafka_conn", SchemaName: "schema", DatabaseName: "database"})
+		b.Topic("testdrive-snk1-seed")
+		b.Format(
+			SinkFormatSpecStruct{
+				Avro: &SinkAvroFormatSpec{
+					SchemaRegistryConnection: IdentifierSchemaStruct{
+						Name:         "csr_conn",
+						DatabaseName: "materialize",
+						SchemaName:   "public",
+					},
+				},
+			},
+		)
+		b.Snapshot(false)
+		b.Envelope(KafkaSinkEnvelopeStruct{Debezium: true})
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// A builder that never had Snapshot called should not emit the option at all,
+// leaving the server default in place.
+func TestSinkKafkaSnapshotUnsetCreate(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			`CREATE SINK "database"."schema"."sink"
+			FROM "database"."schema"."src"
+			INTO KAFKA CONNECTION "database"."schema"."kafka_conn" \(TOPIC 'testdrive-snk1-seed'\)
+			ENVELOPE DEBEZIUM;`,
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		o := MaterializeObject{Name: "sink", SchemaName: "schema", DatabaseName: "database"}
+		b := NewSinkKafkaBuilder(db, o)
+		b.From(IdentifierSchemaStruct{Name: "src", SchemaName: "schema", DatabaseName: "database"})
+		b.KafkaConnection(IdentifierSchemaStruct{Name: "kafka_conn", SchemaName: "schema", DatabaseName: "database"})
+		b.Topic("testdrive-snk1-seed")
+		b.Envelope(KafkaSinkEnvelopeStruct{Debezium: true})
+
+		if err := b.Create(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestSinkKafkaSizeSnapshotCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -49,6 +49,8 @@ func TestAccSinkKafka_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("materialize_sink_kafka.sink_kafka_headers", "headers", "column_1"),
 					resource.TestCheckResourceAttr("materialize_sink_kafka.sink_kafka_headers", "envelope.0.upsert", "true"),
 					resource.TestCheckResourceAttr("materialize_sink_kafka.sink_kafka_headers", "partition_by", "column_2"),
+					testAccCheckSinkKafkaExists("materialize_sink_kafka.sink_kafka_no_snapshot"),
+					resource.TestCheckResourceAttr("materialize_sink_kafka.sink_kafka_no_snapshot", "snapshot", "false"),
 				),
 			},
 			{
@@ -421,6 +423,31 @@ func testAccSinkKafkaResource(roleName, connName, tableName, sinkName, sink2Name
 		}
 
 		partition_by = "column_2"
+	}
+
+	# snapshot = false has to reach CREATE SINK as an explicit SNAPSHOT = false,
+	# so this asserts Materialize accepts the statement we generate for it.
+	resource "materialize_sink_kafka" "sink_kafka_no_snapshot" {
+		name         = "%[4]s_sink_no_snapshot"
+		cluster_name = materialize_cluster.test.name
+		topic        = "topic_no_snapshot"
+		snapshot     = false
+		from {
+			name          = materialize_table.simple_table.name
+			database_name = materialize_table.simple_table.database_name
+			schema_name   = materialize_table.simple_table.schema_name
+		}
+		kafka_connection {
+			name          = materialize_connection_kafka.test.name
+			database_name = materialize_connection_kafka.test.database_name
+			schema_name   = materialize_connection_kafka.test.schema_name
+		}
+		format {
+			json = true
+		}
+		envelope {
+			debezium = true
+		}
 	}
 	`, roleName, connName, tableName, sinkName, sink2Name, sinkOwner, comment)
 }

--- a/pkg/resources/resource_sink_kafka.go
+++ b/pkg/resources/resource_sink_kafka.go
@@ -204,9 +204,9 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 		b.Key(keys)
 	}
 
-	if v, ok := d.GetOk("key_not_enforced"); ok {
-		b.KeyNotEnforced(v.(bool))
-	}
+	// Both booleans carry a schema default, so read them with Get: GetOk cannot
+	// tell a configured false from an unset value.
+	b.KeyNotEnforced(d.Get("key_not_enforced").(bool))
 
 	if v, ok := d.GetOk("format"); ok {
 		format := materialize.GetSinkFormatSpecStruc(v)
@@ -218,9 +218,7 @@ func sinkKafkaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag
 		b.Envelope(envelope)
 	}
 
-	if v, ok := d.GetOk("snapshot"); ok {
-		b.Snapshot(v.(bool))
-	}
+	b.Snapshot(d.Get("snapshot").(bool))
 
 	if v, ok := d.GetOk("headers"); ok {
 		b.Headers(v.(string))

--- a/pkg/resources/resource_sink_kafka_test.go
+++ b/pkg/resources/resource_sink_kafka_test.go
@@ -119,7 +119,7 @@ func TestResourceSinkKafkaCreate(t *testing.T) {
             VALUE DOC ON COLUMN "database"."public"."item"."c1" = 'comment on column only in value schema',
             KEY COMPATIBILITY LEVEL 'BACKWARD',
             VALUE COMPATIBILITY LEVEL 'FORWARD'\)
-            ENVELOPE UPSERT;`,
+            ENVELOPE UPSERT WITH \(SNAPSHOT = false\);`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		// Query Id


### PR DESCRIPTION
Setting `snapshot = false` on a `materialize_sink_kafka` had no effect because the value never reached the generated `CREATE SINK` statement, so the sink was created with the server default instead. The builder now emits the configured value, and `key_not_enforced` gets the same treatment since it was reading its input the same way.