### PR TITLE
Harden Frontegg client logging, body cleanup, and password parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes
 
 * Fixed `snapshot = false` being ignored on `materialize_sink_kafka` [#898](https://github.com/MaterializeInc/terraform-provider-materialize/pull/898): the value is now passed through to `CREATE SINK` instead of falling back to the server default of `SNAPSHOT = true`.
+* Stopped the debug log from including the app password and access token when the Frontegg token is refreshed [#899](https://github.com/MaterializeInc/terraform-provider-materialize/pull/899).
+* Fixed a leaked HTTP connection on every failed Frontegg API call, and app passwords that are not exactly 64 hexadecimal characters are now rejected with a clear error instead of failing authentication later [#899](https://github.com/MaterializeInc/terraform-provider-materialize/pull/899).
 
 ### Misc
 

--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -201,17 +201,19 @@ func cloneRequest(r *http.Request) *http.Request {
 
 func parseAppPassword(password string) (string, string, error) {
 	strippedPassword := strings.TrimPrefix(password, "mzp_")
-	var clientId, secretKey string
 
 	re := regexp.MustCompile("[^0-9a-fA-F]")
 	filteredChars := re.ReplaceAllString(strippedPassword, "")
 
-	if len(filteredChars) < 64 {
-		return "", "", fmt.Errorf("invalid app password length: %d", len(filteredChars))
+	// An app password is two dashless UUIDs, so exactly 64 hex characters.
+	// Anything longer used to be truncated into a malformed secret, which
+	// surfaced later as an opaque authentication failure.
+	if len(filteredChars) != 64 {
+		return "", "", fmt.Errorf("invalid app password: expected 64 hexadecimal characters, got %d", len(filteredChars))
 	}
 
-	clientId = formatDashlessUuid(filteredChars[0:32])
-	secretKey = formatDashlessUuid(filteredChars[32:])
+	clientId := formatDashlessUuid(filteredChars[0:32])
+	secretKey := formatDashlessUuid(filteredChars[32:64])
 
 	return clientId, secretKey, nil
 }
@@ -235,7 +237,8 @@ func (c *FronteggClient) NeedsTokenRefresh() error {
 }
 
 func (c *FronteggClient) RefreshToken() error {
-	log.Printf("[DEBUG] Refreshing Frontegg: %v\n", c)
+	// Never log the client itself: it carries the app password and the token.
+	log.Printf("[DEBUG] Refreshing Frontegg token for %s", c.Email)
 
 	token, email, tokenExpiry, err := getToken(context.Background(), c.Password, c.Endpoint)
 	if err != nil {
@@ -279,7 +282,11 @@ func FronteggRequest(ctx context.Context, client *FronteggClient, method, url st
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, HandleApiError(resp)
+		// The caller never sees this response, so read the error out of the body
+		// and close it here rather than leaking the connection.
+		apiErr := HandleApiError(resp)
+		_ = resp.Body.Close()
+		return nil, apiErr
 	}
 
 	return resp, nil

--- a/pkg/clients/frontegg_client_test.go
+++ b/pkg/clients/frontegg_client_test.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -130,4 +131,42 @@ func TestParseAppPassword(t *testing.T) {
 	invalidPassword := "invalid_password"
 	_, _, err = parseAppPassword(invalidPassword)
 	require.Error(t, err, "Parsing invalid password should result in an error")
+
+	// Anything other than exactly 64 hex characters is rejected rather than
+	// truncated into a malformed secret.
+	_, _, err = parseAppPassword("mzp_" + strings.Repeat("a", 65))
+	require.Error(t, err, "Parsing an over-long password should result in an error")
+}
+
+// trackedBody records whether the response body was closed.
+type trackedBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *trackedBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type stubTransport struct {
+	body *trackedBody
+}
+
+func (t *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       t.body,
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestFronteggRequestClosesBodyOnError(t *testing.T) {
+	body := &trackedBody{Reader: strings.NewReader("boom")}
+	client := &FronteggClient{HTTPClient: &http.Client{Transport: &stubTransport{body: body}}}
+
+	resp, err := FronteggRequest(context.Background(), client, "GET", "https://example.invalid/x", nil)
+	require.Error(t, err, "A 500 response should surface as an error")
+	require.Nil(t, resp, "No response should be returned alongside the error")
+	require.True(t, body.closed, "The response body should be closed when the caller cannot")
 }


### PR DESCRIPTION
The debug log emitted on token refresh was printing the whole client struct, which includes credentials, so it now logs just the account it is refreshing for. Also closes the response body on failed API calls, which was leaking a connection each time, and rejects malformed app passwords up front instead of letting them fail as an opaque auth error.