### PR TITLE
Remove a grant from state when the privilege is no longer present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* Fixed a revoked grant staying in state. `grantRead` cleared the id when the privilege was no longer present on the object, but then set it again before returning, so the next plan saw no drift and the grant was never recreated.
+
 ## 0.11.7 - 2026-08-24
 
 ### Bug Fixes

--- a/pkg/materialize/privilege_test.go
+++ b/pkg/materialize/privilege_test.go
@@ -132,7 +132,7 @@ func TestScanPrivileges(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
+		e := []string{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
 		if !reflect.DeepEqual(o, e) {
 			t.Fatalf("unexpected privileges %s", o)
 		}

--- a/pkg/resources/resource_grant.go
+++ b/pkg/resources/resource_grant.go
@@ -68,6 +68,7 @@ func grantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		log.Printf("[DEBUG] %s object does not contain privilege %s", i, privilege)
 		// Remove id from state
 		d.SetId("")
+		return nil
 	}
 
 	d.SetId(utils.TransformIdWithRegion(string(region), i))

--- a/pkg/resources/resource_grant_test.go
+++ b/pkg/resources/resource_grant_test.go
@@ -42,3 +42,31 @@ func TestResourceGrantPrivilegeReadIdMigration(t *testing.T) {
 		}
 	})
 }
+
+// A grant that is no longer present on the object should leave state, otherwise
+// the next plan sees no drift and the grant is never recreated.
+func TestResourceGrantPrivilegeReadRevoked(t *testing.T) {
+	utils.SetDefaultRegion("aws/us-east-1")
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"role_name":    "joe",
+		"privilege":    "USAGE",
+		"cluster_name": "materialize",
+	}
+	d := schema.TestResourceDataRaw(t, GrantCluster().Schema, in)
+	r.NotNil(d)
+
+	// u99 holds no privileges on the cluster
+	d.SetId("aws/us-east-1:GRANT|CLUSTER|u1|u99|USAGE")
+
+	testhelpers.WithMockProviderMeta(t, func(db *utils.ProviderMeta, mock sqlmock.Sqlmock) {
+		testhelpers.MockClusterScan(mock, `WHERE mz_clusters.id = 'u1'`)
+
+		if err := grantRead(context.TODO(), d, db); err != nil {
+			t.Fatal(err)
+		}
+
+		r.Empty(d.Id(), "a revoked grant should be removed from state")
+	})
+}

--- a/pkg/testhelpers/mock_scans.go
+++ b/pkg/testhelpers/mock_scans.go
@@ -51,7 +51,7 @@ func (a StringArray) Value() (driver.Value, error) {
 	return textArray.Value()
 }
 
-var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1"}
+var defaultPrivilege = StringArray{"s1=arwd/s1", "u1=UC/u18", "u8=arw/s1", "p=UC/u18"}
 
 func mockQueryBuilder(query, predicate, order string) string {
 	q := strings.Builder{}


### PR DESCRIPTION
`grantRead` cleared the id when the privilege was gone from the object, but then set it again two lines later before returning, so a revoked grant stayed in state and the next plan saw no drift.

Adding the missing return exposed that the PUBLIC grant tests were never checking the privilege at all, since the shared mock privileges had no PUBLIC row, so that fixture gets one too.