### PR TITLE
Re-resolve a cluster grant's id when the cluster was swapped or renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fixed `materialize_cluster_grant` wanting to recreate a grant after a cluster swap. The grant addresses its cluster by name but stored the catalog id, so a blue/green deploy left the id pointing at a dropped cluster. The read now re-resolves the id from `cluster_name`.
 * Fixed a revoked grant staying in state. `grantRead` cleared the id when the privilege was no longer present on the object, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
+* Fixed grants to `PUBLIC` never matching on read. `PUBLIC` has no row in `mz_roles` and its privileges come back with an empty grantee, so they were never keyed under the id the grant resources use.
 
 ## 0.11.7 - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* Fixed `materialize_cluster_grant` wanting to recreate a grant after a cluster swap. The grant addresses its cluster by name but stored the catalog id, so a blue/green deploy left the id pointing at a dropped cluster. The read now re-resolves the id from `cluster_name`.
+* Fixed a revoked grant staying in state. `grantRead` cleared the id when the privilege was no longer present on the object, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
+
 ## 0.11.7 - 2026-08-24
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 * Fixed `materialize_cluster_grant` wanting to recreate a grant after a cluster swap. The grant addresses its cluster by name but stored the catalog id, so a blue/green deploy left the id pointing at a dropped cluster. The read now re-resolves the id from `cluster_name`.
-* Fixed a revoked grant staying in state. `grantRead` cleared the id when the privilege was no longer present on the object, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
+* Fixed a revoked grant staying in state. The grant, system privilege and default privilege reads each cleared the id when the privilege was no longer present, but set it again before returning, so the next plan saw no drift and the grant was never recreated.
 * Fixed grants to `PUBLIC` never matching on read. `PUBLIC` has no row in `mz_roles` and its privileges come back with an empty grantee, so they were never keyed under the id the grant resources use.
 
 ## 0.11.7 - 2026-08-24

--- a/pkg/materialize/privilege.go
+++ b/pkg/materialize/privilege.go
@@ -120,7 +120,13 @@ func MapGrantPrivileges(privileges []string) (map[string][]string, error) {
 	mapping := make(map[string][]string)
 	for _, p := range privileges {
 		f := ParseMzAclString(p)
-		mapping[f.Grantee] = f.Privileges
+		grantee := f.Grantee
+		if grantee == "" {
+			// PUBLIC has no row in mz_roles and renders with an empty grantee,
+			// so key it under the same pseudo-role id that RoleId hands out
+			grantee = publicRoleId
+		}
+		mapping[grantee] = f.Privileges
 	}
 	return mapping, nil
 }

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -132,9 +132,25 @@ func TestScanPrivileges(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
+		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "=UC/s1"}
 		if !reflect.DeepEqual(o, e) {
 			t.Fatalf("unexpected privileges %s", o)
 		}
 	})
+}
+
+// PUBLIC has no row in mz_roles and renders with an empty grantee, so it has to
+// be keyed under the same id RoleId returns or its grants never match
+func TestMapGrantPrivilegesPublic(t *testing.T) {
+	m, err := MapGrantPrivileges([]string{"s1=UC/s1", "=U/s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(m["p"], []string{"USAGE"}) {
+		t.Fatalf("PUBLIC privileges not mapped to %q: %v", "p", m)
+	}
+	if _, ok := m[""]; ok {
+		t.Fatalf("empty grantee should not remain in the map: %v", m)
+	}
 }

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -132,7 +132,7 @@ func TestScanPrivileges(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
+		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
 		if !reflect.DeepEqual(o, e) {
 			t.Fatalf("unexpected privileges %s", o)
 		}

--- a/pkg/materialize/role.go
+++ b/pkg/materialize/role.go
@@ -146,9 +146,12 @@ var roleQuery = NewBaseQuery(`
 	) comments
 		ON mz_roles.id = comments.id`)
 
+// publicRoleId is the id used for the PUBLIC pseudo-role, which has no row in mz_roles.
+const publicRoleId = "p"
+
 func RoleId(conn *sqlx.DB, roleName string) (string, error) {
 	if roleName == "PUBLIC" {
-		return "p", nil
+		return publicRoleId, nil
 	} else {
 		p := map[string]string{"mz_roles.name": roleName}
 		q := roleQuery.QueryPredicate(p)

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -51,6 +51,20 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 
 	p, err := materialize.ScanPrivileges(metaDb, materialize.EntityType(key.objectType), key.objectId)
+	if errors.Is(err, sql.ErrNoRows) && materialize.EntityType(key.objectType) == materialize.Cluster {
+		// A swapped or renamed cluster leaves a dropped id in state, re-resolve it from the configured name
+		c, clusterErr := materialize.ScanCluster(metaDb, d.Get("cluster_name").(string), true)
+		if clusterErr != nil && !errors.Is(clusterErr, sql.ErrNoRows) {
+			return diag.FromErr(clusterErr)
+		}
+		if clusterErr == nil {
+			key.objectId = c.ClusterId.String
+			ie := strings.Split(i, "|")
+			ie[2] = key.objectId
+			i = strings.Join(ie, "|")
+			p, err = materialize.ScanPrivileges(metaDb, materialize.Cluster, key.objectId)
+		}
+	}
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[WARN] grant (%s) not found, removing from state file", d.Id())
 		d.SetId("")

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -87,6 +87,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, privilege)
 		// Remove id from state
 		d.SetId("")
+		return nil
 	}
 
 	d.SetId(utils.TransformIdWithRegion(string(region), i))

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -52,17 +52,22 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 
 	p, err := materialize.ScanPrivileges(metaDb, materialize.EntityType(key.objectType), key.objectId)
 	if errors.Is(err, sql.ErrNoRows) && materialize.EntityType(key.objectType) == materialize.Cluster {
-		// A swapped or renamed cluster leaves a dropped id in state, re-resolve it from the configured name
-		c, clusterErr := materialize.ScanCluster(metaDb, d.Get("cluster_name").(string), true)
-		if clusterErr != nil && !errors.Is(clusterErr, sql.ErrNoRows) {
-			return diag.FromErr(clusterErr)
-		}
-		if clusterErr == nil {
-			key.objectId = c.ClusterId.String
-			ie := strings.Split(i, "|")
-			ie[2] = key.objectId
-			i = strings.Join(ie, "|")
-			p, err = materialize.ScanPrivileges(metaDb, materialize.Cluster, key.objectId)
+		// A swapped cluster leaves a dropped id in state, re-resolve it from the configured
+		// name. cluster_name is absent when a cluster id was imported into another grant
+		// resource, and then there is nothing to re-resolve from.
+		clusterName, _ := d.Get("cluster_name").(string)
+		if clusterName != "" {
+			c, clusterErr := materialize.ScanCluster(metaDb, clusterName, true)
+			if clusterErr != nil && !errors.Is(clusterErr, sql.ErrNoRows) {
+				return diag.FromErr(clusterErr)
+			}
+			if clusterErr == nil {
+				key.objectId = c.ClusterId.String
+				ie := strings.Split(i, "|")
+				ie[2] = key.objectId
+				i = strings.Join(ie, "|")
+				p, err = materialize.ScanPrivileges(metaDb, materialize.Cluster, key.objectId)
+			}
 		}
 	}
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/resources/resource_grant_default_privilege.go
+++ b/pkg/resources/resource_grant_default_privilege.go
@@ -73,6 +73,7 @@ func grantDefaultPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, key.privilege)
 		// Remove id from state
 		d.SetId("")
+		return nil
 	}
 
 	d.SetId(utils.TransformIdWithRegion(string(region), i))

--- a/pkg/resources/resource_grant_system_privilege.go
+++ b/pkg/resources/resource_grant_system_privilege.go
@@ -96,6 +96,7 @@ func grantSystemPrivilegeRead(ctx context.Context, d *schema.ResourceData, meta 
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, key.privilege)
 		// Remove id from state
 		d.SetId("")
+		return nil
 	}
 
 	d.SetId(utils.TransformIdWithRegion(string(region), i))

--- a/pkg/resources/resource_grant_system_privilege_test.go
+++ b/pkg/resources/resource_grant_system_privilege_test.go
@@ -92,3 +92,29 @@ func TestResourceGrantSystemPrivilegeDelete(t *testing.T) {
 		}
 	})
 }
+
+// A revoked system privilege has to leave state, or the next plan sees no drift
+func TestResourceGrantSystemPrivilegeReadRevoked(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name": "joe",
+		"privilege": "CREATEDB",
+	}
+	d := schema.TestResourceDataRaw(t, GrantSystemPrivilege().Schema, in)
+	r.NotNil(d)
+
+	// u99 holds no system privileges
+	d.SetId("aws/us-east-1:GRANT SYSTEM|u99|CREATEDB")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		testhelpers.MockSystemPrivilege(mock)
+
+		if err := grantSystemPrivilegeRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		r.Empty(d.Id(), "a revoked system privilege should be removed from state")
+	})
+}

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -42,3 +42,74 @@ func TestResourceGrantPrivilegeReadIdMigration(t *testing.T) {
 		}
 	})
 }
+
+// A cluster swap or rename drops the cluster the id in state refers to
+func TestResourceGrantPrivilegeReadClusterSwapped(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "USAGE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u99|u1|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_clusters.id = 'u99'`
+		testhelpers.MockClusterScanNoRows(mock, pp)
+
+		// Query Cluster Id
+		cp := `WHERE mz_clusters.name = 'materialize'`
+		testhelpers.MockClusterScan(mock, cp)
+
+		// Query Params
+		np := `WHERE mz_clusters.id = 'u1'`
+		testhelpers.MockClusterScan(mock, np)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "aws/us-east-1:GRANT|CLUSTER|u1|u1|USAGE" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}
+
+func TestResourceGrantPrivilegeReadClusterDropped(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "USAGE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u99|u1|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// Query Params
+		pp := `WHERE mz_clusters.id = 'u99'`
+		testhelpers.MockClusterScanNoRows(mock, pp)
+
+		// Query Cluster Id
+		cp := `WHERE mz_clusters.name = 'materialize'`
+		testhelpers.MockClusterScanNoRows(mock, cp)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		if d.Id() != "" {
+			t.Fatalf("unexpected id of %s", d.Id())
+		}
+	})
+}

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -113,3 +113,26 @@ func TestResourceGrantPrivilegeReadClusterDropped(t *testing.T) {
 		}
 	})
 }
+
+// A cluster id imported into another grant resource has no cluster_name to
+// re-resolve from, which must not take the provider down
+func TestResourceGrantPrivilegeReadClusterIdOnOtherResource(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	d := schema.TestResourceDataRaw(t, GrantDatabase().Schema, map[string]interface{}{})
+	r.NotNil(d)
+
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u99|u1|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		pp := `WHERE mz_clusters.id = 'u99'`
+		testhelpers.MockClusterScanNoRows(mock, pp)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		r.Empty(d.Id(), "an unresolvable grant should be removed from state")
+	})
+}

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -136,3 +136,63 @@ func TestResourceGrantPrivilegeReadClusterIdOnOtherResource(t *testing.T) {
 		r.Empty(d.Id(), "an unresolvable grant should be removed from state")
 	})
 }
+
+// A grant that is no longer present on the object should leave state, otherwise
+// the next plan sees no drift and the grant is never recreated
+func TestResourceGrantPrivilegeReadRevoked(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "USAGE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	// u99 holds no privileges on the cluster
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u1|u99|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		testhelpers.MockClusterScan(mock, `WHERE mz_clusters.id = 'u1'`)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		r.Empty(d.Id(), "a revoked grant should be removed from state")
+	})
+}
+
+// The swapped-in cluster does not always carry the grant. Re-resolving must not
+// hide that, or the grant is silently missing and no plan ever restores it
+func TestResourceGrantPrivilegeReadClusterSwappedWithoutGrant(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "USAGE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u99|u77|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		// The id in state was dropped by the swap
+		testhelpers.MockClusterScanNoRows(mock, `WHERE mz_clusters.id = 'u99'`)
+
+		// The name resolves to the new cluster, which holds no grant for u77
+		testhelpers.MockClusterScan(mock, `WHERE mz_clusters.name = 'materialize'`)
+		testhelpers.MockClusterScan(mock, `WHERE mz_clusters.id = 'u1'`)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		r.Empty(d.Id(), "a grant absent from the swapped-in cluster should be removed from state")
+	})
+}

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -96,7 +96,7 @@ func MockClusterReplicaScan(mock sqlmock.Sqlmock, predicate string) {
 	mock.ExpectQuery(q).WillReturnRows(ir)
 }
 
-func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
+func clusterScanQuery(predicate string) string {
 	b := `
 	SELECT
 		mz_clusters.id,
@@ -119,11 +119,20 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 	\) comments
 		ON mz_clusters.id = comments.id`
 
-	q := mockQueryBuilder(b, predicate, "")
+	return mockQueryBuilder(b, predicate, "")
+}
+
+func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 	az := StringArray{"use1-az1", "use1-az2", "use1-az3"}
 	ir := mock.NewRows([]string{"id", "name", "managed", "size", "replication_factor", "disk", "availability_zones", "comment", "owner_name", "privileges"}).
 		AddRow("u1", "cluster", true, "small", 2, true, az, "comment", "joe", defaultPrivilege)
-	mock.ExpectQuery(q).WillReturnRows(ir)
+	mock.ExpectQuery(clusterScanQuery(predicate)).WillReturnRows(ir)
+}
+
+// MockClusterScanNoRows mocks a cluster scan that matches nothing, simulating a
+// cluster that no longer exists.
+func MockClusterScanNoRows(mock sqlmock.Sqlmock, predicate string) {
+	mock.ExpectQuery(clusterScanQuery(predicate)).WillReturnRows(mock.NewRows([]string{"id"}))
 }
 
 // MockClusterAutoScalingScan mocks the best-effort read of a cluster's

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -51,7 +51,7 @@ func (a StringArray) Value() (driver.Value, error) {
 	return textArray.Value()
 }
 
-var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
+var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "=UC/s1"}
 
 func mockQueryBuilder(query, predicate, order string) string {
 	q := strings.Builder{}

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -122,9 +122,11 @@ func clusterScanQuery(predicate string) string {
 	return mockQueryBuilder(b, predicate, "")
 }
 
+var clusterScanColumns = []string{"id", "name", "managed", "size", "replication_factor", "disk", "availability_zones", "comment", "owner_name", "privileges"}
+
 func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 	az := StringArray{"use1-az1", "use1-az2", "use1-az3"}
-	ir := mock.NewRows([]string{"id", "name", "managed", "size", "replication_factor", "disk", "availability_zones", "comment", "owner_name", "privileges"}).
+	ir := mock.NewRows(clusterScanColumns).
 		AddRow("u1", "cluster", true, "small", 2, true, az, "comment", "joe", defaultPrivilege)
 	mock.ExpectQuery(clusterScanQuery(predicate)).WillReturnRows(ir)
 }
@@ -132,7 +134,7 @@ func MockClusterScan(mock sqlmock.Sqlmock, predicate string) {
 // MockClusterScanNoRows mocks a cluster scan that matches nothing, simulating a
 // cluster that no longer exists.
 func MockClusterScanNoRows(mock sqlmock.Sqlmock, predicate string) {
-	mock.ExpectQuery(clusterScanQuery(predicate)).WillReturnRows(mock.NewRows([]string{"id"}))
+	mock.ExpectQuery(clusterScanQuery(predicate)).WillReturnRows(mock.NewRows(clusterScanColumns))
 }
 
 // MockClusterAutoScalingScan mocks the best-effort read of a cluster's

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -51,7 +51,7 @@ func (a StringArray) Value() (driver.Value, error) {
 	return textArray.Value()
 }
 
-var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
+var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
 
 func mockQueryBuilder(query, predicate, order string) string {
 	q := strings.Builder{}


### PR DESCRIPTION
`materialize_cluster_grant` addresses its cluster by name but stores the cluster's catalog id in the resource id. `ALTER CLUSTER ... SWAP WITH` exchanges names, so the canonical name ends up on a different cluster and the stored id refers to a dropped one. `grantRead` then gets no rows, drops the resource from state, and the next plan wants to create a grant that already exists.

The read now re-resolves the id from `cluster_name` when the stored id is gone. A cluster that exists under neither the id nor the name is still removed from state.

Also carries the fix from #918, which is a prerequisite rather than a nice to have. `grantRead` cleared the id when the privilege was missing but set it again before returning, so nothing ever left state that way. Without it, re-resolving to a cluster that does not carry the grant reports no drift at all, which is worse than the bug this PR fixes. Verified locally against a real Materialize: a swap with grants copied plans clean, a swap without them plans the grant back in.