### PR TITLE
Remove dead provider API surface and stabilize ALTER option order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.11.7 - Unreleased
+
+### Misc
+
+* Removed the unused `utils.DefaultRegion` global and `CloudAPIClient.HTTPClient` field, turned `NeedsTokenRefresh` into a boolean check, and simplified the token refresh deadline calculation [#903](https://github.com/MaterializeInc/terraform-provider-materialize/pull/903).
+* `ALTER` statements now emit their options in a stable order [#903](https://github.com/MaterializeInc/terraform-provider-materialize/pull/903).
+
 ## 0.11.6 - 2026-07-24
 
 ### Features

--- a/pkg/clients/cloud_client.go
+++ b/pkg/clients/cloud_client.go
@@ -39,9 +39,10 @@ type CloudProviderResponse struct {
 	NextCursor string          `json:"nextCursor,omitempty"`
 }
 
-// CloudAPIClient is a client for interacting with the Materialize Cloud API
+// CloudAPIClient is a client for interacting with the Materialize Cloud API.
+// Requests go through the FronteggClient's HTTP client, which already carries
+// the Authorization token.
 type CloudAPIClient struct {
-	HTTPClient     *http.Client
 	FronteggClient *FronteggClient
 	Endpoint       string
 	BaseEndpoint   string
@@ -50,7 +51,6 @@ type CloudAPIClient struct {
 // NewCloudAPIClient creates a new Cloud API client
 func NewCloudAPIClient(fronteggClient *FronteggClient, cloudAPIEndpoint, baseEndpoint string) *CloudAPIClient {
 	return &CloudAPIClient{
-		HTTPClient:     &http.Client{},
 		FronteggClient: fronteggClient,
 		Endpoint:       cloudAPIEndpoint,
 		BaseEndpoint:   baseEndpoint,

--- a/pkg/clients/cloud_client_test.go
+++ b/pkg/clients/cloud_client_test.go
@@ -205,7 +205,6 @@ func TestNewCloudAPIClient(t *testing.T) {
 	// Assert that the returned CloudAPIClient has the expected properties
 	require.NotNil(t, cloudAPIClient)
 	require.Equal(t, fronteggClient, cloudAPIClient.FronteggClient)
-	require.NotNil(t, cloudAPIClient.HTTPClient)
 	require.Equal(t, customEndpoint, cloudAPIClient.Endpoint)
 
 	// Call the NewCloudAPIClient function with a different custom API endpoint
@@ -215,7 +214,6 @@ func TestNewCloudAPIClient(t *testing.T) {
 	// Assert that the returned CloudAPIClient has the updated custom endpoint
 	require.NotNil(t, cloudAPIClient)
 	require.Equal(t, fronteggClient, cloudAPIClient.FronteggClient)
-	require.NotNil(t, cloudAPIClient.HTTPClient)
 	require.Equal(t, anotherCustomEndpoint, cloudAPIClient.Endpoint)
 }
 

--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -46,7 +46,7 @@ func NewFronteggClient(ctx context.Context, password, endpoint string) (*Fronteg
 		Token:       token,
 		Email:       email,
 		Endpoint:    endpoint,
-		TokenExpiry: tokenExpiry.Add(-time.Duration(0.5*float64(time.Until(tokenExpiry).Nanoseconds())) * time.Nanosecond),
+		TokenExpiry: refreshDeadline(tokenExpiry),
 		Password:    password,
 	}, nil
 }
@@ -227,11 +227,15 @@ func formatDashlessUuid(dashlessUuid string) string {
 	return strings.Join(parts, "-")
 }
 
-func (c *FronteggClient) NeedsTokenRefresh() error {
-	if time.Now().After(c.TokenExpiry) {
-		return fmt.Errorf("token expired and needs refresh")
-	}
-	return nil
+// NeedsTokenRefresh reports whether the token has passed its refresh deadline.
+func (c *FronteggClient) NeedsTokenRefresh() bool {
+	return time.Now().After(c.TokenExpiry)
+}
+
+// refreshDeadline returns the point at which the token should be refreshed:
+// halfway between now and its actual expiry.
+func refreshDeadline(expiry time.Time) time.Time {
+	return time.Now().Add(time.Until(expiry) / 2)
 }
 
 func (c *FronteggClient) RefreshToken() error {
@@ -252,7 +256,7 @@ func (c *FronteggClient) RefreshToken() error {
 	c.HTTPClient = client
 	c.Token = token
 	c.Email = email
-	c.TokenExpiry = tokenExpiry.Add(-time.Duration(0.5*float64(time.Until(tokenExpiry).Nanoseconds())) * time.Nanosecond)
+	c.TokenExpiry = refreshDeadline(tokenExpiry)
 
 	return nil
 }

--- a/pkg/clients/frontegg_client_test.go
+++ b/pkg/clients/frontegg_client_test.go
@@ -89,7 +89,7 @@ func TestFronteggClient_TokenRefresh(t *testing.T) {
 	require.NotEmpty(t, fronteggClient.Token, "Token should be set correctly in the Frontegg client")
 
 	// Verify that the client does not detect the need for token refresh immediately
-	require.NoError(t, fronteggClient.NeedsTokenRefresh(), "Token should not be considered expired")
+	require.False(t, fronteggClient.NeedsTokenRefresh(), "Token should not be considered expired")
 }
 
 func generateValidJWTToken() string {
@@ -117,7 +117,7 @@ func TestFronteggClient_NeedsTokenRefresh(t *testing.T) {
 	}
 
 	// Verify that the client correctly detects the need for token refresh
-	require.Error(t, fronteggClient.NeedsTokenRefresh(), "Token should be considered expired and require refresh")
+	require.True(t, fronteggClient.NeedsTokenRefresh(), "Token should be considered expired and require refresh")
 }
 
 func TestParseAppPassword(t *testing.T) {

--- a/pkg/materialize/generic.go
+++ b/pkg/materialize/generic.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/jackc/pgconn"
@@ -85,8 +86,16 @@ func (b *Builder) resize(name, size string) error {
 }
 
 func (b *Builder) alter(name string, setOptions map[string]interface{}, resetOptions []string, isSecret, validate bool) error {
+	// Sort the options so the generated statement is stable across runs.
+	options := make([]string, 0, len(setOptions))
+	for option := range setOptions {
+		options = append(options, option)
+	}
+	sort.Strings(options)
+
 	var clauses []string
-	for option, val := range setOptions {
+	for _, option := range options {
+		val := setOptions[option]
 		var setValue string
 		switch v := val.(type) {
 		case ValueSecretStruct:

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -318,11 +318,6 @@ func configureSaaS(ctx context.Context, d *schema.ResourceData, version string) 
 	options := optionsFromResourceData(d)
 	application_name := fmt.Sprintf("terraform-provider-materialize v%s", version)
 
-	err := utils.SetDefaultRegion(string(defaultRegion))
-	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-
 	// Initialize the Frontegg client
 	fronteggClient, err := clients.NewFronteggClient(ctx, password, endpoint)
 	if err != nil {

--- a/pkg/resources/resource_cluster_replica_test.go
+++ b/pkg/resources/resource_cluster_replica_test.go
@@ -56,7 +56,6 @@ func TestResourceClusterReplicaCreate(t *testing.T) {
 
 // Confirm id is updated with region for 0.4.0
 func TestResourceClusterReplicaReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -116,7 +116,6 @@ func TestResourceClusterAutoScalingCreate(t *testing.T) {
 
 // Confirm id is updated with region and type prefix
 func TestResourceClusterReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	testCases := []struct {

--- a/pkg/resources/resource_connection_test.go
+++ b/pkg/resources/resource_connection_test.go
@@ -45,7 +45,6 @@ func TestResourceConnectionUpdate(t *testing.T) {
 // All connections (other than AWS Privatelink and SSH Tunnel)
 // share the same read function
 func TestResourceConnectionReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, ConnectionKafka().Schema, inConnection)
 	r.NotNil(d)

--- a/pkg/resources/resource_grant_cluster_default_privilege_test.go
+++ b/pkg/resources/resource_grant_cluster_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantClusterDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_cluster_test.go
+++ b/pkg/resources/resource_grant_cluster_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantClusterCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -52,7 +51,6 @@ func TestResourceGrantClusterCreate(t *testing.T) {
 }
 
 func TestResourceGrantClusterCreateP(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_connection_default_privilege_test.go
+++ b/pkg/resources/resource_grant_connection_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantConnectionDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_connection_test.go
+++ b/pkg/resources/resource_grant_connection_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantConnectionCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_database_default_privilege_test.go
+++ b/pkg/resources/resource_grant_database_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantDatabaseDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_database_test.go
+++ b/pkg/resources/resource_grant_database_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantDatabaseCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_default_privilege_test.go
+++ b/pkg/resources/resource_grant_default_privilege_test.go
@@ -72,7 +72,6 @@ func TestParseDefaultPrivilegeIdErrorEmpty(t *testing.T) {
 // Confirm id is updated with region for 0.4.0
 // All resources share the same read function
 func TestResourceGrantDefaultPrivilegeReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_materialized_view_test.go
+++ b/pkg/resources/resource_grant_materialized_view_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantMaterializedViewCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_role_test.go
+++ b/pkg/resources/resource_grant_role_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantRolePrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -51,7 +50,6 @@ func TestResourceGrantRolePrivilegeCreate(t *testing.T) {
 
 // Confirm id is updated with region for 0.4.0
 func TestResourceGrantRolePrivilegeReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_schema_default_privilege_test.go
+++ b/pkg/resources/resource_grant_schema_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSchemaDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_schema_test.go
+++ b/pkg/resources/resource_grant_schema_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSchemaCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_secret_default_privilege_test.go
+++ b/pkg/resources/resource_grant_secret_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSecretDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_secret_test.go
+++ b/pkg/resources/resource_grant_secret_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSecretCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_source_test.go
+++ b/pkg/resources/resource_grant_source_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSourceCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_system_privilege_test.go
+++ b/pkg/resources/resource_grant_system_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantSystemPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -47,7 +46,6 @@ func TestResourceGrantSystemPrivilegeCreate(t *testing.T) {
 
 // Confirm id is updated with region for 0.4.0
 func TestResourceGrantSystemPrivilegeReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_table_default_privilege_test.go
+++ b/pkg/resources/resource_grant_table_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantTableDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_table_test.go
+++ b/pkg/resources/resource_grant_table_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantTableCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -54,7 +53,6 @@ func TestResourceGrantTableCreate(t *testing.T) {
 }
 
 func TestResourceGrantTableCreatePublic(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -14,7 +14,6 @@ import (
 // Confirm id is updated with region for 0.4.0
 // All resources share the same read function
 func TestResourceGrantPrivilegeReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_type_default_privilege_test.go
+++ b/pkg/resources/resource_grant_type_default_privilege_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantTypeDefaultPrivilegeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_type_test.go
+++ b/pkg/resources/resource_grant_type_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantTypeCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_grant_view_test.go
+++ b/pkg/resources/resource_grant_view_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestResourceGrantViewCreate(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -55,7 +54,6 @@ func TestResourceGrantViewCreate(t *testing.T) {
 }
 
 func TestResourceGrantViewCreatePublic(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/resource_network_policy_test.go
+++ b/pkg/resources/resource_network_policy_test.go
@@ -62,7 +62,6 @@ func TestResourceNetworkPolicyCreate(t *testing.T) {
 }
 
 func TestResourceNetworkPolicyReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, NetworkPolicy().Schema, inNetworkPolicy)
 	r.NotNil(d)

--- a/pkg/resources/resource_schema_test.go
+++ b/pkg/resources/resource_schema_test.go
@@ -71,7 +71,6 @@ func TestResourceSchemaCreateWithIdentifyByName(t *testing.T) {
 
 // Confirm id is updated with region and identify_by_name (by-id path keeps 2-part format)
 func TestResourceSchemaReadIdMigration(t *testing.T) {
-	utils.SetDefaultRegion("aws/us-east-1")
 	r := require.New(t)
 
 	testCases := []struct {

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -86,7 +86,6 @@ type SSOConfig struct {
 
 func WithMockDb(t *testing.T, f func(*sqlx.DB, sqlmock.Sqlmock)) {
 	// Set the region for testing
-	utils.DefaultRegion = "aws/us-east-1"
 
 	t.Helper()
 	r := require.New(t)

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -124,17 +124,13 @@ For more information on provider configuration, see: https://registry.terraform.
 	return nil
 }
 
-var DefaultRegion string
-
 func GetProviderMeta(meta interface{}) (*ProviderMeta, error) {
 	providerMeta := meta.(*ProviderMeta)
 
 	// Only refresh token for SaaS mode
-	if providerMeta.Mode == ModeSaaS && providerMeta.Frontegg != nil {
-		if err := providerMeta.Frontegg.NeedsTokenRefresh(); err != nil {
-			if err := providerMeta.Frontegg.RefreshToken(); err != nil {
-				return nil, fmt.Errorf("failed to refresh token: %v", err)
-			}
+	if providerMeta.Mode == ModeSaaS && providerMeta.Frontegg != nil && providerMeta.Frontegg.NeedsTokenRefresh() {
+		if err := providerMeta.Frontegg.RefreshToken(); err != nil {
+			return nil, fmt.Errorf("failed to refresh token: %v", err)
 		}
 	}
 
@@ -196,11 +192,6 @@ func GetDBClientFromMeta(meta interface{}, d *schema.ResourceData) (*sqlx.DB, cl
 	}
 
 	return dbClient.SQLX(), region, nil
-}
-
-func SetDefaultRegion(region string) error {
-	DefaultRegion = region
-	return nil
 }
 
 // Helper function to prepend region to the ID


### PR DESCRIPTION
Clears out a few pieces of API that no longer carry their weight: a package-level default region global nothing ever read, an unused HTTP client field on the cloud API client, an error return used as a boolean, and an unreadable token expiry calculation. Also sorts ALTER options so generated statements come out in a stable order.