### PR TITLE
Stop treating cluster scan failures as unconfigured state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed `snapshot = false` being ignored on `materialize_sink_kafka` [#898](https://github.com/MaterializeInc/terraform-provider-materialize/pull/898): the value is now passed through to `CREATE SINK` instead of falling back to the server default of `SNAPSHOT = true`.
 * Stopped the debug log from including the app password and access token when the Frontegg token is refreshed [#899](https://github.com/MaterializeInc/terraform-provider-materialize/pull/899).
 * Fixed a leaked HTTP connection on every failed Frontegg API call, and app passwords that are not exactly 64 hexadecimal characters are now rejected with a clear error instead of failing authentication later [#899](https://github.com/MaterializeInc/terraform-provider-materialize/pull/899).
+* Fixed transient query failures being reported as an absent `auto_scaling_strategy` or an absent in-flight resize on `materialize_cluster` and `materialize_source_*` reads [#900](https://github.com/MaterializeInc/terraform-provider-materialize/pull/900). Only a genuinely missing catalog view (older Materialize versions) is now treated as "not configured".
 
 ### Misc
 

--- a/pkg/materialize/cluster.go
+++ b/pkg/materialize/cluster.go
@@ -2,6 +2,7 @@ package materialize
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -377,9 +378,9 @@ type ClusterReconfigParams struct {
 // returns immediately; until it commits, mz_clusters keeps reporting the old
 // configuration. Callers use the returned target so the read reflects the
 // intended end-state instead of perpetually diffing against the pre-resize
-// values. Best-effort and version-safe: on older Materialize versions without
-// the reconfigurations view (where resizing was synchronous), it reports no
-// in-flight reconfiguration.
+// values. Version-safe: on older Materialize versions without the
+// reconfigurations view (where resizing was synchronous), it reports no
+// in-flight reconfiguration. Any other failure is returned to the caller.
 func ScanClusterPendingReconfiguration(conn *sqlx.DB, clusterId string) (ClusterReconfigParams, bool, error) {
 	var p ClusterReconfigParams
 	q := `
@@ -390,11 +391,14 @@ func ScanClusterPendingReconfiguration(conn *sqlx.DB, clusterId string) (Cluster
 		WHERE cluster_id = $1 AND status = 'in-progress'`
 
 	if err := conn.Get(&p, q, clusterId); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return p, false, nil
 		}
-		log.Printf("[DEBUG] could not read pending reconfiguration for cluster %s: %s", clusterId, err)
-		return p, false, nil
+		if isUndefinedObject(err) {
+			log.Printf("[DEBUG] reconfigurations view unavailable for cluster %s: %s", clusterId, err)
+			return p, false, nil
+		}
+		return p, false, err
 	}
 
 	return p, true, nil
@@ -490,10 +494,10 @@ type AutoScalingStrategyParams struct {
 }
 
 // ScanClusterAutoScalingStrategy reads the configured ON HYDRATION autoscaling
-// strategy for a cluster. It is best-effort: the backing catalog view is in
-// public preview and may not exist on older Materialize versions, and clusters
-// without a strategy have no row. In both cases it returns an empty result and
-// no error so it never breaks the main cluster read.
+// strategy for a cluster. The backing catalog view is in public preview and may
+// not exist on older Materialize versions, and clusters without a strategy have
+// no row; both cases return an empty result and no error. Any other failure is
+// returned so a transient error is not mistaken for "no strategy configured".
 func ScanClusterAutoScalingStrategy(conn *sqlx.DB, clusterId string) (AutoScalingStrategyParams, error) {
 	var s AutoScalingStrategyParams
 	q := `
@@ -504,12 +508,14 @@ func ScanClusterAutoScalingStrategy(conn *sqlx.DB, clusterId string) (AutoScalin
 		WHERE cluster_id = $1`
 
 	if err := conn.Get(&s, q, clusterId); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return AutoScalingStrategyParams{}, nil
 		}
-		// View may not exist on older versions; degrade gracefully.
-		log.Printf("[DEBUG] could not read auto scaling strategy for cluster %s: %s", clusterId, err)
-		return AutoScalingStrategyParams{}, nil
+		if isUndefinedObject(err) {
+			log.Printf("[DEBUG] auto scaling strategies view unavailable for cluster %s: %s", clusterId, err)
+			return AutoScalingStrategyParams{}, nil
+		}
+		return AutoScalingStrategyParams{}, err
 	}
 
 	return s, nil

--- a/pkg/materialize/cluster_test.go
+++ b/pkg/materialize/cluster_test.go
@@ -1,10 +1,12 @@
 package materialize
 
 import (
+	"errors"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
+	"github.com/jackc/pgconn"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -240,6 +242,58 @@ func TestClusterUpdateWithWaitUntilReady(t *testing.T) {
 
 		if err := b.AlterCluster(ReconfigurationOptions{enabled: true, timeout: "10s", on_timeout: "COMMIT"}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestScanClusterAutoScalingStrategyMissingView(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(`FROM mz_internal.mz_cluster_auto_scaling_strategies`).
+			WillReturnError(&pgconn.PgError{Code: "42P01", Message: "unknown catalog item"})
+
+		s, err := ScanClusterAutoScalingStrategy(db, "u1")
+		if err != nil {
+			t.Fatalf("Expected a missing view to degrade gracefully, got %v", err)
+		}
+		if s.HydrationSize.Valid {
+			t.Fatal("Expected an empty strategy")
+		}
+	})
+}
+
+func TestScanClusterAutoScalingStrategyQueryError(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(`FROM mz_internal.mz_cluster_auto_scaling_strategies`).
+			WillReturnError(errors.New("connection reset by peer"))
+
+		if _, err := ScanClusterAutoScalingStrategy(db, "u1"); err == nil {
+			t.Fatal("Expected a transient failure to be returned, not swallowed")
+		}
+	})
+}
+
+func TestScanClusterPendingReconfigurationMissingView(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(`FROM mz_internal.mz_cluster_reconfigurations`).
+			WillReturnError(&pgconn.PgError{Code: "42P01", Message: "unknown catalog item"})
+
+		_, inFlight, err := ScanClusterPendingReconfiguration(db, "u1")
+		if err != nil {
+			t.Fatalf("Expected a missing view to degrade gracefully, got %v", err)
+		}
+		if inFlight {
+			t.Fatal("Expected no in-flight reconfiguration")
+		}
+	})
+}
+
+func TestScanClusterPendingReconfigurationQueryError(t *testing.T) {
+	testhelpers.WithMockDb(t, func(db *sqlx.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(`FROM mz_internal.mz_cluster_reconfigurations`).
+			WillReturnError(errors.New("connection reset by peer"))
+
+		if _, _, err := ScanClusterPendingReconfiguration(db, "u1"); err == nil {
+			t.Fatal("Expected a transient failure to be returned, not swallowed")
 		}
 	})
 }

--- a/pkg/materialize/utils.go
+++ b/pkg/materialize/utils.go
@@ -2,11 +2,30 @@ package materialize
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
 )
+
+// isUndefinedObject reports whether err is Postgres undefined_table or
+// undefined_column. Materialize versions that predate a catalog view the
+// provider reads fail this way, which lets callers degrade gracefully without
+// also swallowing genuine query failures.
+func isUndefinedObject(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.SQLState() {
+	case "42P01", "42703":
+		return true
+	default:
+		return false
+	}
+}
 
 func QuoteString(input string) string {
 	return "'" + strings.Replace(input, "'", "''", -1) + "'"

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -241,7 +241,8 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diag.FromErr(err)
 	}
 
-	// Best-effort read of the autoscaling strategy; keyed on the cluster id.
+	// Returns an empty strategy on Materialize versions without the backing
+	// view; genuine query failures surface as an error.
 	strategy, err := materialize.ScanClusterAutoScalingStrategy(metaDb, s.ClusterId.String)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
The reads for a cluster's autoscaling strategy and in-flight resize were swallowing every error, so a brief connection problem looked identical to "nothing configured" and could produce a spurious diff. They now only degrade quietly when the catalog view genuinely does not exist on the server version, and surface anything else.