### PR TITLE
Add an explicit connection mode to the provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.11.8 - Unreleased
+
+### Features
+
+* Added a `mode` argument to the provider, either `cloud` or `direct`, that states how to connect instead of leaving it to be inferred. `cloud` authenticates with an app password and finds a connection for each region through the Materialize Cloud API, and ignores `MZ_HOST`. `direct` connects to the `host` you supply, which may be self-hosted or Materialize Cloud, and reports a clear error when no host is given. Leaving `mode` unset keeps the existing behaviour, where a host selects direct and its absence selects cloud [#914](https://github.com/MaterializeInc/terraform-provider-materialize/pull/914).
+
+### Bug Fixes
+
+* The provider now warns when it inferred a direct connection from `MZ_HOST` rather than from the configuration. A leftover `MZ_HOST` silently redirected Materialize Cloud projects, authenticated as the `username` default instead of the app password owner, and failed with a confusing `invalid password` error [#914](https://github.com/MaterializeInc/terraform-provider-materialize/pull/914).
+* Fixed a provider crash when `materialize_region` was used without Materialize Cloud credentials. The Cloud API client is only built in cloud mode, so reading it in a direct connection dereferenced a nil pointer; it now reports the same clear error as the other Cloud-only resources [#914](https://github.com/MaterializeInc/terraform-provider-materialize/pull/914).
+* Corrected the documented environment variable for `username`, which is `MZ_USERNAME` and not `MZ_USER` [#914](https://github.com/MaterializeInc/terraform-provider-materialize/pull/914).
+
 ## 0.11.7 - 2026-08-24
 
 ### Bug Fixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,15 +92,18 @@ When configured with `host`, `username`, etc. (second example above), **some res
 
 These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
 
+**Choosing a mode:** set `mode` in the provider configuration to say which of the two you want. `mode = "cloud"` authenticates with an app password and finds a connection for each region through the Materialize Cloud API. `mode = "direct"` connects straight to the `host` you supply, which can be a self-hosted instance or a Materialize Cloud one. If you leave `mode` unset the provider infers it, using `direct` when a host is set and `cloud` otherwise. Because `host` falls back to the `MZ_HOST` environment variable, that inference can be decided by your shell rather than by your configuration, so setting `mode` explicitly is recommended.
+
 **⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
 
 ## Schema
 
 * `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
 * `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
-* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `mode` (String, Optional) How the provider connects: `cloud` or `direct`. When unset, the provider infers `direct` if a host is set and `cloud` otherwise.
+* `host` (String, Optional) The Materialize host, used by `direct` mode. Can also come from the `MZ_HOST` environment variable.
 * `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
-* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USERNAME` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 * `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.

--- a/pkg/datasources/datasource_region.go
+++ b/pkg/datasources/datasource_region.go
@@ -57,6 +57,12 @@ func RegionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// The Cloud API is only configured in cloud mode; without this the
+	// client below is nil and the provider panics.
+	if diags := providerMeta.ValidateSaaSOnly("materialize_region"); diags.HasError() {
+		return diags
+	}
 	client := providerMeta.CloudAPI
 
 	providers, err := client.ListCloudProviders(ctx)

--- a/pkg/datasources/datasource_region_test.go
+++ b/pkg/datasources/datasource_region_test.go
@@ -60,3 +60,15 @@ func TestRegionRead(t *testing.T) {
 		r.Equal("sql.materialize.com", d.Get("regions.0.host"))
 	})
 }
+
+// The Cloud API client is only built in cloud mode. Without the guard the
+// client is nil here and the provider panics instead of reporting an error.
+func TestRegionDatasourceInDirectModeDoesNotPanic(t *testing.T) {
+	meta := &utils.ProviderMeta{Mode: utils.ModeSelfHosted}
+	d := schema.TestResourceDataRaw(t, Region().Schema, map[string]interface{}{})
+
+	diags := RegionRead(context.TODO(), d, meta)
+	if !diags.HasError() {
+		t.Fatal("expected an error when the Cloud API is not configured")
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"strings"
 
@@ -16,7 +17,16 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	_ "github.com/jackc/pgx/v4/stdlib"
+)
+
+// The two ways the provider can reach Materialize. `cloud` discovers a SQL
+// connection per region through the Materialize Cloud API; `direct` connects to
+// a single host you supply, which may be a self-managed instance or a Cloud one.
+const (
+	modeCloud  = "cloud"
+	modeDirect = "direct"
 )
 
 // reservedOptionKeys are connection parameters the provider manages itself.
@@ -113,10 +123,22 @@ func Provider(version string) *schema.Provider {
 				Description: "The default region if not specified in the resource",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_DEFAULT_REGION", "aws/us-east-1"),
 			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// Deliberately no environment fallback. The mode decides which
+				// backend the provider talks to, and that must be visible in the
+				// configuration rather than in someone's shell.
+				Description: "How the provider connects to Materialize. `cloud` authenticates with an app password and discovers a SQL connection for each region through the Materialize Cloud API. `direct` connects straight to the `host` you supply. When unset, the provider infers `direct` if a host is set and `cloud` otherwise; setting it explicitly is recommended.",
+				ValidateFunc: validation.StringInSlice([]string{
+					modeCloud,
+					modeDirect,
+				}, false),
+			},
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The Materialize host. Can also come from the `MZ_HOST` environment variable.",
+				Description: "The Materialize host, used by `direct` mode. Can also come from the `MZ_HOST` environment variable. Note that when `mode` is unset, supplying a host is what selects `direct` mode.",
 				DefaultFunc: schema.EnvDefaultFunc("MZ_HOST", nil),
 			},
 			"port": {
@@ -242,13 +264,102 @@ func Provider(version string) *schema.Provider {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
-	// Check for self-hosted configuration
-	if host := d.Get("host").(string); host != "" {
-		log.Printf("[DEBUG] Configuring self-hosted provider")
+	host := d.Get("host").(string)
+
+	switch d.Get("mode").(string) {
+	case modeDirect:
+		if host == "" {
+			return nil, diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "`host` is required when `mode` is \"direct\"",
+				Detail: "Set `host` in the provider configuration, or supply it through the MZ_HOST " +
+					"environment variable.",
+			}}
+		}
+		log.Printf("[DEBUG] Configuring provider in direct mode")
 		return configureSelfHosted(ctx, d, version)
+
+	case modeCloud:
+		// A host written into the configuration alongside `mode = "cloud"` is a
+		// contradiction. A host that merely arrived from MZ_HOST is ignored,
+		// which is the entire point of stating the mode explicitly.
+		if host != "" && !hostOnlyFromEnvironment(d) {
+			return nil, diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "`host` cannot be set when `mode` is \"cloud\"",
+				Detail: "In cloud mode the provider discovers a connection for each region through the " +
+					"Materialize Cloud API. Remove `host`, or set `mode` to \"direct\" to connect to it.",
+			}}
+		}
+		if host != "" {
+			log.Printf("[DEBUG] Ignoring MZ_HOST because mode is cloud")
+		}
+		return configureCloud(ctx, d, version)
+
+	case "":
+		// Fall through to the inference below.
+
+	default:
+		// ValidateFunc catches this during plan, but never silently fall back to
+		// inference for a mode we do not recognise.
+		return nil, diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("unknown `mode` %q", d.Get("mode").(string)),
+			Detail:   fmt.Sprintf("Valid values are %q and %q.", modeCloud, modeDirect),
+		}}
 	}
-	log.Printf("[DEBUG] Configuring SaaS provider")
-	return configureSaaS(ctx, d, version)
+
+	// No mode given, so fall back to the historical rule: a host means direct.
+	if host != "" {
+		log.Printf("[DEBUG] Configuring provider in direct mode (inferred from host)")
+		meta, diags := configureSelfHosted(ctx, d, version)
+		return meta, append(diags, inferredModeWarning(d, host)...)
+	}
+	log.Printf("[DEBUG] Configuring provider in cloud mode (inferred)")
+	return configureCloud(ctx, d, version)
+}
+
+// inferredModeWarning flags the case where nothing in the configuration says
+// which backend to use and the deciding value came from the environment. That
+// combination is invisible when reading the configuration, and it is how a
+// leftover MZ_HOST silently redirects a Materialize Cloud project.
+func inferredModeWarning(d *schema.ResourceData, host string) diag.Diagnostics {
+	if !hostOnlyFromEnvironment(d) {
+		return nil
+	}
+
+	return diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  "Connecting in direct mode because MZ_HOST is set",
+		Detail: fmt.Sprintf(
+			"The provider is connecting directly to %q. That host came from the MZ_HOST environment "+
+				"variable, not from this configuration, so nothing here shows which backend is in use.\n\n"+
+				"Direct mode authenticates with the `username` argument (currently %q), prefixes resource IDs "+
+				"with `self-hosted` rather than a region, and cannot manage Materialize Cloud resources such "+
+				"as materialize_app_password, materialize_user or the SSO and SCIM resources.\n\n"+
+				"Set `mode` in the provider configuration to say which you want. Use `mode = \"cloud\"` to "+
+				"reach Materialize Cloud and ignore MZ_HOST.",
+			host, d.Get("username").(string),
+		),
+	}}
+}
+
+// hostOnlyFromEnvironment reports whether `host` was left out of the
+// configuration, meaning its value can only have come from MZ_HOST.
+func hostOnlyFromEnvironment(d *schema.ResourceData) bool {
+	envHost := os.Getenv("MZ_HOST")
+	if envHost == "" {
+		return false
+	}
+
+	// The raw configuration is the reliable answer: it holds what the user
+	// actually wrote, before any environment fallback is applied.
+	if raw := d.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
+		return raw.GetAttr("host").IsNull()
+	}
+
+	// No raw configuration available, so compare the resolved value instead.
+	return d.Get("host").(string) == envHost
 }
 
 func configureSelfHosted(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
@@ -307,7 +418,7 @@ func optionsFromResourceData(d *schema.ResourceData) map[string]string {
 	return out
 }
 
-func configureSaaS(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
+func configureCloud(ctx context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
 	password := d.Get("password").(string)
 	database := d.Get("database").(string)
 	sslmode := d.Get("sslmode").(string)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -9,7 +10,9 @@ import (
 
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/materialize"
 	"github.com/MaterializeInc/terraform-provider-materialize/pkg/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sdkterraform "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"golang.org/x/exp/slices"
@@ -298,5 +301,115 @@ func testAccCheckGrantDefaultPrivilegeExists(objectType, grantName, granteeName,
 			return fmt.Errorf("object %s does not include privilege %s", p, privilege)
 		}
 		return nil
+	}
+}
+
+// modeDiags configures the provider with the given raw config and environment,
+// returning the diagnostics so each mode rule can be asserted in isolation.
+func modeDiags(t *testing.T, envHost string, raw map[string]interface{}) diag.Diagnostics {
+	t.Helper()
+	t.Setenv("MZ_HOST", envHost)
+	if raw["password"] == nil {
+		// Any value works; cloud configuration fails later at the network call,
+		// which is past every rule under test here.
+		raw["password"] = "mzp_" + strings.Repeat("a", 64)
+	}
+	return Provider("test").Configure(context.Background(), sdkterraform.NewResourceConfigRaw(raw))
+}
+
+func hasDiag(diags diag.Diagnostics, sev diag.Severity, needle string) bool {
+	for _, d := range diags {
+		if d.Severity == sev && (strings.Contains(d.Summary, needle) || strings.Contains(d.Detail, needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProviderModeDirectRequiresHost(t *testing.T) {
+	// No host anywhere: this must be a clear error rather than a silent switch
+	// to cloud, which is what the old inference did.
+	diags := modeDiags(t, "", map[string]interface{}{"mode": "direct"})
+	if !hasDiag(diags, diag.Error, "`host` is required") {
+		t.Fatalf("expected a missing-host error, got %+v", diags)
+	}
+
+	// Host from the environment satisfies it, because the mode was still stated.
+	diags = modeDiags(t, "some-host.example.com", map[string]interface{}{
+		"mode": "direct", "sslmode": "disable",
+	})
+	if hasDiag(diags, diag.Error, "`host` is required") {
+		t.Fatalf("MZ_HOST should satisfy direct mode, got %+v", diags)
+	}
+}
+
+func TestProviderModeCloudIgnoresStrayMZHost(t *testing.T) {
+	// The reported incident: a cloud configuration with MZ_HOST left in the
+	// shell. Stating the mode must make the stray value irrelevant, so the
+	// provider must not report the direct-mode connection error.
+	diags := modeDiags(t, "leftover-host.example.com", map[string]interface{}{"mode": "cloud"})
+
+	if hasDiag(diags, diag.Error, "cannot be set when `mode`") {
+		t.Fatalf("a host from the environment should be ignored in cloud mode, got %+v", diags)
+	}
+	if hasDiag(diags, diag.Warning, "MZ_HOST is set") {
+		t.Fatalf("no inference warning should appear once mode is explicit, got %+v", diags)
+	}
+	for _, d := range diags {
+		if d.Severity == diag.Error && strings.Contains(d.Detail, "leftover-host.example.com") {
+			t.Fatalf("provider tried to use the stray host: %+v", d)
+		}
+	}
+}
+
+func TestProviderModeCloudRejectsConfiguredHost(t *testing.T) {
+	// Writing both into the configuration is a contradiction, unlike a stray
+	// environment variable.
+	diags := modeDiags(t, "", map[string]interface{}{
+		"mode": "cloud", "host": "written-in-config.example.com",
+	})
+	if !hasDiag(diags, diag.Error, "cannot be set when `mode`") {
+		t.Fatalf("expected a contradiction error, got %+v", diags)
+	}
+}
+
+func TestProviderModeRejectsUnknownValue(t *testing.T) {
+	// Terraform runs ValidateFunc during plan.
+	_, errs := Provider("test").Schema["mode"].ValidateFunc("self_hosted", "mode")
+	if len(errs) == 0 {
+		t.Fatal("expected schema validation to reject an unknown mode")
+	}
+
+	// And configuring with one must error rather than quietly inferring.
+	diags := modeDiags(t, "", map[string]interface{}{"mode": "self_hosted"})
+	if !hasDiag(diags, diag.Error, "unknown `mode`") {
+		t.Fatalf("expected an unknown-mode error, got %+v", diags)
+	}
+}
+
+func TestProviderInferredModeWarnsOnlyWhenHostCameFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envHost  string
+		raw      map[string]interface{}
+		wantWarn bool
+	}{
+		// Nothing in the configuration reveals the backend: worth a warning.
+		{name: "host from env", envHost: "h.example.com",
+			raw: map[string]interface{}{"sslmode": "disable"}, wantWarn: true},
+		// The host is written down, so the inference is visible to the reader.
+		{name: "host in config", envHost: "",
+			raw: map[string]interface{}{"host": "h.example.com", "sslmode": "disable"}, wantWarn: false},
+		// Plain cloud usage.
+		{name: "no host at all", envHost: "", raw: map[string]interface{}{}, wantWarn: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := modeDiags(t, tt.envHost, tt.raw)
+			if got := hasDiag(diags, diag.Warning, "MZ_HOST is set"); got != tt.wantWarn {
+				t.Fatalf("warning = %v, want %v (diags: %+v)", got, tt.wantWarn, diags)
+			}
+		})
 	}
 }

--- a/pkg/resources/resource_region.go
+++ b/pkg/resources/resource_region.go
@@ -68,6 +68,12 @@ func resourceCloudRegionCreate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// The Cloud API is only configured in cloud mode; without this the
+	// client below is nil and the provider panics.
+	if diags := providerMeta.ValidateSaaSOnly("materialize_region"); diags.HasError() {
+		return diags
+	}
 	client := providerMeta.CloudAPI
 
 	regionID := d.Get("region_id").(string)
@@ -132,6 +138,12 @@ func resourceCloudRegionRead(ctx context.Context, d *schema.ResourceData, meta i
 	providerMeta, err := utils.GetProviderMeta(meta)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// The Cloud API is only configured in cloud mode; without this the
+	// client below is nil and the provider panics.
+	if diags := providerMeta.ValidateSaaSOnly("materialize_region"); diags.HasError() {
+		return diags
 	}
 	client := providerMeta.CloudAPI
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -30,15 +30,18 @@ When configured with `host`, `username`, etc. (second example above), **some res
 
 These organization and identity management resources depend on Frontegg (Materialize Cloud's identity provider) and will produce clear error messages if used in self-hosted mode.
 
+**Choosing a mode:** set `mode` in the provider configuration to say which of the two you want. `mode = "cloud"` authenticates with an app password and finds a connection for each region through the Materialize Cloud API. `mode = "direct"` connects straight to the `host` you supply, which can be a self-hosted instance or a Materialize Cloud one. If you leave `mode` unset the provider infers it, using `direct` when a host is set and `cloud` otherwise. Because `host` falls back to the `MZ_HOST` environment variable, that inference can be decided by your shell rather than by your configuration, so setting `mode` explicitly is recommended.
+
 **⚠️ Migration Warning:** Switching between SaaS and self-hosted modes requires careful state file management. We strongly recommend using consistent configuration mode from the beginning to avoid complex state migrations.
 
 ## Schema
 
 * `password` (String, Sensitive) Materialize App Password (SaaS) or database password (self-hosted). Can also come from the `MZ_PASSWORD` environment variable.
 * `default_region` (String, Optional) The Materialize AWS region (SaaS only). Can also come from the `MZ_DEFAULT_REGION` environment variable. Defaults to `aws/us-east-1`.
-* `host` (String, Optional) The Materialize host (self-hosted only). Can also come from the `MZ_HOST` environment variable.
+* `mode` (String, Optional) How the provider connects: `cloud` or `direct`. When unset, the provider infers `direct` if a host is set and `cloud` otherwise.
+* `host` (String, Optional) The Materialize host, used by `direct` mode. Can also come from the `MZ_HOST` environment variable.
 * `port` (Number, Optional) The Materialize port (self-hosted only). Can also come from the `MZ_PORT` environment variable. Defaults to `6875`.
-* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USER` environment variable. Defaults to `materialize`.
+* `username` (String, Optional) The database username (self-hosted only). Can also come from the `MZ_USERNAME` environment variable. Defaults to `materialize`.
 * `database` (String, Optional) The Materialize database. Can also come from the `MZ_DATABASE` environment variable. Defaults to `materialize`.
 * `sslmode` (String, Optional) SSL mode (self-hosted only). Can also come from the `MZ_SSLMODE` environment variable. Defaults to `require`.
 * `options` (Map of String, Optional) Additional Postgres connection options forwarded in the `options` connection string parameter as `--key=value` flags. Useful for session-level settings such as `cluster`, `search_path`, or `oidc_auth_enabled` (required for OIDC/SSO authentication). The `transaction_isolation` and `application_name` keys are reserved and managed by the provider.


### PR DESCRIPTION
The provider decided between Materialize Cloud and a direct connection by checking whether `host` was set, and `host` falls back to `MZ_HOST`. A leftover environment variable could therefore redirect a Cloud project without anything in the configuration showing it, which is what a customer hit.

Adds a `mode` argument, `cloud` or `direct`, with no environment fallback so the choice is always visible in the configuration. `cloud` ignores a stray `MZ_HOST`, `direct` errors when no host is given instead of quietly falling back to Cloud, and writing `host` next to `mode = "cloud"` is rejected as a contradiction. Leaving `mode` unset behaves exactly as before, with a warning only when the host came from the environment.

Verified against a staging Cloud account and a local Materialize: the reported incident now succeeds, direct mode works, a missing host is a clear error, and the old env-only setup still works.