### PR TITLE
Run vet and race tests in CI and enforce the coverage threshold

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: lint
+on:
+  pull_request:
+    paths:
+      - pkg/**
+      - main.go
+      - go.mod
+      - .golangci.yml
+      - .github/workflows/lint.yml
+
+jobs:
+  vet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      # The codebase still has a backlog of findings, so only issues introduced
+      # by the pull request fail the job. Drop this once the backlog is cleared.
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          only-new-issues: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
       - pkg/**
       - main.go
       - go.mod
+      - .github/workflows/test.yml
+
+env:
+  COVERAGE_THRESHOLD: 50
 
 jobs:
   test:
@@ -17,21 +21,10 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      # No retries: these are deterministic unit tests, so a failure here is a
+      # real failure and retrying would only hide it.
       - name: Run Tests with Coverage
-        run: |
-          set -e
-          retries=3
-          count=0
-          until [ $count -ge $retries ]
-          do
-            go test -v -coverprofile=coverage.out -covermode=atomic ./... && break
-            count=$((count+1))
-            echo "Retrying tests... Attempt $count of $retries"
-          done
-          if [ $count -ge $retries ]; then
-            echo "Tests failed after $retries attempts."
-            exit 1
-          fi
+        run: go test -race -v -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Generate Coverage Report
         run: |
@@ -60,14 +53,23 @@ jobs:
 
             echo ""
 
-            # Check against 50% threshold
+            # Check against the 50% threshold, enforced by the step below
             COV_NUM=$(echo "$TOTAL_COV" | sed 's/%//')
-            if (( $(echo "$COV_NUM < 50" | bc -l) )); then
-              echo "⚠️ **Warning:** Coverage is below 50% threshold"
+            if (( $(echo "$COV_NUM < $COVERAGE_THRESHOLD" | bc -l) )); then
+              echo "❌ **Coverage is below the ${COVERAGE_THRESHOLD}% threshold**"
             else
-              echo "✅ Coverage meets minimum threshold (50%)"
+              echo "✅ Coverage meets minimum threshold (${COVERAGE_THRESHOLD}%)"
             fi
           } >> $GITHUB_STEP_SUMMARY
+
+      - name: Enforce Coverage Threshold
+        run: |
+          TOTAL_COV=$(tail -1 coverage.txt | awk '{gsub(/%/, "", $NF); print $NF}')
+          echo "Total coverage: ${TOTAL_COV}% (threshold ${COVERAGE_THRESHOLD}%)"
+          if (( $(echo "$TOTAL_COV < $COVERAGE_THRESHOLD" | bc -l) )); then
+            echo "Coverage ${TOTAL_COV}% is below the ${COVERAGE_THRESHOLD}% threshold."
+            exit 1
+          fi
 
       - name: Archive Coverage Report
         uses: actions/upload-artifact@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  exclusions:
+    rules:
+      # Test helpers intentionally ignore some setup errors.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.7 - Unreleased
+
+### Misc
+
+* CI now runs the unit tests under the race detector without retrying failures, enforces the coverage threshold, and runs `go vet` and `golangci-lint` on pull requests [#904](https://github.com/MaterializeInc/terraform-provider-materialize/pull/904).
+
 ## 0.11.6 - 2026-07-24
 
 ### Features

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,9 +22,17 @@ install:
 	mkdir -p ${PLUGIN_PATH}
 	go build -o ${PLUGIN_PATH}/${BINARY}
 
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: lint
+lint:
+	golangci-lint run
+
 .PHONY: test
 test:
-	go test ./... -v $(TESTARGS) -timeout 120m
+	go test -race ./... -v $(TESTARGS) -timeout 120m
 
 .PHONY: testacc
 testacc:


### PR DESCRIPTION
Drops the retry loop around the unit tests so a failure is reported instead of retried away, runs them under the race detector, and makes the coverage threshold actually fail the job rather than just printing a warning. Adds a lint workflow running `go vet` and golangci-lint, scoped to issues the pull request introduces since there is an existing backlog of findings to work through separately.