### PR TITLE
Use errors.Is/As for error checks and report failed rollback drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Fixed identifiers and literals that were hand-quoted when generating SQL [#901](https://github.com/MaterializeInc/terraform-provider-materialize/pull/901), so ownership roles, system parameters, default privilege database and schema qualifiers, resize sizes, CSV delimiters and Protobuf message names now escape correctly instead of producing invalid statements.
 * Fixed a data race on the Frontegg access token that could corrupt the shared HTTP client when Terraform ran resource operations in parallel, and stopped concurrent operations from each firing their own token request when the token expired [#906](https://github.com/MaterializeInc/terraform-provider-materialize/pull/906).
 * Every Frontegg and Cloud API request now has a 30 second timeout. Previously an unresponsive endpoint could hang a plan or apply indefinitely [#906](https://github.com/MaterializeInc/terraform-provider-materialize/pull/906).
+* Reads now match "not found" with `errors.Is`, so a wrapped `sql.ErrNoRows` correctly removes the resource from state instead of failing the plan [#902](https://github.com/MaterializeInc/terraform-provider-materialize/pull/902).
+* When a resource is created but its ownership or comment cannot be applied, a failed cleanup drop is now reported as a warning instead of silently leaving an orphaned object behind [#902](https://github.com/MaterializeInc/terraform-provider-materialize/pull/902).
+* An unexpected provider meta type now returns an error instead of panicking [#902](https://github.com/MaterializeInc/terraform-provider-materialize/pull/902).
 
 ### Misc
 

--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -274,7 +274,8 @@ func HandleAPIError(resp *http.Response) error {
 
 // IsNotFoundError checks if the error is a 404 Not Found error
 func IsNotFoundError(err error) bool {
-	if fronteggErr, ok := err.(*FronteggAPIError); ok {
+	var fronteggErr *FronteggAPIError
+	if errors.As(err, &fronteggErr) {
 		return fronteggErr.StatusCode == http.StatusNotFound
 	}
 	return false

--- a/pkg/datasources/datasource_user.go
+++ b/pkg/datasources/datasource_user.go
@@ -36,7 +36,11 @@ func User() *schema.Resource {
 }
 
 func userDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*utils.ProviderMeta).Frontegg
+	providerMeta, err := utils.GetProviderMeta(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	client := providerMeta.Frontegg
 
 	email := d.Get("email").(string)
 

--- a/pkg/materialize/generic.go
+++ b/pkg/materialize/generic.go
@@ -40,14 +40,15 @@ type Builder struct {
 }
 
 func (b *Builder) exec(statement string) error {
-	if statement[len(statement)-1:] != ";" {
+	if !strings.HasSuffix(statement, ";") {
 		statement += ";"
 	}
 
 	_, err := b.conn.Exec(statement)
 	if err != nil {
 		log.Printf("[DEBUG] error executing: %s", statement)
-		if pgErr, ok := err.(*pgconn.PgError); ok {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
 			msg := fmt.Sprintf("%s: %s", pgErr.Severity, pgErr.Message)
 			if pgErr.Detail != "" {
 				msg += fmt.Sprintf(" DETAIL: %s", pgErr.Detail)

--- a/pkg/provider/acceptance_cluster_replica_test.go
+++ b/pkg/provider/acceptance_cluster_replica_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -161,7 +162,7 @@ func testAccCheckAllClusterReplicaDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanClusterReplica(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("Cluster replica %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -634,7 +635,7 @@ func testAccCheckAllClusterDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanCluster(db, utils.ExtractId(r.Primary.ID), false)
 		if err == nil {
 			return fmt.Errorf("Cluster %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_aws_test.go
+++ b/pkg/provider/acceptance_connection_aws_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -228,7 +229,7 @@ func testAccCheckConnectionAwsDestroyed(s *terraform.State) error {
 			return fmt.Errorf("Connection AWS %s still exists", rs.Primary.ID)
 		}
 
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
+++ b/pkg/provider/acceptance_connection_confluent_schema_registry_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -252,7 +253,7 @@ func testAccCheckAllConnConfluentSchemaRegistryDestroyed(s *terraform.State) err
 		_, err := materialize.ScanConnection(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_iceberg_catalog_test.go
+++ b/pkg/provider/acceptance_connection_iceberg_catalog_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -207,7 +208,7 @@ func testAccCheckConnectionIcebergCatalogDestroyed(s *terraform.State) error {
 			return fmt.Errorf("connection Iceberg Catalog %s still exists", rs.Primary.ID)
 		}
 
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_kafka_test.go
+++ b/pkg/provider/acceptance_connection_kafka_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -779,7 +780,7 @@ func testAccCheckAllConnKafkaDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanConnection(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_mysql_test.go
+++ b/pkg/provider/acceptance_connection_mysql_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -165,7 +166,7 @@ func testAccCheckAllConnectionMySQLDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanConnection(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_postgres_test.go
+++ b/pkg/provider/acceptance_connection_postgres_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -302,7 +303,7 @@ func testAccCheckAllConnPostgresDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanConnection(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_sqlserver_test.go
+++ b/pkg/provider/acceptance_connection_sqlserver_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -282,7 +283,7 @@ func testAccCheckAllConnectionSQLServerDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanConnection(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_connection_ssh_tunnel_test.go
+++ b/pkg/provider/acceptance_connection_ssh_tunnel_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -173,7 +174,7 @@ func testAccCheckAllConnSshTunnelDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanConnectionSshTunnel(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("connection %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_database_test.go
+++ b/pkg/provider/acceptance_database_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -165,7 +166,7 @@ func testAccCheckAllDatabasesDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanDatabase(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("database %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_index_test.go
+++ b/pkg/provider/acceptance_index_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -197,7 +198,7 @@ func testAccCheckAllIndexDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanIndex(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("index %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_materialized_view_test.go
+++ b/pkg/provider/acceptance_materialized_view_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -170,7 +171,7 @@ func testAccCheckAllMaterializedViewsDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanMaterializedView(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("Materialized View %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_network_policy_test.go
+++ b/pkg/provider/acceptance_network_policy_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -156,7 +157,7 @@ func testAccCheckAllNetworkPoliciesDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanNetworkPolicy(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("Network Policy %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_role_test.go
+++ b/pkg/provider/acceptance_role_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -364,7 +365,7 @@ func testAccCheckAllRolesDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanRole(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("role %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_schema_test.go
+++ b/pkg/provider/acceptance_schema_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -202,7 +203,7 @@ func testAccCheckAllSchemasDestroyed(s *terraform.State) error {
 		_, err = materialize.ScanSchema(db, utils.ExtractId(r.Primary.ID), false)
 		if err == nil {
 			return fmt.Errorf("Schema %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_secret_test.go
+++ b/pkg/provider/acceptance_secret_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -216,7 +217,7 @@ func testAccCheckAllSecretsDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSecret(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("secret %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_sink_iceberg_test.go
+++ b/pkg/provider/acceptance_sink_iceberg_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -249,7 +250,7 @@ func testAccCheckSinkIcebergDestroyed(s *terraform.State) error {
 			return fmt.Errorf("sink Iceberg %s still exists", rs.Primary.ID)
 		}
 
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_sink_kafka_test.go
+++ b/pkg/provider/acceptance_sink_kafka_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -587,7 +588,7 @@ func testAccCheckAllSinkKafkaDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSink(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("sink %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_kafka_test.go
+++ b/pkg/provider/acceptance_source_kafka_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -477,7 +478,7 @@ func testAccCheckAllSourceKafkaDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_load_generator_test.go
+++ b/pkg/provider/acceptance_source_load_generator_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -419,7 +420,7 @@ func testAccCheckAllSourceLoadGeneratorsDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("SourceLoadGenerator %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_mysql_test.go
+++ b/pkg/provider/acceptance_source_mysql_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -373,7 +374,7 @@ func testAccCheckAllSourceMySQLDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_postgres_test.go
+++ b/pkg/provider/acceptance_source_postgres_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -446,7 +447,7 @@ func testAccCheckAllSourcePostgresDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_sqlserver_test.go
+++ b/pkg/provider/acceptance_source_sqlserver_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -505,7 +506,7 @@ func testAccCheckAllSourceSQLServerDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_table_mysql_test.go
+++ b/pkg/provider/acceptance_source_table_mysql_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -250,7 +251,7 @@ func testAccCheckAllSourceTableDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSourceTable(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source table %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_table_postgres_test.go
+++ b/pkg/provider/acceptance_source_table_postgres_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -277,7 +278,7 @@ func testAccCheckAllSourceTablePostgresDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSourceTable(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source table %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_table_sqlserver_test.go
+++ b/pkg/provider/acceptance_source_table_sqlserver_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -262,7 +263,7 @@ func testAccCheckAllSourceTableSQLServerDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSourceTableSQLServer(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source table %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_table_webhook_test.go
+++ b/pkg/provider/acceptance_source_table_webhook_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -178,7 +179,7 @@ func testAccCheckAllSourceTableWebhookDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSourceTable(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source table %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_source_webhook_test.go
+++ b/pkg/provider/acceptance_source_webhook_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -369,7 +370,7 @@ func testAccCheckAllSourceWebhookDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanSource(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("source %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_table_test.go
+++ b/pkg/provider/acceptance_table_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -249,7 +250,7 @@ func testAccCheckAllTablesDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanTable(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("Table %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_type_test.go
+++ b/pkg/provider/acceptance_type_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -254,7 +255,7 @@ func testAccCheckAllTypesDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanType(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("Type %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/provider/acceptance_view_test.go
+++ b/pkg/provider/acceptance_view_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -169,7 +170,7 @@ func testAccCheckAllViewsDestroyed(s *terraform.State) error {
 		_, err := materialize.ScanView(db, utils.ExtractId(r.Primary.ID))
 		if err == nil {
 			return fmt.Errorf("View %v still exists", utils.ExtractId(r.Primary.ID))
-		} else if err != sql.ErrNoRows {
+		} else if !errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 	}

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -179,7 +180,7 @@ func clusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	useNameAsId := d.Get("identify_by_name").(bool)
 
 	s, err := materialize.ScanCluster(metaDb, value, idType == "name")
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_cluster_replica.go
+++ b/pkg/resources/resource_cluster_replica.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -57,7 +57,7 @@ func clusterReplicaRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanClusterReplica(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {
@@ -139,9 +139,7 @@ func clusterReplicaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		comment := materialize.NewCommentBuilder(metaDb, o)
 
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 

--- a/pkg/resources/resource_connection.go
+++ b/pkg/resources/resource_connection.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -19,7 +20,7 @@ func connectionRead(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanConnection(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_connection_aws.go
+++ b/pkg/resources/resource_connection_aws.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -85,7 +86,7 @@ func connectionAwsRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanConnectionAws(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_connection_aws_privatelink.go
+++ b/pkg/resources/resource_connection_aws_privatelink.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -66,7 +67,7 @@ func connectionAwsPrivatelinkRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanConnectionAwsPrivatelink(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_connection_ssh_tunnel.go
+++ b/pkg/resources/resource_connection_ssh_tunnel.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -75,7 +76,7 @@ func connectionSshTunnelRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanConnectionSshTunnel(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_database.go
+++ b/pkg/resources/resource_database.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -46,7 +47,7 @@ func databaseRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 	}
 
 	s, err := materialize.ScanDatabase(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_database_test.go
+++ b/pkg/resources/resource_database_test.go
@@ -2,6 +2,8 @@ package resources
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -87,4 +89,35 @@ func TestResourceDatabaseDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+// The reads match "not found" with errors.Is, so an ErrNoRows that arrives
+// wrapped still drops the resource from state instead of failing the plan. The
+// bare case is the control: both must behave the same way.
+func TestResourceDatabaseReadNotFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		scanErr error
+	}{
+		{"bare", sql.ErrNoRows},
+		{"wrapped", fmt.Errorf("scanning database: %w", sql.ErrNoRows)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+
+			d := schema.TestResourceDataRaw(t, Database().Schema, map[string]interface{}{"name": "database"})
+			r.NotNil(d)
+			d.SetId("aws/us-east-1:u1")
+
+			testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`WHERE mz_databases.id = 'u1'`).WillReturnError(tt.scanErr)
+
+				diags := databaseRead(context.TODO(), d, db)
+				r.Nil(diags, "a missing database should not be reported as an error")
+				r.Empty(d.Id(), "a missing database should be removed from state")
+			})
+		})
+	}
 }

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -50,7 +51,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 
 	p, err := materialize.ScanPrivileges(metaDb, materialize.EntityType(key.objectType), key.objectId)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[WARN] grant (%s) not found, removing from state file", d.Id())
 		d.SetId("")
 		return nil

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -56,7 +57,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	privileges, err := materialize.ScanDefaultPrivilege(metaDb, key.objectType, key.granteeId, key.targetRoleId, key.databaseId, key.schemaId)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[WARN] grant (%s) not found, removing from state file", d.Id())
 		d.SetId("")
 		return nil

--- a/pkg/resources/resource_grant_role.go
+++ b/pkg/resources/resource_grant_role.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -75,7 +76,7 @@ func grantRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	// Scan role members
 	roles, err := materialize.ScanRolePrivilege(metaDb, key.roleId, key.memberId)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -73,7 +74,7 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	p, err := materialize.ScanSystemPrivileges(metaDb)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[WARN] grant (%s) not found, removing from state file", d.Id())
 		d.SetId("")
 		return nil

--- a/pkg/resources/resource_helpers.go
+++ b/pkg/resources/resource_helpers.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -16,6 +17,24 @@ type Droppable interface {
 	Drop() error
 }
 
+// rollbackCreate drops an object that was created but could not be fully
+// configured, and returns cause as the resource error. A drop that itself fails
+// is surfaced as a warning so the leftover object does not go unnoticed.
+func rollbackCreate(builder Droppable, o materialize.MaterializeObject, stage string, cause error) diag.Diagnostics {
+	log.Printf("[DEBUG] resource failed %s, dropping object: %s", stage, o.Name)
+
+	diags := diag.FromErr(cause)
+	if err := builder.Drop(); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("Could not drop %q after a failed %s", o.Name, stage),
+			Detail:   fmt.Sprintf("The object may still exist in Materialize and need to be dropped manually: %s", err),
+		})
+	}
+
+	return diags
+}
+
 // applyOwnership applies ownership to a newly created resource.
 // If the operation fails, it drops the resource and returns an error.
 // This is a common pattern across connection, source, table, view, and other resources.
@@ -24,9 +43,7 @@ func applyOwnership(d *schema.ResourceData, metaDb *sqlx.DB, o materialize.Mater
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
 
 		if err := ownership.Alter(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
-			builder.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(builder, o, "ownership", err)
 		}
 	}
 
@@ -41,9 +58,7 @@ func applyComment(d *schema.ResourceData, metaDb *sqlx.DB, o materialize.Materia
 		comment := materialize.NewCommentBuilder(metaDb, o)
 
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			builder.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(builder, o, "comment", err)
 		}
 	}
 

--- a/pkg/resources/resource_helpers_test.go
+++ b/pkg/resources/resource_helpers_test.go
@@ -1,0 +1,45 @@
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDroppable struct {
+	err     error
+	dropped bool
+}
+
+func (s *stubDroppable) Drop() error {
+	s.dropped = true
+	return s.err
+}
+
+func TestRollbackCreate(t *testing.T) {
+	o := materialize.MaterializeObject{ObjectType: materialize.Table, Name: "table"}
+	cause := errors.New("could not set comment")
+
+	t.Run("drop succeeds", func(t *testing.T) {
+		b := &stubDroppable{}
+		diags := rollbackCreate(b, o, "comment", cause)
+
+		require.True(t, b.dropped, "The object should be dropped")
+		require.Len(t, diags, 1, "Only the original error should be reported")
+		require.Equal(t, diag.Error, diags[0].Severity)
+	})
+
+	t.Run("drop fails", func(t *testing.T) {
+		b := &stubDroppable{err: errors.New("still referenced")}
+		diags := rollbackCreate(b, o, "comment", cause)
+
+		require.Len(t, diags, 2, "A failed drop should add a warning")
+		require.Equal(t, diag.Error, diags[0].Severity)
+		require.Equal(t, diag.Warning, diags[1].Severity)
+		require.Contains(t, diags[1].Detail, "still referenced")
+	})
+}

--- a/pkg/resources/resource_index.go
+++ b/pkg/resources/resource_index.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -107,7 +107,7 @@ func indexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanIndex(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {
@@ -207,9 +207,7 @@ func indexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	// object comment
 	if v, ok := d.GetOk("comment"); ok {
 		if err := b.Comment(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 

--- a/pkg/resources/resource_materialized_view.go
+++ b/pkg/resources/resource_materialized_view.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -72,7 +73,7 @@ func materializedViewRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanMaterializedView(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_network_policy.go
+++ b/pkg/resources/resource_network_policy.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
-	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -94,7 +94,7 @@ func networkPolicyRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	policy, err := materialize.ScanNetworkPolicy(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {
@@ -167,9 +167,7 @@ func networkPolicyCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	if v, ok := d.GetOk("comment"); ok {
 		comment := materialize.NewCommentBuilder(metaDb, o)
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 

--- a/pkg/resources/resource_role.go
+++ b/pkg/resources/resource_role.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -90,7 +91,7 @@ func roleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	}
 
 	s, err := materialize.ScanRole(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {
@@ -153,7 +154,7 @@ func roleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	// present, reconcile it into state by applying the configured attributes.
 	if d.Get("create_if_not_exists").(bool) {
 		existingID, err := materialize.RoleId(metaDb, roleName)
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return diag.FromErr(err)
 		}
 		if err == nil && existingID != "" {
@@ -194,9 +195,7 @@ func roleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		comment := materialize.NewCommentBuilder(metaDb, o)
 
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 

--- a/pkg/resources/resource_schema.go
+++ b/pkg/resources/resource_schema.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -56,7 +57,7 @@ func schemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	useNameAsId := d.Get("identify_by_name").(bool)
 
 	s, err := materialize.ScanSchema(metaDb, value, idType == "name")
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_secret.go
+++ b/pkg/resources/resource_secret.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -69,7 +70,7 @@ func secretRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSecret(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_sink.go
+++ b/pkg/resources/resource_sink.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -19,7 +20,7 @@ func sinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSink(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source.go
+++ b/pkg/resources/resource_source.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -19,7 +20,7 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSource(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_kafka.go
+++ b/pkg/resources/resource_source_kafka.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -367,7 +368,7 @@ func sourceKafkaRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSource(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_mysql.go
+++ b/pkg/resources/resource_source_mysql.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -195,7 +196,7 @@ func sourceMySQLRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSource(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_postgres.go
+++ b/pkg/resources/resource_source_postgres.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -119,7 +120,7 @@ func sourcePostgresRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSource(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_sqlserver.go
+++ b/pkg/resources/resource_source_sqlserver.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -197,7 +198,7 @@ func sourceSQLServerRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanSource(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table.go
+++ b/pkg/resources/resource_source_table.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -20,7 +21,7 @@ func sourceTableRead(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	t, err := materialize.ScanSourceTable(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table_kafka.go
+++ b/pkg/resources/resource_source_table_kafka.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -317,7 +318,7 @@ func sourceTableKafkaRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	t, err := materialize.ScanSourceTableKafka(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table_mysql.go
+++ b/pkg/resources/resource_source_table_mysql.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -115,9 +115,7 @@ func sourceTableMySQLCreate(ctx context.Context, d *schema.ResourceData, meta an
 	if v, ok := d.GetOk("ownership_role"); ok {
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
 		if err := ownership.Alter(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "ownership", err)
 		}
 	}
 
@@ -125,9 +123,7 @@ func sourceTableMySQLCreate(ctx context.Context, d *schema.ResourceData, meta an
 	if v, ok := d.GetOk("comment"); ok {
 		comment := materialize.NewCommentBuilder(metaDb, o)
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 
@@ -191,7 +187,7 @@ func sourceTableMySQLRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	t, err := materialize.ScanSourceTableMySQL(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table_postgres.go
+++ b/pkg/resources/resource_source_table_postgres.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -115,9 +115,7 @@ func sourceTablePostgresCreate(ctx context.Context, d *schema.ResourceData, meta
 	if v, ok := d.GetOk("ownership_role"); ok {
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
 		if err := ownership.Alter(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "ownership", err)
 		}
 	}
 
@@ -125,9 +123,7 @@ func sourceTablePostgresCreate(ctx context.Context, d *schema.ResourceData, meta
 	if v, ok := d.GetOk("comment"); ok {
 		comment := materialize.NewCommentBuilder(metaDb, o)
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 
@@ -191,7 +187,7 @@ func sourceTablePostgresRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	t, err := materialize.ScanSourceTablePostgres(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table_sqlserver.go
+++ b/pkg/resources/resource_source_table_sqlserver.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -123,9 +123,7 @@ func sourceTableSQLServerCreate(ctx context.Context, d *schema.ResourceData, met
 	if v, ok := d.GetOk("ownership_role"); ok {
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
 		if err := ownership.Alter(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "ownership", err)
 		}
 	}
 
@@ -133,9 +131,7 @@ func sourceTableSQLServerCreate(ctx context.Context, d *schema.ResourceData, met
 	if v, ok := d.GetOk("comment"); ok {
 		comment := materialize.NewCommentBuilder(metaDb, o)
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 
@@ -199,7 +195,7 @@ func sourceTableSQLServerRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	t, err := materialize.ScanSourceTableSQLServer(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_source_table_webhook.go
+++ b/pkg/resources/resource_source_table_webhook.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
-	"log"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -257,9 +257,7 @@ func sourceTableWebhookCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if v, ok := d.GetOk("ownership_role"); ok {
 		ownership := materialize.NewOwnershipBuilder(metaDb, o)
 		if err := ownership.Alter(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed ownership, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "ownership", err)
 		}
 	}
 
@@ -267,9 +265,7 @@ func sourceTableWebhookCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if v, ok := d.GetOk("comment"); ok {
 		comment := materialize.NewCommentBuilder(metaDb, o)
 		if err := comment.Object(v.(string)); err != nil {
-			log.Printf("[DEBUG] resource failed comment, dropping object: %s", o.Name)
-			b.Drop()
-			return diag.FromErr(err)
+			return rollbackCreate(b, o, "comment", err)
 		}
 	}
 
@@ -292,7 +288,7 @@ func sourceTableWebhookRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	t, err := materialize.ScanSourceTableWebhook(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_table.go
+++ b/pkg/resources/resource_table.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
@@ -92,7 +93,7 @@ func tableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanTable(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {
@@ -190,9 +191,7 @@ func tableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		for _, c := range columns {
 			if c.Comment != "" {
 				if err := comment.Column(c.ColName, c.Comment); err != nil {
-					log.Printf("[DEBUG] resource failed column comment, dropping object: %s", o.Name)
-					b.Drop()
-					return diag.FromErr(err)
+					return rollbackCreate(b, o, "column comment", err)
 				}
 			}
 		}

--- a/pkg/resources/resource_type.go
+++ b/pkg/resources/resource_type.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -114,7 +115,7 @@ func typeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanType(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/resources/resource_view.go
+++ b/pkg/resources/resource_view.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
@@ -57,7 +58,7 @@ func viewRead(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		return diag.FromErr(err)
 	}
 	s, err := materialize.ScanView(metaDb, utils.ExtractId(i))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		d.SetId("")
 		return nil
 	} else if err != nil {

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -130,7 +130,10 @@ var DefaultRegion string
 // freshness is not checked here: authorized clients resolve a valid token per
 // request, so there is nothing to refresh up front.
 func GetProviderMeta(meta interface{}) (*ProviderMeta, error) {
-	providerMeta := meta.(*ProviderMeta)
+	providerMeta, ok := meta.(*ProviderMeta)
+	if !ok {
+		return nil, fmt.Errorf("unexpected provider meta type %T", meta)
+	}
 
 	return providerMeta, nil
 }

--- a/pkg/utils/provider_meta_test.go
+++ b/pkg/utils/provider_meta_test.go
@@ -344,3 +344,9 @@ func TestProviderMeta_GetFronteggRoles_RetryAfterError(t *testing.T) {
 	r.Equal("role-1", roles["Admin"])
 	r.Equal(2, callCount) // Still 2, fetcher not called again after success
 }
+
+func TestGetProviderMetaWrongType(t *testing.T) {
+	if _, err := GetProviderMeta("not a provider meta"); err == nil {
+		t.Fatal("Expected an error rather than a panic for an unexpected meta type")
+	}
+}


### PR DESCRIPTION
Error checks that compared or asserted concrete types directly now use `errors.Is`/`errors.As`, so a wrapped not-found error still removes the resource from state rather than failing the plan. Also reports a warning when the cleanup drop after a failed create fails, which previously left an orphaned object with no indication, and replaces two panic paths with errors.