### PR TITLE
Only send WAIT UNTIL READY for cluster changes that create replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed `materialize_cluster_grant` wanting to recreate a grant after a cluster swap. The grant addresses its cluster by name but stored the catalog id, so a blue/green deploy left the id pointing at a dropped cluster. The read now re-resolves the id from `cluster_name`.
 * Fixed a revoked grant staying in state. The grant, system privilege and default privilege reads each cleared the id when the privilege was no longer present, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
 * Fixed grants to `PUBLIC` never matching on read. `PUBLIC` has no row in `mz_roles` and its privileges come back with an empty grantee, so they were never keyed under the id the grant resources use.
+* Fixed `ALTER CLUSTER` failing when `wait_until_ready` is enabled and the change does not create new replicas, for example a change to `replication_factor` or `auto_scaling_strategy`. `WAIT UNTIL READY` is now only sent for changes Materialize accepts it with.
 
 ## 0.11.7 - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fixed `materialize_cluster_grant` wanting to recreate a grant after a cluster swap. The grant addresses its cluster by name but stored the catalog id, so a blue/green deploy left the id pointing at a dropped cluster. The read now re-resolves the id from `cluster_name`.
 * Fixed a revoked grant staying in state. The grant, system privilege and default privilege reads each cleared the id when the privilege was no longer present, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
 * Fixed grants to `PUBLIC` never matching on read. `PUBLIC` has no row in `mz_roles` and its privileges come back with an empty grantee, so they were never keyed under the id the grant resources use.
-* Fixed `ALTER CLUSTER` failing when `wait_until_ready` is enabled and the change does not create new replicas, for example a change to `replication_factor` or `auto_scaling_strategy`. `WAIT UNTIL READY` is now only sent for changes Materialize accepts it with.
+* Fixed `ALTER CLUSTER` failing when `wait_until_ready` is enabled and the change was one Materialize does not allow waiting on, such as `replication_factor` or `auto_scaling_strategy`. `WAIT UNTIL READY` is now only sent alongside a `size`, `availability_zones` or introspection change. Other changes are applied without waiting, and a warning is emitted so the skipped wait is visible.
 
 ## 0.11.7 - 2026-08-24
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -39,7 +39,7 @@ resource "materialize_cluster" "example_cluster" {
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
 - `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))
 - `size` (String) The size of the managed cluster.
-- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options (see [below for nested schema](#nestedblock--wait_until_ready))
+- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change to `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting. (see [below for nested schema](#nestedblock--wait_until_ready))
 
 ### Read-Only
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -39,7 +39,7 @@ resource "materialize_cluster" "example_cluster" {
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
 - `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))
 - `size` (String) The size of the managed cluster.
-- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change that sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting. (see [below for nested schema](#nestedblock--wait_until_ready))
+- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options. Materialize only allows waiting when the same change also sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. For any other change, such as `replication_factor`, the wait is skipped. (see [below for nested schema](#nestedblock--wait_until_ready))
 
 ### Read-Only
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -39,7 +39,7 @@ resource "materialize_cluster" "example_cluster" {
 - `replication_factor` (Number) The number of replicas of each dataflow-powered object to maintain.
 - `scheduling` (Block List, Max: 1) Defines the scheduling parameters for the cluster. (see [below for nested schema](#nestedblock--scheduling))
 - `size` (String) The size of the managed cluster.
-- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change to `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting. (see [below for nested schema](#nestedblock--wait_until_ready))
+- `wait_until_ready` (Block List, Max: 1) Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change that sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting. (see [below for nested schema](#nestedblock--wait_until_ready))
 
 ### Read-Only
 

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -417,6 +417,66 @@ func TestAccClusterAlterGraceful(t *testing.T) {
 	})
 }
 
+// Materialize rejects WAIT unless the ALTER also changes size, availability
+// zones or introspection, so a cluster that leaves wait_until_ready enabled
+// must still be able to change other attributes.
+func TestAccClusterAlterGracefulWithoutReplicaChange(t *testing.T) {
+	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	size := "25cc"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckAllClusterDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "1", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists("materialize_cluster.test_graceful"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "replication_factor", "1"),
+				),
+			},
+			{
+				// Replication factor only
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "replication_factor", "2"),
+				),
+			},
+			{
+				// Autoscaling only, the case the customer reported
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", "50cc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "auto_scaling_strategy.0.on_hydration.0.hydration_size", "50cc"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterGracefulWithoutReplicaChange(clusterName, clusterSize, replicationFactor, hydrationSize string) string {
+	strategy := ""
+	if hydrationSize != "" {
+		strategy = fmt.Sprintf(`
+		auto_scaling_strategy {
+			on_hydration {
+				hydration_size = "%s"
+			}
+		}`, hydrationSize)
+	}
+	return fmt.Sprintf(`
+	resource "materialize_cluster" "test_graceful" {
+		name               = "%[1]s"
+		size               = "%[2]s"
+		replication_factor = %[3]s
+		wait_until_ready {
+			enabled    = true
+			timeout    = "10m"
+			on_timeout = "COMMIT"
+		}%[4]s
+	}
+	`, clusterName, clusterSize, replicationFactor, strategy)
+}
+
 func testAccClusterResource(
 	roleName,
 	cluster1Name,

--- a/pkg/provider/acceptance_cluster_test.go
+++ b/pkg/provider/acceptance_cluster_test.go
@@ -417,9 +417,9 @@ func TestAccClusterAlterGraceful(t *testing.T) {
 	})
 }
 
-// Materialize rejects WAIT unless the ALTER also changes size, availability
-// zones or introspection, so a cluster that leaves wait_until_ready enabled
-// must still be able to change other attributes.
+// Materialize rejects WAIT unless the ALTER also carries a size, availability
+// zones or introspection option, so a cluster that leaves wait_until_ready
+// enabled must still be able to change its other attributes.
 func TestAccClusterAlterGracefulWithoutReplicaChange(t *testing.T) {
 	clusterName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	size := "25cc"
@@ -429,7 +429,7 @@ func TestAccClusterAlterGracefulWithoutReplicaChange(t *testing.T) {
 		CheckDestroy:      testAccCheckAllClusterDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "1", ""),
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "1", "", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists("materialize_cluster.test_graceful"),
 					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "replication_factor", "1"),
@@ -437,23 +437,32 @@ func TestAccClusterAlterGracefulWithoutReplicaChange(t *testing.T) {
 			},
 			{
 				// Replication factor only
-				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", ""),
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", "", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "replication_factor", "2"),
 				),
 			},
 			{
 				// Autoscaling only, the case the customer reported
-				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", "50cc"),
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "2", "50cc", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "auto_scaling_strategy.0.on_hydration.0.hydration_size", "50cc"),
+				),
+			},
+			{
+				// Turning introspection debugging off drops the option from the
+				// statement, so it cannot carry WAIT either.
+				Config: testAccClusterGracefulWithoutReplicaChange(clusterName, size, "3", "50cc", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "replication_factor", "3"),
+					resource.TestCheckResourceAttr("materialize_cluster.test_graceful", "introspection_debugging", "false"),
 				),
 			},
 		},
 	})
 }
 
-func testAccClusterGracefulWithoutReplicaChange(clusterName, clusterSize, replicationFactor, hydrationSize string) string {
+func testAccClusterGracefulWithoutReplicaChange(clusterName, clusterSize, replicationFactor, hydrationSize string, introspectionDebugging bool) string {
 	strategy := ""
 	if hydrationSize != "" {
 		strategy = fmt.Sprintf(`
@@ -465,16 +474,17 @@ func testAccClusterGracefulWithoutReplicaChange(clusterName, clusterSize, replic
 	}
 	return fmt.Sprintf(`
 	resource "materialize_cluster" "test_graceful" {
-		name               = "%[1]s"
-		size               = "%[2]s"
-		replication_factor = %[3]s
+		name                    = "%[1]s"
+		size                    = "%[2]s"
+		replication_factor      = %[3]s
+		introspection_debugging = %[5]t
 		wait_until_ready {
 			enabled    = true
 			timeout    = "10m"
 			on_timeout = "COMMIT"
 		}%[4]s
 	}
-	`, clusterName, clusterSize, replicationFactor, strategy)
+	`, clusterName, clusterSize, replicationFactor, strategy, introspectionDebugging)
 }
 
 func testAccClusterResource(

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -123,7 +123,7 @@ var clusterSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		MaxItems:    1,
-		Description: "Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change that sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting.",
+		Description: "Defines the parameters for the WAIT UNTIL READY options. Materialize only allows waiting when the same change also sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. For any other change, such as `replication_factor`, the wait is skipped.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
@@ -405,9 +405,8 @@ type clusterChanges interface {
 
 // waitUntilReadySupported reports whether the pending change will put an option
 // in the statement that Materialize allows WAIT UNTIL READY alongside: size,
-// availability zones or introspection. Anything else alters the cluster in
-// place, so there are no new replicas to wait on and the server rejects the
-// whole statement.
+// availability zones or introspection. Sending WAIT with anything else makes
+// the server reject the whole statement.
 //
 // A field being unset does not count. GenerateClusterOptions omits an option
 // without a value, so the server never sees it, and these conditions mirror it.
@@ -431,6 +430,22 @@ func waitUntilReadySupported(d clusterChanges) bool {
 	}
 
 	return false
+}
+
+// waitUntilReadyEnabled reports whether the config asks to wait at all.
+func waitUntilReadyEnabled(d clusterChanges) bool {
+	v, ok := d.Get("wait_until_ready").([]interface{})
+	if !ok || len(v) == 0 {
+		return false
+	}
+
+	opts, ok := v[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	enabled, _ := opts["enabled"].(bool)
+	return enabled
 }
 
 func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -552,14 +567,25 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	var diags diag.Diagnostics
+
 	if changed {
 		_, reconfigOptsRaw := d.GetChange("wait_until_ready")
 		reconfigOpts := b.GetReconfigOpts(reconfigOptsRaw)
 		if !waitUntilReadySupported(d) {
-			// Nothing here builds new replicas to wait on, and sending WAIT
-			// anyway makes Materialize reject the whole statement.
-			log.Printf("[DEBUG] dropping WAIT UNTIL READY: this change does not create replicas")
+			// Materialize would reject the statement, so apply the change
+			// without waiting rather than failing the whole update.
+			log.Printf("[DEBUG] dropping WAIT UNTIL READY: no size, availability zones or introspection change to wait on")
 			reconfigOpts = materialize.ReconfigurationOptions{}
+
+			if waitUntilReadyEnabled(d) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "wait_until_ready was skipped for this change",
+					Detail: fmt.Sprintf("Materialize only supports WAIT UNTIL READY when the same change sets size, availability zones or introspection. "+
+						"Cluster %q was updated without waiting for it to be ready.", clusterName),
+				})
+			}
 		}
 		if err := b.AlterCluster(reconfigOpts); err != nil {
 			return diag.FromErr(err)
@@ -575,7 +601,7 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	return clusterRead(ctx, d, meta)
+	return append(diags, clusterRead(ctx, d, meta)...)
 }
 
 func clusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -123,7 +123,7 @@ var clusterSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		MaxItems:    1,
-		Description: "Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change to `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting.",
+		Description: "Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change that sets `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
@@ -397,27 +397,39 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 	return clusterRead(ctx, d, meta)
 }
 
-// waitUntilReadyFields are the attributes Materialize allows WAIT UNTIL READY
-// to be combined with. Any other change alters the cluster in place, so there
-// are no new replicas to wait on and the server rejects the statement.
-var waitUntilReadyFields = []string{
-	"size",
-	"availability_zones",
-	"introspection_interval",
-	"introspection_debugging",
-}
-
-// changeChecker is the part of schema.ResourceData that waitUntilReadySupported needs.
-type changeChecker interface {
+// clusterChanges is the part of schema.ResourceData that waitUntilReadySupported needs.
+type clusterChanges interface {
 	HasChange(key string) bool
+	Get(key string) interface{}
 }
 
-func waitUntilReadySupported(d changeChecker) bool {
-	for _, f := range waitUntilReadyFields {
-		if d.HasChange(f) {
+// waitUntilReadySupported reports whether the pending change will put an option
+// in the statement that Materialize allows WAIT UNTIL READY alongside: size,
+// availability zones or introspection. Anything else alters the cluster in
+// place, so there are no new replicas to wait on and the server rejects the
+// whole statement.
+//
+// A field being unset does not count. GenerateClusterOptions omits an option
+// without a value, so the server never sees it, and these conditions mirror it.
+func waitUntilReadySupported(d clusterChanges) bool {
+	if d.HasChange("size") && d.Get("size").(string) != "" {
+		return true
+	}
+
+	if d.HasChange("availability_zones") {
+		if azs, ok := d.Get("availability_zones").([]interface{}); ok && len(azs) > 0 {
 			return true
 		}
 	}
+
+	if d.HasChange("introspection_interval") && d.Get("introspection_interval").(string) != "" {
+		return true
+	}
+
+	if d.HasChange("introspection_debugging") && d.Get("introspection_debugging").(bool) {
+		return true
+	}
+
 	return false
 }
 

--- a/pkg/resources/resource_cluster.go
+++ b/pkg/resources/resource_cluster.go
@@ -123,7 +123,7 @@ var clusterSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		MaxItems:    1,
-		Description: "Defines the parameters for the WAIT UNTIL READY options",
+		Description: "Defines the parameters for the WAIT UNTIL READY options. Only applied when the change creates new replicas, meaning a change to `size`, `availability_zones`, `introspection_interval` or `introspection_debugging`. Other changes are applied without waiting.",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
@@ -397,6 +397,30 @@ func clusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 	return clusterRead(ctx, d, meta)
 }
 
+// waitUntilReadyFields are the attributes Materialize allows WAIT UNTIL READY
+// to be combined with. Any other change alters the cluster in place, so there
+// are no new replicas to wait on and the server rejects the statement.
+var waitUntilReadyFields = []string{
+	"size",
+	"availability_zones",
+	"introspection_interval",
+	"introspection_debugging",
+}
+
+// changeChecker is the part of schema.ResourceData that waitUntilReadySupported needs.
+type changeChecker interface {
+	HasChange(key string) bool
+}
+
+func waitUntilReadySupported(d changeChecker) bool {
+	for _, f := range waitUntilReadyFields {
+		if d.HasChange(f) {
+			return true
+		}
+	}
+	return false
+}
+
 func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clusterName := d.Get("name").(string)
 
@@ -519,6 +543,12 @@ func clusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 	if changed {
 		_, reconfigOptsRaw := d.GetChange("wait_until_ready")
 		reconfigOpts := b.GetReconfigOpts(reconfigOptsRaw)
+		if !waitUntilReadySupported(d) {
+			// Nothing here builds new replicas to wait on, and sending WAIT
+			// anyway makes Materialize reject the whole statement.
+			log.Printf("[DEBUG] dropping WAIT UNTIL READY: this change does not create replicas")
+			reconfigOpts = materialize.ReconfigurationOptions{}
+		}
 		if err := b.AlterCluster(reconfigOpts); err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -230,3 +230,40 @@ func TestResourceClusterDelete(t *testing.T) {
 		}
 	})
 }
+
+// fakeChanges reports a fixed set of attributes as changed.
+type fakeChanges map[string]bool
+
+func (f fakeChanges) HasChange(key string) bool { return f[key] }
+
+// Materialize rejects WAIT unless the same statement also changes something
+// that builds new replicas, so we only send it for those attributes.
+func TestWaitUntilReadySupported(t *testing.T) {
+	tests := []struct {
+		changed string
+		want    bool
+	}{
+		{"size", true},
+		{"availability_zones", true},
+		{"introspection_interval", true},
+		{"introspection_debugging", true},
+		// The reported case: autoscaling resizes in place, nothing to wait on.
+		{"auto_scaling_strategy", false},
+		// Same restriction, and more likely to be hit in practice.
+		{"replication_factor", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.changed, func(t *testing.T) {
+			require.Equal(t, tt.want, waitUntilReadySupported(fakeChanges{tt.changed: true}))
+		})
+	}
+
+	t.Run("a supported change alongside an unsupported one still waits", func(t *testing.T) {
+		require.True(t, waitUntilReadySupported(fakeChanges{"size": true, "replication_factor": true}))
+	})
+
+	t.Run("no changes", func(t *testing.T) {
+		require.False(t, waitUntilReadySupported(fakeChanges{}))
+	})
+}

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -246,7 +246,7 @@ func (f fakeChanges) Get(key string) interface{} {
 	}
 	// Match ResourceData, which returns the zero value for an unset attribute.
 	switch key {
-	case "availability_zones":
+	case "availability_zones", "wait_until_ready":
 		return []interface{}{}
 	case "introspection_debugging":
 		return false
@@ -295,4 +295,17 @@ func TestWaitUntilReadySupported(t *testing.T) {
 	t.Run("an unset supported attribute does not rescue an unsupported change", func(t *testing.T) {
 		require.False(t, waitUntilReadySupported(fakeChanges{"introspection_debugging": false, "replication_factor": 3}))
 	})
+}
+
+func TestWaitUntilReadyEnabled(t *testing.T) {
+	block := func(enabled bool) fakeChanges {
+		return fakeChanges{"wait_until_ready": []interface{}{
+			map[string]interface{}{"enabled": enabled},
+		}}
+	}
+
+	require.True(t, waitUntilReadyEnabled(block(true)))
+	require.False(t, waitUntilReadyEnabled(block(false)))
+	require.False(t, waitUntilReadyEnabled(fakeChanges{"wait_until_ready": []interface{}{}}))
+	require.False(t, waitUntilReadyEnabled(fakeChanges{}))
 }

--- a/pkg/resources/resource_cluster_test.go
+++ b/pkg/resources/resource_cluster_test.go
@@ -231,39 +231,68 @@ func TestResourceClusterDelete(t *testing.T) {
 	})
 }
 
-// fakeChanges reports a fixed set of attributes as changed.
-type fakeChanges map[string]bool
+// fakeChanges reports a fixed set of attributes as changed, with the values
+// they are changing to.
+type fakeChanges map[string]interface{}
 
-func (f fakeChanges) HasChange(key string) bool { return f[key] }
+func (f fakeChanges) HasChange(key string) bool {
+	_, ok := f[key]
+	return ok
+}
 
-// Materialize rejects WAIT unless the same statement also changes something
-// that builds new replicas, so we only send it for those attributes.
+func (f fakeChanges) Get(key string) interface{} {
+	if v, ok := f[key]; ok {
+		return v
+	}
+	// Match ResourceData, which returns the zero value for an unset attribute.
+	switch key {
+	case "availability_zones":
+		return []interface{}{}
+	case "introspection_debugging":
+		return false
+	default:
+		return ""
+	}
+}
+
+// Materialize rejects WAIT unless the same statement also carries a size,
+// availability zones or introspection option, so we only send it for those.
 func TestWaitUntilReadySupported(t *testing.T) {
 	tests := []struct {
-		changed string
+		name    string
+		changed fakeChanges
 		want    bool
 	}{
-		{"size", true},
-		{"availability_zones", true},
-		{"introspection_interval", true},
-		{"introspection_debugging", true},
+		{"size", fakeChanges{"size": "small"}, true},
+		{"availability_zones", fakeChanges{"availability_zones": []interface{}{"use1-az1"}}, true},
+		{"introspection_interval", fakeChanges{"introspection_interval": "10s"}, true},
+		{"introspection_debugging", fakeChanges{"introspection_debugging": true}, true},
+
 		// The reported case: autoscaling resizes in place, nothing to wait on.
-		{"auto_scaling_strategy", false},
+		{"auto_scaling_strategy", fakeChanges{"auto_scaling_strategy": []interface{}{}}, false},
 		// Same restriction, and more likely to be hit in practice.
-		{"replication_factor", false},
+		{"replication_factor", fakeChanges{"replication_factor": 3}, false},
+
+		// Unsetting one of the supported attributes leaves the option out of
+		// the statement, so there is still nothing for WAIT to attach to.
+		{"introspection_debugging turned off", fakeChanges{"introspection_debugging": false}, false},
+		{"availability_zones emptied", fakeChanges{"availability_zones": []interface{}{}}, false},
+		{"introspection_interval cleared", fakeChanges{"introspection_interval": ""}, false},
+
+		{"no changes", fakeChanges{}, false},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.changed, func(t *testing.T) {
-			require.Equal(t, tt.want, waitUntilReadySupported(fakeChanges{tt.changed: true}))
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, waitUntilReadySupported(tt.changed))
 		})
 	}
 
 	t.Run("a supported change alongside an unsupported one still waits", func(t *testing.T) {
-		require.True(t, waitUntilReadySupported(fakeChanges{"size": true, "replication_factor": true}))
+		require.True(t, waitUntilReadySupported(fakeChanges{"size": "small", "replication_factor": 3}))
 	})
 
-	t.Run("no changes", func(t *testing.T) {
-		require.False(t, waitUntilReadySupported(fakeChanges{}))
+	t.Run("an unset supported attribute does not rescue an unsupported change", func(t *testing.T) {
+		require.False(t, waitUntilReadySupported(fakeChanges{"introspection_debugging": false, "replication_factor": 3}))
 	})
 }


### PR DESCRIPTION
Materialize only accepts `WAIT UNTIL READY` when the same `ALTER CLUSTER` also changes size, availability zones or introspection. We were sending it for any change, so a cluster with `wait_until_ready` enabled failed when only `replication_factor` or `auto_scaling_strategy` moved.

Now we drop the WAIT clause for those changes and apply them directly.