### PR TITLE
Authorize API clients from a shared token source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fixed a leaked HTTP connection on every failed Frontegg API call, and app passwords that are not exactly 64 hexadecimal characters are now rejected with a clear error instead of failing authentication later [#899](https://github.com/MaterializeInc/terraform-provider-materialize/pull/899).
 * Fixed transient query failures being reported as an absent `auto_scaling_strategy` or an absent in-flight resize on `materialize_cluster` and `materialize_source_*` reads [#900](https://github.com/MaterializeInc/terraform-provider-materialize/pull/900). Only a genuinely missing catalog view (older Materialize versions) is now treated as "not configured".
 * Fixed identifiers and literals that were hand-quoted when generating SQL [#901](https://github.com/MaterializeInc/terraform-provider-materialize/pull/901), so ownership roles, system parameters, default privilege database and schema qualifiers, resize sizes, CSV delimiters and Protobuf message names now escape correctly instead of producing invalid statements.
+* Fixed a data race on the Frontegg access token that could corrupt the shared HTTP client when Terraform ran resource operations in parallel, and stopped concurrent operations from each firing their own token request when the token expired [#906](https://github.com/MaterializeInc/terraform-provider-materialize/pull/906).
+* Every Frontegg and Cloud API request now has a 30 second timeout. Previously an unresponsive endpoint could hang a plan or apply indefinitely [#906](https://github.com/MaterializeInc/terraform-provider-materialize/pull/906).
 
 ### Misc
 

--- a/pkg/clients/cloud_client.go
+++ b/pkg/clients/cloud_client.go
@@ -41,28 +41,35 @@ type CloudProviderResponse struct {
 
 // CloudAPIClient is a client for interacting with the Materialize Cloud API
 type CloudAPIClient struct {
-	HTTPClient     *http.Client
-	FronteggClient *FronteggClient
-	Endpoint       string
-	BaseEndpoint   string
+	HTTPClient   *http.Client
+	Endpoint     string
+	BaseEndpoint string
 }
 
-// NewCloudAPIClient creates a new Cloud API client
-func NewCloudAPIClient(fronteggClient *FronteggClient, cloudAPIEndpoint, baseEndpoint string) *CloudAPIClient {
+// NewCloudAPIClient creates a new Cloud API client that authorizes its requests
+// from the given token source.
+func NewCloudAPIClient(tokens TokenSource, cloudAPIEndpoint, baseEndpoint string) *CloudAPIClient {
 	return &CloudAPIClient{
-		HTTPClient:     &http.Client{},
-		FronteggClient: fronteggClient,
-		Endpoint:       cloudAPIEndpoint,
-		BaseEndpoint:   baseEndpoint,
+		HTTPClient:   newAuthorizedClient(tokens),
+		Endpoint:     cloudAPIEndpoint,
+		BaseEndpoint: baseEndpoint,
 	}
+}
+
+// get issues an authorized GET that honours ctx.
+func (c *CloudAPIClient) get(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.HTTPClient.Do(req)
 }
 
 // ListCloudProviders fetches the list of cloud providers and their regions
 func (c *CloudAPIClient) ListCloudProviders(ctx context.Context) ([]CloudProvider, error) {
 	providersEndpoint := fmt.Sprintf("%s/api/cloud-regions", c.Endpoint)
 
-	// Reuse the FronteggClient's HTTPClient which already includes the Authorization token.
-	resp, err := c.FronteggClient.HTTPClient.Get(providersEndpoint)
+	resp, err := c.get(ctx, providersEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error listing cloud providers: %v", err)
 	}
@@ -90,7 +97,7 @@ func (c *CloudAPIClient) ListCloudProviders(ctx context.Context) ([]CloudProvide
 func (c *CloudAPIClient) GetRegionDetails(ctx context.Context, provider CloudProvider) (*CloudRegion, error) {
 	regionEndpoint := fmt.Sprintf("%s/api/region", provider.Url)
 
-	resp, err := c.FronteggClient.HTTPClient.Get(regionEndpoint)
+	resp, err := c.get(ctx, regionEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving region details: %v", err)
 	}
@@ -127,7 +134,7 @@ func (c *CloudAPIClient) EnableRegion(ctx context.Context, provider CloudProvide
 
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.FronteggClient.HTTPClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error sending request to enable region: %v", err)
 	}

--- a/pkg/clients/cloud_client_test.go
+++ b/pkg/clients/cloud_client_test.go
@@ -63,8 +63,8 @@ func TestCloudAPIClient_ListCloudProviders(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	// Call the method to test
@@ -86,8 +86,8 @@ func TestCloudAPIClient_GetRegionDetails(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	provider := CloudProvider{
@@ -115,8 +115,8 @@ func TestCloudAPIClient_GetHost(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	regionID := "aws/us-east-1"
@@ -140,8 +140,8 @@ func TestCloudAPIClient_ListCloudProviders_ErrorResponse(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	// Call the method to test
@@ -158,8 +158,8 @@ func TestCloudAPIClient_GetRegionDetails_ErrorResponse(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 	provider := CloudProvider{
 		ID:   "aws/us-east-1",
@@ -180,8 +180,8 @@ func TestCloudAPIClient_GetHost_RegionNotFound(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 	regionID := "non-existent-region"
 
@@ -194,7 +194,7 @@ func TestCloudAPIClient_GetHost_RegionNotFound(t *testing.T) {
 }
 
 func TestNewCloudAPIClient(t *testing.T) {
-	// Create a FronteggClient instance for testing
+	// Any TokenSource will do; the constructor only wires it into the transport.
 	fronteggClient := &FronteggClient{}
 
 	// Call the NewCloudAPIClient function with a custom API endpoint
@@ -204,7 +204,6 @@ func TestNewCloudAPIClient(t *testing.T) {
 
 	// Assert that the returned CloudAPIClient has the expected properties
 	require.NotNil(t, cloudAPIClient)
-	require.Equal(t, fronteggClient, cloudAPIClient.FronteggClient)
 	require.NotNil(t, cloudAPIClient.HTTPClient)
 	require.Equal(t, customEndpoint, cloudAPIClient.Endpoint)
 
@@ -214,7 +213,6 @@ func TestNewCloudAPIClient(t *testing.T) {
 
 	// Assert that the returned CloudAPIClient has the updated custom endpoint
 	require.NotNil(t, cloudAPIClient)
-	require.Equal(t, fronteggClient, cloudAPIClient.FronteggClient)
 	require.NotNil(t, cloudAPIClient.HTTPClient)
 	require.Equal(t, anotherCustomEndpoint, cloudAPIClient.Endpoint)
 }
@@ -225,8 +223,8 @@ func TestCloudAPIClient_EnableRegion_Success(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	provider := CloudProvider{
@@ -250,8 +248,8 @@ func TestCloudAPIClient_EnableRegion_Error(t *testing.T) {
 	}
 	mockClient := &http.Client{Transport: mockService}
 	apiClient := &CloudAPIClient{
-		FronteggClient: &FronteggClient{HTTPClient: mockClient},
-		Endpoint:       "http://mockendpoint.com",
+		HTTPClient: mockClient,
+		Endpoint:   "http://mockendpoint.com",
 	}
 
 	provider := CloudProvider{

--- a/pkg/clients/frontegg_client.go
+++ b/pkg/clients/frontegg_client.go
@@ -7,61 +7,87 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// FronteggClient struct to encapsulate the http.Client with additional properties
+// FronteggClient talks to the Frontegg admin API and doubles as the TokenSource
+// for every other authorized client.
+//
+// HTTPClient, Endpoint and Email are fixed once the client is built. The token
+// state behind them is mutable and guarded by mu.
 type FronteggClient struct {
-	HTTPClient  *http.Client
-	Token       string
-	Email       string
-	Endpoint    string
-	TokenExpiry time.Time
-	Password    string
+	HTTPClient *http.Client
+	Endpoint   string
+	// Email identifies the authenticated principal and is also used as the
+	// database user. It is derived from the credentials, so it never changes for
+	// the lifetime of the client.
+	Email string
+
+	mu          sync.Mutex
+	token       string
+	tokenExpiry time.Time
+	password    string
 }
 
 // NewFronteggClient function for initializing a new Frontegg client with an auth token
 func NewFronteggClient(ctx context.Context, password, endpoint string) (*FronteggClient, error) {
+	// Fetch a token up front: it validates the credentials before Terraform gets
+	// going and yields the email used as the database user.
 	token, email, tokenExpiry, err := getToken(ctx, password, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token: %v", err)
 	}
 
-	transport := &tokenTransport{
-		Token:     token,
-		Transport: http.DefaultTransport,
+	c := &FronteggClient{
+		Endpoint:    endpoint,
+		Email:       email,
+		token:       token,
+		tokenExpiry: refreshDeadline(tokenExpiry),
+		password:    password,
+	}
+	c.HTTPClient = newAuthorizedClient(c)
+
+	return c, nil
+}
+
+// Token implements TokenSource. It returns the cached token while it is still
+// good and otherwise fetches a new one. The lock is deliberately held across the
+// fetch so that concurrent callers arriving on an expired token produce a single
+// request instead of one each.
+func (c *FronteggClient) Token(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.token != "" && time.Now().Before(c.tokenExpiry) {
+		return c.token, nil
 	}
 
-	client := &http.Client{Transport: transport}
+	if c.password == "" {
+		return "", errors.New("no credentials available to obtain a Frontegg token")
+	}
 
-	return &FronteggClient{
-		HTTPClient:  client,
-		Token:       token,
-		Email:       email,
-		Endpoint:    endpoint,
-		TokenExpiry: tokenExpiry.Add(-time.Duration(0.5*float64(time.Until(tokenExpiry).Nanoseconds())) * time.Nanosecond),
-		Password:    password,
-	}, nil
+	token, _, tokenExpiry, err := getToken(ctx, c.password, c.Endpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	c.token = token
+	c.tokenExpiry = refreshDeadline(tokenExpiry)
+
+	return c.token, nil
 }
 
-// tokenTransport struct to add the Authorization header to each request
-type tokenTransport struct {
-	Token     string
-	Transport http.RoundTripper
-}
-
-// RoundTrip method to execute the request with the token
-func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req2 := cloneRequest(req)
-	req2.Header.Set("Authorization", "Bearer "+t.Token)
-	return t.Transport.RoundTrip(req2)
+// refreshDeadline returns the point at which a token should be replaced: halfway
+// between now and its actual expiry, so a request is never sent with a token
+// about to lapse.
+func refreshDeadline(expiry time.Time) time.Time {
+	return time.Now().Add(time.Until(expiry) / 2)
 }
 
 // GetToken function to authenticate with the Frontegg API and retrieve a token
@@ -88,7 +114,8 @@ func getToken(ctx context.Context, password string, endpoint string) (string, st
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	// Not the authorized client: this call is what obtains the token.
+	resp, err := authClient.Do(req)
 	if err != nil {
 		return "", "", time.Time{}, err
 	}
@@ -154,51 +181,6 @@ func getToken(ctx context.Context, password string, endpoint string) (string, st
 	return tokenString, email, tokenExpiry, nil
 }
 
-// Get the token from the FronteggClient
-func (c *FronteggClient) GetToken() string {
-	return c.Token
-}
-
-// Get the email from the FronteggClient
-func (c *FronteggClient) GetEmail() string {
-	return c.Email
-}
-
-// Get the endpoint from the FronteggClient
-func (c *FronteggClient) GetEndpoint() string {
-	return c.Endpoint
-}
-
-// Get the token expiry from the FronteggClient
-func (c *FronteggClient) GetTokenExpiry() time.Time {
-	return c.TokenExpiry
-}
-
-// Get the password from the FronteggClient
-func (c *FronteggClient) GetPassword() string {
-	return c.Password
-}
-
-// cloneRequest creates a deep copy of an HTTP request to enable safe modifications
-// while preserving concurrency safety, immutability, and reusability.
-// https://stackoverflow.com/questions/62017146/http-request-clone-is-not-deep-clone
-func cloneRequest(r *http.Request) *http.Request {
-	// Deep copy the request
-	r2 := new(http.Request)
-	*r2 = *r
-
-	// Deep copy the URL
-	r2.URL = new(url.URL)
-	*r2.URL = *r.URL
-
-	// Deep copy the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-	return r2
-}
-
 func parseAppPassword(password string) (string, string, error) {
 	strippedPassword := strings.TrimPrefix(password, "mzp_")
 
@@ -227,37 +209,6 @@ func formatDashlessUuid(dashlessUuid string) string {
 		dashlessUuid[20:],
 	}
 	return strings.Join(parts, "-")
-}
-
-func (c *FronteggClient) NeedsTokenRefresh() error {
-	if time.Now().After(c.TokenExpiry) {
-		return fmt.Errorf("token expired and needs refresh")
-	}
-	return nil
-}
-
-func (c *FronteggClient) RefreshToken() error {
-	// Never log the client itself: it carries the app password and the token.
-	log.Printf("[DEBUG] Refreshing Frontegg token for %s", c.Email)
-
-	token, email, tokenExpiry, err := getToken(context.Background(), c.Password, c.Endpoint)
-	if err != nil {
-		return fmt.Errorf("failed to get token: %v", err)
-	}
-
-	transport := &tokenTransport{
-		Token:     token,
-		Transport: http.DefaultTransport,
-	}
-
-	client := &http.Client{Transport: transport}
-
-	c.HTTPClient = client
-	c.Token = token
-	c.Email = email
-	c.TokenExpiry = tokenExpiry.Add(-time.Duration(0.5*float64(time.Until(tokenExpiry).Nanoseconds())) * time.Nanosecond)
-
-	return nil
 }
 
 // Helper function to handle API errors

--- a/pkg/clients/frontegg_client_test.go
+++ b/pkg/clients/frontegg_client_test.go
@@ -38,8 +38,10 @@ func TestNewFronteggClient(t *testing.T) {
 	require.NoError(t, err, "Error should be nil")
 	require.NotNil(t, fronteggClient, "Frontegg client should not be nil")
 
-	// The token should be set correctly in the Frontegg client
-	require.Equal(t, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Im16X3N5c3RlbSIsImV4cCI6MTcwMDAwMDAwMH0.c2lnbmF0dXJl", fronteggClient.Token, "Token should be set correctly in the Frontegg client")
+	// The token fetched at construction should be the one handed to callers.
+	token, err := fronteggClient.Token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Im16X3N5c3RlbSIsImV4cCI6MTcwMDAwMDAwMH0.c2lnbmF0dXJl", token, "Token should be set correctly in the Frontegg client")
 }
 
 func TestFronteggClient_AuthenticationError(t *testing.T) {
@@ -86,11 +88,10 @@ func TestFronteggClient_TokenRefresh(t *testing.T) {
 	require.NoError(t, err, "Error should be nil")
 	require.NotNil(t, fronteggClient, "Frontegg client should not be nil")
 
-	// The token should be initially set correctly in the Frontegg client
-	require.NotEmpty(t, fronteggClient.Token, "Token should be set correctly in the Frontegg client")
-
-	// Verify that the client does not detect the need for token refresh immediately
-	require.NoError(t, fronteggClient.NeedsTokenRefresh(), "Token should not be considered expired")
+	// A freshly built client hands back its token without going back to the API.
+	token, err := fronteggClient.Token(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, token, "Token should be available from the Frontegg client")
 }
 
 func generateValidJWTToken() string {
@@ -107,18 +108,13 @@ func generateValidJWTToken() string {
 	return tokenString
 }
 
-func TestFronteggClient_NeedsTokenRefresh(t *testing.T) {
-	// Create a Frontegg client with an expired token
-	fronteggClient := &FronteggClient{
-		Token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Im16X3N5c3RlbSIsImV4cCI6MTYwMDAwMDAwMH0.c2lnbmF0dXJl",
-		Email:       "test@example.com",
-		Endpoint:    "http://mockedendpoint",
-		TokenExpiry: time.Now().Add(-time.Hour), // Expired token
-		Password:    "mzp_" + strings.Repeat("a", 64),
-	}
+func TestFronteggClientTokenWithoutCredentials(t *testing.T) {
+	// A client assembled without credentials cannot mint a token, and must say so
+	// rather than panicking.
+	fronteggClient := &FronteggClient{Endpoint: "http://mockedendpoint"}
 
-	// Verify that the client correctly detects the need for token refresh
-	require.Error(t, fronteggClient.NeedsTokenRefresh(), "Token should be considered expired and require refresh")
+	_, err := fronteggClient.Token(context.Background())
+	require.Error(t, err, "A client with no credentials should report an error")
 }
 
 func TestParseAppPassword(t *testing.T) {

--- a/pkg/clients/token_source.go
+++ b/pkg/clients/token_source.go
@@ -1,0 +1,56 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// requestTimeout bounds every outbound API call. Without it a hung endpoint
+// stalls a Terraform operation indefinitely with no way out but Ctrl-C.
+const requestTimeout = 30 * time.Second
+
+// authClient issues the unauthenticated token requests themselves, so it must
+// not carry a bearerTransport.
+var authClient = &http.Client{Timeout: requestTimeout}
+
+// TokenSource supplies a currently valid bearer token, refreshing it when it has
+// expired. Implementations must be safe for concurrent use: Terraform runs
+// resource operations in parallel.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// bearerTransport authorizes each request with a token taken from source at the
+// moment the request is sent. Resolving per request means callers never hold a
+// stale token and nothing has to be swapped out when the token is refreshed.
+type bearerTransport struct {
+	source TokenSource
+	base   http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.source.Token(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	// RoundTrip must not modify the request it is given.
+	r := req.Clone(req.Context())
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(r)
+}
+
+// newAuthorizedClient returns an HTTP client that authorizes every request from
+// source and gives up after requestTimeout.
+func newAuthorizedClient(source TokenSource) *http.Client {
+	return &http.Client{
+		Timeout:   requestTimeout,
+		Transport: &bearerTransport{source: source},
+	}
+}

--- a/pkg/clients/token_source_test.go
+++ b/pkg/clients/token_source_test.go
@@ -1,0 +1,136 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// countingAuthServer serves the token endpoint and records how many times it was
+// asked for a token.
+func countingAuthServer(t *testing.T, calls *int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/identity/resources/auth/v1/api-token" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt64(calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessToken":"` + generateValidJWTToken() + `","expiresIn":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newTestFronteggClient(t *testing.T, endpoint string) *FronteggClient {
+	t.Helper()
+	c, err := NewFronteggClient(context.Background(), "mzp_"+strings.Repeat("a", 64), endpoint)
+	require.NoError(t, err)
+	return c
+}
+
+func TestTokenIsCachedUntilItExpires(t *testing.T) {
+	var calls int64
+	srv := countingAuthServer(t, &calls)
+	c := newTestFronteggClient(t, srv.URL)
+	require.EqualValues(t, 1, atomic.LoadInt64(&calls), "constructing the client fetches one token")
+
+	for i := 0; i < 5; i++ {
+		_, err := c.Token(context.Background())
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 1, atomic.LoadInt64(&calls), "a valid token should be reused")
+}
+
+func TestTokenRefreshesOnceForConcurrentCallers(t *testing.T) {
+	var calls int64
+	srv := countingAuthServer(t, &calls)
+	c := newTestFronteggClient(t, srv.URL)
+
+	// Force the cached token past its refresh deadline.
+	c.mu.Lock()
+	c.tokenExpiry = time.Now().Add(-time.Hour)
+	c.mu.Unlock()
+
+	// This is the case that used to fire one token request per goroutine and race
+	// on the shared client.
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.Token(context.Background()); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.EqualValues(t, 2, atomic.LoadInt64(&calls),
+		"an expired token should be refreshed exactly once regardless of caller count")
+}
+
+// stubTokenSource is the whole fake a client needs now.
+type stubTokenSource struct {
+	token string
+	err   error
+}
+
+func (s stubTokenSource) Token(context.Context) (string, error) { return s.token, s.err }
+
+type capturingTransport struct {
+	gotAuth  string
+	gotOther string
+}
+
+func (c *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.gotAuth = req.Header.Get("Authorization")
+	c.gotOther = req.Header.Get("X-Original")
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+func TestBearerTransportAuthorizesEachRequest(t *testing.T) {
+	capture := &capturingTransport{}
+	rt := &bearerTransport{source: stubTokenSource{token: "abc123"}, base: capture}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/x", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Original", "kept")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "Bearer abc123", capture.gotAuth, "the token should be applied per request")
+	require.Equal(t, "kept", capture.gotOther, "existing headers should survive")
+	require.Empty(t, req.Header.Get("Authorization"), "RoundTrip must not mutate the caller's request")
+}
+
+func TestBearerTransportPropagatesTokenFailure(t *testing.T) {
+	rt := &bearerTransport{source: stubTokenSource{err: context.DeadlineExceeded}, base: &capturingTransport{}}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/x", nil)
+	require.NoError(t, err)
+
+	_, err = rt.RoundTrip(req)
+	require.Error(t, err, "a token failure should surface instead of sending an unauthorized request")
+}
+
+func TestAuthorizedClientsAreBounded(t *testing.T) {
+	require.Equal(t, requestTimeout, newAuthorizedClient(stubTokenSource{}).Timeout)
+	require.Equal(t, requestTimeout, authClient.Timeout, "the token request itself must be bounded too")
+}

--- a/pkg/datasources/datasource_region_test.go
+++ b/pkg/datasources/datasource_region_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -24,14 +23,13 @@ func TestRegionRead(t *testing.T) {
 		}
 
 		fronteggClient := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  mockClient,
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: mockClient,
 		}
 		// Create a mock cloud client
 		mockCloudClient := &clients.CloudAPIClient{
-			FronteggClient: fronteggClient,
-			Endpoint:       serverURL,
+			HTTPClient: fronteggClient.HTTPClient,
+			Endpoint:   serverURL,
 		}
 
 		// Create a provider meta with the mock cloud client

--- a/pkg/datasources/datasource_scim_configs_test.go
+++ b/pkg/datasources/datasource_scim_configs_test.go
@@ -18,9 +18,8 @@ func TestDataSourceSCIM2ConfigurationsRead_Success(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/datasources/datasource_scim_groups_test.go
+++ b/pkg/datasources/datasource_scim_groups_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -18,9 +17,8 @@ func TestDataSourceSCIMGroupsRead_Success(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/datasources/datasource_sso_config_test.go
+++ b/pkg/datasources/datasource_sso_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -18,9 +17,8 @@ func TestDataSourceSSOConfigRead_Success(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/datasources/datasource_user_test.go
+++ b/pkg/datasources/datasource_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -19,9 +18,8 @@ func TestUserDataSourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -46,9 +44,8 @@ func TestUserDataSourceRead_UserNotFound(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/frontegg/tenant_api_token_test.go
+++ b/pkg/frontegg/tenant_api_token_test.go
@@ -28,7 +28,6 @@ func TestListTenantApiTokens(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	tokens, err := ListTenantApiTokens(context.Background(), client)

--- a/pkg/frontegg/user.go
+++ b/pkg/frontegg/user.go
@@ -85,7 +85,7 @@ func CreateUser(ctx context.Context, client *clients.FronteggClient, userRequest
 func ReadUser(ctx context.Context, client *clients.FronteggClient, userID string) (UserResponse, error) {
 	var userResponse UserResponse
 
-	endpoint := fmt.Sprintf("%s%s/%s", client.GetEndpoint(), UsersApiPathV1, userID)
+	endpoint := fmt.Sprintf("%s%s/%s", client.Endpoint, UsersApiPathV1, userID)
 	resp, err := doRequest(ctx, client, "GET", endpoint, nil)
 	if err != nil {
 		return userResponse, err

--- a/pkg/frontegg/user_api_token_test.go
+++ b/pkg/frontegg/user_api_token_test.go
@@ -28,7 +28,6 @@ func TestListUserApiTokens(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	tokens, err := ListUserApiTokens(context.Background(), client)

--- a/pkg/frontegg/user_test.go
+++ b/pkg/frontegg/user_test.go
@@ -142,7 +142,6 @@ func TestCreateUser(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	userRequest := UserRequest{
@@ -166,7 +165,6 @@ func TestReadUser(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	userID := "test-user-id"
@@ -187,7 +185,6 @@ func TestDeleteUser(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	userID := "test-user-id"
@@ -204,7 +201,6 @@ func TestGetUsers(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	// Test case 1: User found
@@ -241,7 +237,6 @@ func TestUpdateUserRoles(t *testing.T) {
 	client := &clients.FronteggClient{
 		HTTPClient: &http.Client{},
 		Endpoint:   mockServer.URL,
-		Token:      "mock-token",
 	}
 
 	userID := "test-user-id"

--- a/pkg/resources/resource_app_password_test.go
+++ b/pkg/resources/resource_app_password_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -24,9 +23,8 @@ func TestAppPasswordResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -72,9 +70,8 @@ func TestAppPasswordResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -99,9 +96,8 @@ func TestAppPasswordResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_region_test.go
+++ b/pkg/resources/resource_region_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -24,14 +23,13 @@ func TestResourceCloudRegionCreate(t *testing.T) {
 		}
 
 		fronteggClient := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  mockClient,
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: mockClient,
 		}
 		// Create a mock cloud client
 		mockCloudClient := &clients.CloudAPIClient{
-			FronteggClient: fronteggClient,
-			Endpoint:       serverURL,
+			HTTPClient: fronteggClient.HTTPClient,
+			Endpoint:   serverURL,
 		}
 
 		// Create a provider meta with the mock cloud client
@@ -68,14 +66,13 @@ func TestResourceCloudRegionRead(t *testing.T) {
 		}
 
 		fronteggClient := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  mockClient,
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: mockClient,
 		}
 
 		mockCloudClient := &clients.CloudAPIClient{
-			FronteggClient: fronteggClient,
-			Endpoint:       serverURL,
+			HTTPClient: fronteggClient.HTTPClient,
+			Endpoint:   serverURL,
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_scim_config_test.go
+++ b/pkg/resources/resource_scim_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -25,9 +24,8 @@ func TestSCIM2ConfigurationResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -52,9 +50,8 @@ func TestSCIM2ConfigurationResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -82,9 +79,8 @@ func TestSCIM2ConfigurationResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_scim_group_roles_test.go
+++ b/pkg/resources/resource_scim_group_roles_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -25,9 +24,8 @@ func TestScimGroupRoleResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -52,9 +50,8 @@ func TestScimGroupRoleResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -77,9 +74,8 @@ func TestScimGroupRoleResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_scim_group_test.go
+++ b/pkg/resources/resource_scim_group_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -25,9 +24,8 @@ func TestScimGroupResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -50,9 +48,8 @@ func TestScimGroupResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -78,9 +75,8 @@ func TestScimGroupResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_scim_group_users_test.go
+++ b/pkg/resources/resource_scim_group_users_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -25,9 +24,8 @@ func TestScimGroupUsersCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -48,9 +46,8 @@ func TestScimGroupUsersRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -72,9 +69,8 @@ func TestScimGroupUsersUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -98,9 +94,8 @@ func TestScimGroupUsersDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_sso_config_test.go
+++ b/pkg/resources/resource_sso_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -30,14 +29,13 @@ func TestSSOConfigResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		mockCloudClient := &clients.CloudAPIClient{
-			FronteggClient: client,
-			Endpoint:       serverURL,
+			HTTPClient: client.HTTPClient,
+			Endpoint:   serverURL,
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -63,9 +61,8 @@ func TestSSOConfigResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -92,14 +89,13 @@ func TestSSOConfigResourceUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		mockCloudClient := &clients.CloudAPIClient{
-			FronteggClient: client,
-			Endpoint:       serverURL,
+			HTTPClient: client.HTTPClient,
+			Endpoint:   serverURL,
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -122,9 +118,8 @@ func TestSSOConfigResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_sso_default_roles_test.go
+++ b/pkg/resources/resource_sso_default_roles_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -19,9 +18,8 @@ func TestSSODefaultRolesCreateOrUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -67,9 +65,8 @@ func TestSSODefaultRolesRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -111,9 +108,8 @@ func TestSSODefaultRolesDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_sso_domain_test.go
+++ b/pkg/resources/resource_sso_domain_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -25,9 +24,8 @@ func TestSSODomainResourceCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -48,9 +46,8 @@ func TestSSODomainResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -80,9 +77,8 @@ func TestSSODomainResourceUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -110,9 +106,8 @@ func TestSSODomainResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_sso_group_mapping_test.go
+++ b/pkg/resources/resource_sso_group_mapping_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -18,9 +17,8 @@ func TestSSORoleGroupMappingCreate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -59,9 +57,8 @@ func TestSSORoleGroupMappingRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -97,9 +94,8 @@ func TestSSORoleGroupMappingUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -146,9 +142,8 @@ func TestSSORoleGroupMappingDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/resources/resource_user_test.go
+++ b/pkg/resources/resource_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/testhelpers"
@@ -18,9 +17,8 @@ func TestUserResourceRead(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -43,9 +41,8 @@ func TestUserResourceDelete(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{
@@ -69,9 +66,8 @@ func TestUserResourceUpdate(t *testing.T) {
 
 	testhelpers.WithMockFronteggServer(t, func(serverURL string) {
 		client := &clients.FronteggClient{
-			Endpoint:    serverURL,
-			HTTPClient:  &http.Client{},
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
+			Endpoint:   serverURL,
+			HTTPClient: &http.Client{},
 		}
 
 		providerMeta := &utils.ProviderMeta{

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -117,10 +117,8 @@ func WithMockProviderMeta(t *testing.T, f func(*utils.ProviderMeta, sqlmock.Sqlm
 		DB:             dbClients,
 		RegionsEnabled: regionsEnabled,
 		DefaultRegion:  clients.AwsUsEast1,
-		Frontegg: &clients.FronteggClient{
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
-		},
-		CloudAPI: nil,
+		Frontegg:       &clients.FronteggClient{},
+		CloudAPI:       nil,
 		FronteggRoles: map[string]string{
 			"Admin":  "1",
 			"Member": "2",

--- a/pkg/utils/provider_meta.go
+++ b/pkg/utils/provider_meta.go
@@ -126,17 +126,11 @@ For more information on provider configuration, see: https://registry.terraform.
 
 var DefaultRegion string
 
+// GetProviderMeta returns the provider meta carried through the SDK. Token
+// freshness is not checked here: authorized clients resolve a valid token per
+// request, so there is nothing to refresh up front.
 func GetProviderMeta(meta interface{}) (*ProviderMeta, error) {
 	providerMeta := meta.(*ProviderMeta)
-
-	// Only refresh token for SaaS mode
-	if providerMeta.Mode == ModeSaaS && providerMeta.Frontegg != nil {
-		if err := providerMeta.Frontegg.NeedsTokenRefresh(); err != nil {
-			if err := providerMeta.Frontegg.RefreshToken(); err != nil {
-				return nil, fmt.Errorf("failed to refresh token: %v", err)
-			}
-		}
-	}
 
 	return providerMeta, nil
 }

--- a/pkg/utils/provider_meta_test.go
+++ b/pkg/utils/provider_meta_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/clients"
@@ -33,9 +32,7 @@ func TestGetDBClientFromMeta(t *testing.T) {
 			clients.AwsUsEast1: true,
 		},
 		DefaultRegion: clients.AwsUsEast1,
-		Frontegg: &clients.FronteggClient{
-			TokenExpiry: time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC),
-		},
+		Frontegg:      &clients.FronteggClient{},
 	}
 
 	// Create a ResourceData schema with the "region" key


### PR DESCRIPTION
Having the cloud API client borrow the Frontegg client's HTTP client was a shortcut taken when cloud and Frontegg support first went in, and it never got revisited. The token was baked into that transport, so refreshing it meant swapping out the shared client, which is what made the refresh path racy. Each client now builds its own HTTP client around a small `TokenSource` interface: tokens resolve per request under a lock, refreshes are single-flight, and every call has a timeout.

Most of the diff is mechanical, 22 test files that set `TokenExpiry` only to satisfy the old eager-refresh check. The real change is in `token_source.go`, `frontegg_client.go`, `cloud_client.go` and `provider_meta.go`.

Verified against staging with a race-enabled build: apply, clean plan, destroy, plus a forced token refresh against real Frontegg.

Fixes https://github.com/MaterializeInc/terraform-provider-materialize/issues/543