### PR TITLE
Wait for SQL Server Agent before enabling CDC in the sqlserver fixture

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -30,7 +30,10 @@ jobs:
 
       - name: Container logs on failure
         if: failure()
-        run: docker compose logs --no-color --tail=200
+        run: |
+          docker compose logs --no-color --tail=200
+          # The healthcheck output says why the container never went healthy.
+          docker inspect --format '{{json .State.Health}}' sqlserver || true
 
       - name: Configure hosts file
         run: echo "127.0.0.1 materialized frontegg cloud" | sudo tee -a /etc/hosts

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - pkg/**
+      - compose.yaml
+      - .github/workflows/acceptance.yml
       - main.go
       - go.mod
   schedule:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d
 
+      - name: Container logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=200
+
       - name: Configure hosts file
         run: echo "127.0.0.1 materialized frontegg cloud" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/integration-self-hosted.yml
+++ b/.github/workflows/integration-self-hosted.yml
@@ -23,7 +23,10 @@ jobs:
 
       - name: Container logs on failure
         if: failure()
-        run: docker compose logs --no-color --tail=200
+        run: |
+          docker compose logs --no-color --tail=200
+          # The healthcheck output says why the container never went healthy.
+          docker inspect --format '{{json .State.Health}}' sqlserver || true
 
       - name: Terraform Init
         run: |

--- a/.github/workflows/integration-self-hosted.yml
+++ b/.github/workflows/integration-self-hosted.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d materialized materialized_init redpanda postgres mysql provider sqlserver
 
+      - name: Container logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=200
+
       - name: Terraform Init
         run: |
           docker exec --workdir /usr/src/app/integration/self_hosted provider terraform init

--- a/.github/workflows/integration-self-hosted.yml
+++ b/.github/workflows/integration-self-hosted.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - pkg/**
       - integration/self_hosted/**
+      - integration/sqlserver/**
+      - compose.yaml
+      - .github/workflows/integration-self-hosted.yml
       - main.go
       - go.mod
   schedule:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,10 @@ jobs:
 
       - name: Container logs on failure
         if: failure()
-        run: docker compose logs --no-color --tail=200
+        run: |
+          docker compose logs --no-color --tail=200
+          # The healthcheck output says why the container never went healthy.
+          docker inspect --format '{{json .State.Health}}' sqlserver || true
 
       - name: Terraform Init
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Docker Compose Up
         run: docker compose up --build -d
 
+      - name: Container logs on failure
+        if: failure()
+        run: docker compose logs --no-color --tail=200
+
       - name: Terraform Init
         run: |
           docker exec provider terraform init

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - pkg/**
       - integration/**
+      - compose.yaml
+      - .github/workflows/integration.yml
       - main.go
       - go.mod
   schedule:

--- a/compose.yaml
+++ b/compose.yaml
@@ -185,7 +185,12 @@ services:
       interval: 10s
       timeout: 10s
       retries: 20
-      start_period: 120s
+      # The entrypoint can spend up to 240s waiting for SQL Server to accept
+      # connections before it even starts enabling CDC, so a 120s start period
+      # left almost no headroom on a busy runner. Failures during the start
+      # period do not count against retries and a success ends it immediately,
+      # so this costs nothing when the container comes up quickly.
+      start_period: 300s
 
   provider:
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -185,12 +185,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 20
-      # The entrypoint can spend up to 240s waiting for SQL Server to accept
-      # connections before it even starts enabling CDC, so a 120s start period
-      # left almost no headroom on a busy runner. Failures during the start
-      # period do not count against retries and a success ends it immediately,
-      # so this costs nothing when the container comes up quickly.
-      start_period: 300s
+      start_period: 120s
 
   provider:
     build:

--- a/integration/sqlserver/entrypoint.sh
+++ b/integration/sqlserver/entrypoint.sh
@@ -42,6 +42,26 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Enabling CDC creates a capture job, which needs SQL Server Agent. The Agent
+# only finishes starting after SQL Server begins accepting connections, and
+# sp_cdc_enable_table fails with 14258 while it is still coming up. The
+# bootstrap runs without -b so that failure is not fatal, which left CDC
+# silently disabled and the healthcheck waiting forever.
+echo "Waiting for SQL Server Agent..."
+for i in {1..60}
+do
+    $SQLCMD -S localhost -U sa -P "${SA_PASSWORD}" -C -b -Q \
+        "SET NOCOUNT ON; IF NOT EXISTS (SELECT 1 FROM sys.dm_server_services WHERE servicename LIKE 'SQL Server Agent%' AND status_desc = 'Running') RAISERROR('agent not ready', 16, 1);" > /dev/null 2>&1
+    if [ $? -eq 0 ]
+    then
+        echo "SQL Server Agent is running after $i attempts"
+        break
+    else
+        echo "Attempt $i: SQL Server Agent not ready yet..."
+        sleep 2
+    fi
+done
+
 # Run the bootstrap script. We intentionally do NOT pass -b here: the bootstrap
 # is not idempotent (re-running sp_cdc_enable_table on an already-CDC-enabled
 # table raises Msg 22926), so -b combined with `restart: always` would crash-loop


### PR DESCRIPTION
The sqlserver container intermittently fails `Docker Compose Up` with "container sqlserver is unhealthy", which has been failing integration jobs for a while.

Adding container logs on failure showed the cause: enabling CDC needs SQL Server Agent, the Agent is still starting when the bootstrap runs, and `sp_cdc_enable_table` fails with 14258. The bootstrap runs without `-b` so it carries on and reports success while CDC was never enabled, and the healthcheck then waits for tables that never appear. That is why a good run is healthy in about 24 seconds and a bad one never recovers.

Waits for the Agent before running the bootstrap, keeps the logs on failure, and makes the integration workflows run when compose or their own definition changes, which they did not before.