### PR TITLE
Warn when MZ_HOST silently selects self-hosted mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.11.8 - Unreleased
+
+### Bug Fixes
+
+* The provider now warns when it selects self-hosted mode because `MZ_HOST` is set in the environment rather than `host` being set in the configuration. A leftover `MZ_HOST` silently switched the provider away from Materialize Cloud, which authenticated as the `username` default instead of the app password owner and produced a confusing `invalid password` error [#913](https://github.com/MaterializeInc/terraform-provider-materialize/pull/913).
+* Corrected the documented environment variable for `username`, which is `MZ_USERNAME` and not `MZ_USER`, and documented that `host` selects self-hosted mode [#913](https://github.com/MaterializeInc/terraform-provider-materialize/pull/913).
+
 ## 0.11.7 - 2026-08-24
 
 ### Bug Fixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,15 +92,17 @@ When configured with `host`, `username`, etc. (second example above), **some res
 
 These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
 
+**⚠️ Watch out for `MZ_HOST`:** `host` is what selects self-hosted mode, and it falls back to the `MZ_HOST` environment variable. If `MZ_HOST` is set in your shell, the provider uses self-hosted mode even when your configuration never mentions a host. Unset it before running against Materialize Cloud.
+
 **⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
 
 ## Schema
 
 * `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
 * `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
-* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `host` (String, Optional) The Materialize host (self-hosted only). Setting this, including through the `MZ_HOST` environment variable, switches the provider to self-hosted mode. Leave it unset to connect to Materialize Cloud.
 * `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
-* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USERNAME` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 * `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 
@@ -116,7 +117,7 @@ func Provider(version string) *schema.Provider {
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The Materialize host. Can also come from the `MZ_HOST` environment variable.",
+				Description: "The Materialize host (self-hosted only). Setting this, including through the `MZ_HOST` environment variable, switches the provider to self-hosted mode. Leave it unset to connect to Materialize Cloud.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_HOST", nil),
 			},
 			"port": {
@@ -128,7 +129,7 @@ func Provider(version string) *schema.Provider {
 			"username": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The Materialize username. Can also come from the `MZ_USERNAME` environment variable.",
+				Description: "The database username (self-hosted only). Ignored in Materialize Cloud, where the account that owns the app password is used. Can also come from the `MZ_USERNAME` environment variable.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_USERNAME", "materialize"),
 			},
 			"options": {
@@ -242,13 +243,62 @@ func Provider(version string) *schema.Provider {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
-	// Check for self-hosted configuration
+	// Setting `host` is what selects self-hosted mode, and `host` falls back to
+	// MZ_HOST. That means a stray environment variable can switch modes even
+	// though the configuration never mentions a host, which changes how the
+	// connection authenticates and prefixes resource IDs with `self-hosted`.
 	if host := d.Get("host").(string); host != "" {
 		log.Printf("[DEBUG] Configuring self-hosted provider")
-		return configureSelfHosted(ctx, d, version)
+		meta, diags := configureSelfHosted(ctx, d, version)
+		if hostOnlyFromEnvironment(d) && usesCloudCredentials(d) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Connecting to a self-hosted Materialize because MZ_HOST is set",
+				Detail: fmt.Sprintf(
+					"The provider is using self-hosted mode with host %q, which came from the MZ_HOST "+
+						"environment variable rather than this configuration.\n\n"+
+						"In this mode the provider authenticates with the `username` argument (currently %q) "+
+						"instead of the account that owns the app password, resource IDs are prefixed with "+
+						"`self-hosted` instead of the region, and Materialize Cloud resources such as "+
+						"materialize_app_password, materialize_user and the SSO/SCIM resources are unavailable.\n\n"+
+						"If you meant to connect to Materialize Cloud, unset MZ_HOST.",
+					host, d.Get("username").(string),
+				),
+			})
+		}
+		return meta, diags
 	}
 	log.Printf("[DEBUG] Configuring SaaS provider")
 	return configureSaaS(ctx, d, version)
+}
+
+// usesCloudCredentials reports whether the password is a Materialize Cloud app
+// password. That is the one signal that is unambiguous: self-managed instances
+// use ordinary database passwords. Cloud-only arguments such as default_region
+// are deliberately not used here, because a self-managed user migrating from
+// Cloud can easily leave one behind, and a warning that fires on every plan for
+// a correct setup is worse than missing a case.
+func usesCloudCredentials(d *schema.ResourceData) bool {
+	return strings.HasPrefix(d.Get("password").(string), "mzp_")
+}
+
+// hostOnlyFromEnvironment reports whether `host` was left out of the
+// configuration, meaning its value can only have come from MZ_HOST.
+func hostOnlyFromEnvironment(d *schema.ResourceData) bool {
+	envHost := os.Getenv("MZ_HOST")
+	if envHost == "" {
+		return false
+	}
+
+	// The raw configuration is the reliable answer: it holds what the user
+	// actually wrote, before any environment fallback is applied.
+	if raw := d.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
+		return raw.GetAttr("host").IsNull()
+	}
+
+	// No raw configuration available, so fall back to comparing the value the
+	// provider ended up with against the environment.
+	return d.Get("host").(string) == envHost
 }
 
 func configureSelfHosted(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -9,7 +10,9 @@ import (
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sdkterraform "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"golang.org/x/exp/slices"
@@ -298,5 +301,63 @@ func testAccCheckGrantDefaultPrivilegeExists(objectType, grantName, granteeName,
 			return fmt.Errorf("object %s does not include privilege %s", p, privilege)
 		}
 		return nil
+	}
+}
+
+// Setting host is what selects self-hosted mode, and host falls back to MZ_HOST.
+// A stray environment variable therefore switches modes silently, so the
+// provider warns when the host it used never appeared in the configuration.
+func TestProviderWarnsWhenModeComesFromMZHost(t *testing.T) {
+	host := "some-host.aws.materialize.cloud"
+
+	tests := []struct {
+		name       string
+		envHost    string
+		configHost string
+		password   string
+		cloudArg   bool
+		wantWarn   bool
+	}{
+		{name: "cloud config with stray MZ_HOST", envHost: host, password: "mzp_secret", wantWarn: true},
+		{name: "host set in config", envHost: host, configHost: "configured-host.example.com", password: "mzp_secret", wantWarn: false},
+		{name: "no host anywhere", password: "mzp_secret", wantWarn: false},
+		// The documented self-managed setup supplies the host from the
+		// environment on purpose, so it must not be warned at every apply.
+		{name: "self-managed supplying host from env", envHost: host, password: "ordinary-password", wantWarn: false},
+		// A self-managed user migrating from Cloud may leave default_region
+		// behind; an ordinary password still means no warning.
+		{name: "self-managed with leftover cloud argument", envHost: host, password: "ordinary-password", cloudArg: true, wantWarn: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envHost != "" {
+				t.Setenv("MZ_HOST", tt.envHost)
+			} else {
+				t.Setenv("MZ_HOST", "")
+			}
+
+			raw := map[string]interface{}{"password": tt.password, "sslmode": "disable"}
+			if tt.configHost != "" {
+				raw["host"] = tt.configHost
+			}
+			if tt.cloudArg {
+				raw["default_region"] = "aws/us-east-1"
+			}
+
+			p := Provider("test")
+			diags := p.Configure(context.Background(), sdkterraform.NewResourceConfigRaw(raw))
+
+			var warned bool
+			for _, d := range diags {
+				if d.Severity == diag.Warning && strings.Contains(d.Summary, "MZ_HOST") {
+					warned = true
+				}
+			}
+
+			if warned != tt.wantWarn {
+				t.Fatalf("warning about MZ_HOST = %v, want %v (diags: %+v)", warned, tt.wantWarn, diags)
+			}
+		})
 	}
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -30,15 +30,17 @@ When configured with `host`, `username`, etc. (second example above), **some res
 
 These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
 
+**⚠️ Watch out for `MZ_HOST`:** `host` is what selects self-hosted mode, and it falls back to the `MZ_HOST` environment variable. If `MZ_HOST` is set in your shell, the provider uses self-hosted mode even when your configuration never mentions a host. Unset it before running against Materialize Cloud.
+
 **⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
 
 ## Schema
 
 * `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
 * `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
-* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `host` (String, Optional) The Materialize host (self-hosted only). Setting this, including through the `MZ_HOST` environment variable, switches the provider to self-hosted mode. Leave it unset to connect to Materialize Cloud.
 * `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
-* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USERNAME` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 * `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.


### PR DESCRIPTION
A customer hit a confusing `invalid password` error after upgrading, because `MZ_HOST` was left over in their shell. Setting `host` is what selects self-hosted mode, and `host` falls back to `MZ_HOST`, so the provider switched away from Materialize Cloud even though their configuration never mentioned a host. The provider now warns when the host it used did not come from the configuration, and the docs say that `host` selects the mode. Also fixes the documented variable name for `username`, which is `MZ_USERNAME` and not `MZ_USER`.